### PR TITLE
minimized the binary size

### DIFF
--- a/.cargo/config.toml
+++ b/.cargo/config.toml
@@ -1,3 +1,11 @@
 [target.armv7-unknown-linux-gnueabihf]
 linker = "arm-linux-gnueabihf-gcc"
 rustflags = ["-C", "target-feature=+crt-static"]
+
+# optimizations to reduce the binary size
+[profile.release]
+strip = true
+opt-level = "z"
+lto = true
+codegen-units = 1
+panic = "abort"


### PR DESCRIPTION
This commit enables various compile options to reduce the binary file size to fit on hardware with smaller filesystems.
See the recommendations of https://github.com/johnthagen/min-sized-rust
Applying reduces the binary size of the `rayhunter_daemon` by ~60%. (11619420 bytes ->  4614596 bytes).
Please verify if the optimizations still produce a working binary on actual hardware.