### PR TITLE
fix installer script

### DIFF
--- a/dist/install-common.sh
+++ b/dist/install-common.sh
@@ -68,7 +68,7 @@ setup_rayhunter() {
     _adb_push config.toml.example /tmp/config.toml
     _at_syscmd "mv /tmp/config.toml /data/rayhunter"
     _adb_push rayhunter-daemon /tmp/rayhunter-daemon
-    _at_syscmd "mv /tmp/rayhunter-daemon /data/rayhunter"
+    _at_syscmd "mv /tmp/rayhunter-daemon /data/rayhunter-daemon"
     _adb_push scripts/rayhunter_daemon /tmp/rayhunter_daemon
     _at_syscmd "mv /tmp/rayhunter_daemon /etc/init.d/rayhunter_daemon"
     _adb_push scripts/misc-daemon /tmp/misc-daemon

--- a/dist/install-common.sh
+++ b/dist/install-common.sh
@@ -68,7 +68,7 @@ setup_rayhunter() {
     _adb_push config.toml.example /tmp/config.toml
     _at_syscmd "mv /tmp/config.toml /data/rayhunter"
     _adb_push rayhunter-daemon /tmp/rayhunter-daemon
-    _at_syscmd "mv /tmp/rayhunter-daemon /data/rayhunter-daemon"
+    _at_syscmd "mv /tmp/rayhunter-daemon /data/rayhunter"
     _adb_push scripts/rayhunter_daemon /tmp/rayhunter_daemon
     _at_syscmd "mv /tmp/rayhunter_daemon /etc/init.d/rayhunter_daemon"
     _adb_push scripts/misc-daemon /tmp/misc-daemon

--- a/dist/install-common.sh
+++ b/dist/install-common.sh
@@ -65,14 +65,18 @@ _at_syscmd() {
 
 setup_rayhunter() {
     _at_syscmd "mkdir -p /data/rayhunter"
-    _adb_push config.toml.example /data/rayhunter/config.toml
-    _adb_push rayhunter-daemon /data/rayhunter/
+    _adb_push config.toml.example /tmp/config.toml
+    _at_syscmd "mv /tmp/config.toml /data/rayhunter"
+    _adb_push rayhunter-daemon /tmp/rayhunter-daemon
+    _at_syscmd "mv /tmp/rayhunter-daemon /data/rayhunter"
     _adb_push scripts/rayhunter_daemon /tmp/rayhunter_daemon
+    _at_syscmd "mv /tmp/rayhunter_daemon /etc/init.d/rayhunter_daemon"
     _adb_push scripts/misc-daemon /tmp/misc-daemon
-    _at_syscmd "cp /tmp/rayhunter_daemon /etc/init.d/rayhunter_daemon"
-    _at_syscmd "cp /tmp/misc-daemon /etc/init.d/misc-daemon"
+    _at_syscmd "mv /tmp/misc-daemon /etc/init.d/misc-daemon"
+
     _at_syscmd "chmod 755 /etc/init.d/rayhunter_daemon"
     _at_syscmd "chmod 755 /etc/init.d/misc-daemon"
+
     echo -n "waiting for reboot..."
     _at_syscmd reboot
 


### PR DESCRIPTION
With the odd permissions issues we've been seeing, we should use AT_SYSCMD for all mv operations into /data