### PR TITLE
Remove the quarantine bit from the serial command on macOS

### DIFF
--- a/dist/install.sh
+++ b/dist/install.sh
@@ -105,6 +105,7 @@ if [[ `uname -s` == "Linux" ]]; then
 elif [[ `uname -s` == "Darwin" && `uname -m` == "arm64" ]]; then
     export SERIAL_PATH="./serial-macos-latest/serial"
     export PLATFORM_TOOLS="platform-tools-latest-darwin.zip"
+    xattr -d com.apple.quarantine "$SERIAL_PATH"
 else
     echo "This script only supports Linux or macOS with M1/M2 arm chips, for MacOS on Intel devices see the instructions here: https://github.com/EFForg/rayhunter/wiki/Install-Rayhunter-on-Mac-Intel-devices"
     exit 1


### PR DESCRIPTION
The `serial-macos-latest/serial` command in the installer bundle has the quarantine bit set. This unsets that attribute so that macOS doesn't throw an error message like

> “serial” Not Opened: Apple could not verify “serial” is free of malware that may harm your Mac or compromise your privacy.

This is the same error message @jullrich saw in #149. This fixes it. After the change, the installer script runs to completion on my M2 MacBook Air running macOS 15.3.2.

<img width="372" alt="Screenshot of a macOS error message that says: &quot;serial&quot; Not Opened: Apple could not verify &quot;serial&quot; is free of malware that may harm your Mac or compromise your privacy." src="https://github.com/user-attachments/assets/e30e1505-cf91-48e4-842c-639ae5f1ad0f" />
