### PR TITLE
fix(tools): add pycrate dependency to requirements.txt

### DIFF
--- a/tools/requirements.txt
+++ b/tools/requirements.txt
@@ -1,4 +1,5 @@
 asn1tools==0.166.0
 bitstruct==8.19.0
 diskcache==5.6.3
+pycrate==0.7.8
 pyparsing==3.1.2


### PR DESCRIPTION
nasparse.py and nasparse_test.py require the pycrate_mobile and pycrate_core libraries provided by the pycrate package.

This commit adds the required package to requirements.txt.