### PR TITLE
feat(pcap): add rayhunter name and version to metadata

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1717,7 +1717,6 @@ dependencies = [
  "include_dir",
  "log",
  "mime_guess",
- "nix",
  "rayhunter",
  "serde",
  "serde_json",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1717,6 +1717,7 @@ dependencies = [
  "include_dir",
  "log",
  "mime_guess",
+ "nix",
  "rayhunter",
  "serde",
  "serde_json",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1694,6 +1694,7 @@ dependencies = [
  "futures-core",
  "libc",
  "log",
+ "nix",
  "pcap-file-tokio",
  "serde",
  "telcom-parser",

--- a/bin/Cargo.toml
+++ b/bin/Cargo.toml
@@ -33,3 +33,4 @@ serde_json = "1.0.114"
 image = "0.25.1"
 tempfile = "3.10.1"
 simple_logger = "5.0.0"
+nix = { version = "0.29.0", features = ["feature"] }

--- a/bin/Cargo.toml
+++ b/bin/Cargo.toml
@@ -33,4 +33,3 @@ serde_json = "1.0.114"
 image = "0.25.1"
 tempfile = "3.10.1"
 simple_logger = "5.0.0"
-nix = { version = "0.29.0", features = ["feature"] }

--- a/bin/src/qmdl_store.rs
+++ b/bin/src/qmdl_store.rs
@@ -1,4 +1,4 @@
-use rayhunter::util::RayhunterMetadata;
+use rayhunter::util::RuntimeMetadata;
 use chrono::{DateTime, Local};
 use serde::{Deserialize, Serialize};
 use std::path::{Path, PathBuf};
@@ -45,25 +45,23 @@ pub struct ManifestEntry {
     pub qmdl_size_bytes: usize,
     pub analysis_size_bytes: usize,
     pub rayhunter_version: Option<String>,
-    pub os: Option<String>,
+    pub system_os: Option<String>,
     pub arch: Option<String>,
-    pub hardware: Option<String>,
 }
 
 impl ManifestEntry {
     fn new() -> Self {
         let now = Local::now();
-        let metadata = RayhunterMetadata::new();
+        let metadata = RuntimeMetadata::new();
         ManifestEntry {
             name: format!("{}", now.timestamp()),
             start_time: now,
             last_message_time: None,
             qmdl_size_bytes: 0,
             analysis_size_bytes: 0,
-            rayhunter_version: Some(metadata.version),
-            os: Some(metadata.os),
+            rayhunter_version: Some(metadata.rayhunter_version),
+            system_os: Some(metadata.system_os),
             arch: Some(metadata.arch),
-            hardware: Some(metadata.hardware),
         }
     }
 

--- a/bin/src/qmdl_store.rs
+++ b/bin/src/qmdl_store.rs
@@ -45,7 +45,9 @@ pub struct ManifestEntry {
     pub qmdl_size_bytes: usize,
     pub analysis_size_bytes: usize,
     pub rayhunter_version: Option<String>,
-    pub rayhunter_os: Option<String>,
+    pub os: Option<String>,
+    pub arch: Option<String>,
+    pub hardware: Option<String>,
 }
 
 impl ManifestEntry {
@@ -59,7 +61,9 @@ impl ManifestEntry {
             qmdl_size_bytes: 0,
             analysis_size_bytes: 0,
             rayhunter_version: Some(metadata.version),
-            rayhunter_os: Some(metadata.os),
+            os: Some(metadata.os),
+            arch: Some(metadata.arch),
+            hardware: Some(metadata.hardware),
         }
     }
 

--- a/bin/src/qmdl_store.rs
+++ b/bin/src/qmdl_store.rs
@@ -1,7 +1,6 @@
+use rayhunter::util::RayhunterMetadata;
 use chrono::{DateTime, Local};
-use nix::sys::utsname::uname;
 use serde::{Deserialize, Serialize};
-use std::env::consts::OS;
 use std::path::{Path, PathBuf};
 use thiserror::Error;
 use tokio::{
@@ -52,22 +51,15 @@ pub struct ManifestEntry {
 impl ManifestEntry {
     fn new() -> Self {
         let now = Local::now();
-        let operating_system = match uname() {
-            Ok(utsname) => format!(
-                "{} {}",
-                utsname.sysname().to_string_lossy(),
-                utsname.release().to_string_lossy()
-            ),
-            Err(_) => OS.to_owned(),
-        };
+        let metadata = RayhunterMetadata::new();
         ManifestEntry {
             name: format!("{}", now.timestamp()),
             start_time: now,
             last_message_time: None,
             qmdl_size_bytes: 0,
             analysis_size_bytes: 0,
-            rayhunter_version: Some(env!("CARGO_PKG_VERSION").to_owned()),
-            rayhunter_os: Some(operating_system),
+            rayhunter_version: Some(metadata.version),
+            rayhunter_os: Some(metadata.os),
         }
     }
 

--- a/bin/src/qmdl_store.rs
+++ b/bin/src/qmdl_store.rs
@@ -1,5 +1,7 @@
 use chrono::{DateTime, Local};
+use nix::sys::utsname::uname;
 use serde::{Deserialize, Serialize};
+use std::env::consts::OS;
 use std::path::{Path, PathBuf};
 use thiserror::Error;
 use tokio::{
@@ -43,17 +45,29 @@ pub struct ManifestEntry {
     pub last_message_time: Option<DateTime<Local>>,
     pub qmdl_size_bytes: usize,
     pub analysis_size_bytes: usize,
+    pub rayhunter_version: Option<String>,
+    pub rayhunter_os: Option<String>,
 }
 
 impl ManifestEntry {
     fn new() -> Self {
         let now = Local::now();
+        let operating_system = match uname() {
+            Ok(utsname) => format!(
+                "{} {}",
+                utsname.sysname().to_string_lossy(),
+                utsname.release().to_string_lossy()
+            ),
+            Err(_) => OS.to_owned(),
+        };
         ManifestEntry {
             name: format!("{}", now.timestamp()),
             start_time: now,
             last_message_time: None,
             qmdl_size_bytes: 0,
             analysis_size_bytes: 0,
+            rayhunter_version: Some(env!("CARGO_PKG_VERSION").to_owned()),
+            rayhunter_os: Some(operating_system),
         }
     }
 

--- a/lib/Cargo.toml
+++ b/lib/Cargo.toml
@@ -17,6 +17,7 @@ deku = { version = "0.16.0", features = ["logging"] }
 env_logger = "0.10.1"
 libc = "0.2.150"
 log = "0.4.20"
+nix = { version = "0.29.0", features = ["feature"] }
 pcap-file-tokio = "0.1.0"
 thiserror = "1.0.50"
 telcom-parser = { path = "../telcom-parser" }

--- a/lib/src/analysis/analyzer.rs
+++ b/lib/src/analysis/analyzer.rs
@@ -71,8 +71,17 @@ pub struct AnalyzerMetadata {
 }
 
 #[derive(Serialize, Debug)]
+pub struct RayhunterMetadata {
+    pub version: String,
+    pub os: String,
+    pub arch: String,
+    pub hardware: String,
+}
+
+#[derive(Serialize, Debug)]
 pub struct ReportMetadata {
     pub analyzers: Vec<AnalyzerMetadata>,
+    pub rayhunter: RayhunterMetadata,
 }
 
 #[derive(Serialize, Debug, Clone)]
@@ -205,8 +214,18 @@ impl Harness {
             });
         }
 
+        let metadata = crate::util::RayhunterMetadata::new();
+
+        let rayhunter = RayhunterMetadata {
+            version: metadata.version,
+            os: metadata.os,
+            arch: metadata.arch,
+            hardware: metadata.hardware,
+        };
+
         ReportMetadata {
             analyzers,
+            rayhunter,
         }
     }
 }

--- a/lib/src/analysis/analyzer.rs
+++ b/lib/src/analysis/analyzer.rs
@@ -3,6 +3,7 @@ use chrono::{DateTime, FixedOffset};
 use serde::Serialize;
 
 use crate::{diag::MessagesContainer, gsmtap_parser};
+use crate::util::RuntimeMetadata;
 
 use super::{
     imsi_requested::ImsiRequestedAnalyzer,
@@ -71,17 +72,9 @@ pub struct AnalyzerMetadata {
 }
 
 #[derive(Serialize, Debug)]
-pub struct RayhunterMetadata {
-    pub version: String,
-    pub os: String,
-    pub arch: String,
-    pub hardware: String,
-}
-
-#[derive(Serialize, Debug)]
 pub struct ReportMetadata {
     pub analyzers: Vec<AnalyzerMetadata>,
-    pub rayhunter: RayhunterMetadata,
+    pub rayhunter: RuntimeMetadata,
 }
 
 #[derive(Serialize, Debug, Clone)]
@@ -214,14 +207,7 @@ impl Harness {
             });
         }
 
-        let metadata = crate::util::RayhunterMetadata::new();
-
-        let rayhunter = RayhunterMetadata {
-            version: metadata.version,
-            os: metadata.os,
-            arch: metadata.arch,
-            hardware: metadata.hardware,
-        };
+        let rayhunter = RuntimeMetadata::new();
 
         ReportMetadata {
             analyzers,

--- a/lib/src/lib.rs
+++ b/lib/src/lib.rs
@@ -7,6 +7,7 @@ pub mod gsmtap;
 pub mod gsmtap_parser;
 pub mod pcap;
 pub mod analysis;
+pub mod util;
 
 // re-export telcom_parser, since we use its types in our API
 pub use telcom_parser;

--- a/lib/src/pcap.rs
+++ b/lib/src/pcap.rs
@@ -9,8 +9,9 @@ use chrono::prelude::*;
 use deku::prelude::*;
 use pcap_file_tokio::pcapng::blocks::enhanced_packet::EnhancedPacketBlock;
 use pcap_file_tokio::pcapng::blocks::interface_description::InterfaceDescriptionBlock;
+use pcap_file_tokio::pcapng::blocks::section_header::{SectionHeaderBlock, SectionHeaderOption};
 use pcap_file_tokio::pcapng::PcapNgWriter;
-use pcap_file_tokio::PcapError;
+use pcap_file_tokio::{Endianness, PcapError};
 use thiserror::Error;
 
 #[derive(Error, Debug)]
@@ -60,7 +61,17 @@ struct UdpHeader {
 
 impl<T> GsmtapPcapWriter<T> where T: AsyncWrite + Unpin + Send {
     pub async fn new(writer: T) -> Result<Self, GsmtapPcapError> {
-        let writer = PcapNgWriter::new(writer).await?;
+        let package = concat!(env!("CARGO_PKG_NAME"), " ", env!("CARGO_PKG_VERSION"));
+        let application = SectionHeaderOption::UserApplication(Cow::from(package));
+        let section = SectionHeaderBlock {
+            endianness: Endianness::Big,
+            major_version: 1,
+            minor_version: 0,
+            section_length: -1,
+            options: vec![application],
+        };
+        let writer = PcapNgWriter::with_section_header(writer, section).await?;
+
         Ok(GsmtapPcapWriter { writer, ip_id: 0 })
     }
 

--- a/lib/src/pcap.rs
+++ b/lib/src/pcap.rs
@@ -61,8 +61,8 @@ struct UdpHeader {
 
 impl<T> GsmtapPcapWriter<T> where T: AsyncWrite + Unpin + Send {
     pub async fn new(writer: T) -> Result<Self, GsmtapPcapError> {
-        let metadata = crate::util::RayhunterMetadata::new();
-        let package = format!("{} {}", metadata.name, metadata.version);
+        let metadata = crate::util::RuntimeMetadata::new();
+        let package = format!("{} {}", env!("CARGO_PKG_NAME").to_owned(), metadata.rayhunter_version);
         let section = SectionHeaderBlock {
             endianness: Endianness::Big,
             major_version: 1,
@@ -70,7 +70,7 @@ impl<T> GsmtapPcapWriter<T> where T: AsyncWrite + Unpin + Send {
             section_length: -1,
             options: vec![
                 SectionHeaderOption::Hardware(Cow::from(metadata.arch)),
-                SectionHeaderOption::OS(Cow::from(metadata.os)),
+                SectionHeaderOption::OS(Cow::from(metadata.system_os)),
                 SectionHeaderOption::UserApplication(Cow::from(package)),
             ],
         };

--- a/lib/src/pcap.rs
+++ b/lib/src/pcap.rs
@@ -7,13 +7,11 @@ use tokio::io::AsyncWrite;
 use std::borrow::Cow;
 use chrono::prelude::*;
 use deku::prelude::*;
-use nix::sys::utsname::uname;
 use pcap_file_tokio::pcapng::blocks::enhanced_packet::EnhancedPacketBlock;
 use pcap_file_tokio::pcapng::blocks::interface_description::InterfaceDescriptionBlock;
 use pcap_file_tokio::pcapng::blocks::section_header::{SectionHeaderBlock, SectionHeaderOption};
 use pcap_file_tokio::pcapng::PcapNgWriter;
 use pcap_file_tokio::{Endianness, PcapError};
-use std::env::consts::OS;
 use thiserror::Error;
 
 #[derive(Error, Debug)]
@@ -63,23 +61,18 @@ struct UdpHeader {
 
 impl<T> GsmtapPcapWriter<T> where T: AsyncWrite + Unpin + Send {
     pub async fn new(writer: T) -> Result<Self, GsmtapPcapError> {
-        let package = format!("{} {}", env!("CARGO_PKG_NAME"), env!("CARGO_PKG_VERSION"));
-        let application = SectionHeaderOption::UserApplication(Cow::from(package));
-        let operating_system = match uname() {
-            Ok(utsname) => format!(
-                "{} {}",
-                utsname.sysname().to_string_lossy(),
-                utsname.release().to_string_lossy()
-            ),
-            Err(_) => OS.to_owned(),
-        };
-        let os = SectionHeaderOption::OS(Cow::from(operating_system));
+        let metadata = crate::util::RayhunterMetadata::new();
+        let package = format!("{} {}", metadata.name, metadata.version);
         let section = SectionHeaderBlock {
             endianness: Endianness::Big,
             major_version: 1,
             minor_version: 0,
             section_length: -1,
-            options: vec![os, application],
+            options: vec![
+                SectionHeaderOption::Hardware(Cow::from(metadata.arch)),
+                SectionHeaderOption::OS(Cow::from(metadata.os)),
+                SectionHeaderOption::UserApplication(Cow::from(package)),
+            ],
         };
         let writer = PcapNgWriter::with_section_header(writer, section).await?;
         Ok(GsmtapPcapWriter { writer, ip_id: 0 })

--- a/lib/src/util.rs
+++ b/lib/src/util.rs
@@ -1,0 +1,35 @@
+use nix::sys::utsname::uname;
+
+/// Expose binary and system information.
+pub struct RayhunterMetadata {
+    pub name: String,
+    pub version: String,
+    pub os: String,
+    pub arch: String,
+    pub hardware: String,
+}
+
+impl RayhunterMetadata {
+    pub fn new() -> Self {
+        match uname() {
+            Ok(utsname) => RayhunterMetadata {
+                name: env!("CARGO_PKG_NAME").to_owned(),
+                version: env!("CARGO_PKG_VERSION").to_owned(),
+                arch: format!("{}", utsname.machine().to_string_lossy()),
+                os: format!(
+                    "{} {}",
+                    utsname.sysname().to_string_lossy(),
+                    utsname.release().to_string_lossy(),
+                ),
+                hardware: String::from("unknown"),
+            },
+            Err(_) => RayhunterMetadata {
+                name: env!("CARGO_PKG_NAME").to_owned(),
+                version: env!("CARGO_PKG_VERSION").to_owned(),
+                arch: std::env::consts::ARCH.to_string(),
+                os: std::env::consts::OS.to_string(),
+                hardware: String::from("unknown"),
+            },
+        }
+    }
+}

--- a/lib/src/util.rs
+++ b/lib/src/util.rs
@@ -1,34 +1,36 @@
 use nix::sys::utsname::uname;
+use serde::Serialize;
 
 /// Expose binary and system information.
-pub struct RayhunterMetadata {
-    pub name: String,
-    pub version: String,
-    pub os: String,
+#[derive(Serialize, Debug)]
+pub struct RuntimeMetadata {
+    /// The cargo package version from this library's cargo.toml, e.g., "1.2.3".
+    pub rayhunter_version: String,
+    /// The operating system `sysname` and optionally `release`. e.g., "Linux 3.18.48" or "linux".
+    pub system_os: String,
+    /// The CPU architecture in use. e.g., "armv7l" or "arm".
     pub arch: String,
-    pub hardware: String,
 }
 
-impl RayhunterMetadata {
+impl RuntimeMetadata {
+    /// Return the binary and system information, attempting to retrieve
+    /// attributes from `uname(2)` and falling back to values from
+    /// `std::env::consts`.
     pub fn new() -> Self {
         match uname() {
-            Ok(utsname) => RayhunterMetadata {
-                name: env!("CARGO_PKG_NAME").to_owned(),
-                version: env!("CARGO_PKG_VERSION").to_owned(),
+            Ok(utsname) => RuntimeMetadata {
+                rayhunter_version: env!("CARGO_PKG_VERSION").to_owned(),
                 arch: format!("{}", utsname.machine().to_string_lossy()),
-                os: format!(
+                system_os: format!(
                     "{} {}",
                     utsname.sysname().to_string_lossy(),
                     utsname.release().to_string_lossy(),
                 ),
-                hardware: String::from("unknown"),
             },
-            Err(_) => RayhunterMetadata {
-                name: env!("CARGO_PKG_NAME").to_owned(),
-                version: env!("CARGO_PKG_VERSION").to_owned(),
+            Err(_) => RuntimeMetadata {
+                rayhunter_version: env!("CARGO_PKG_VERSION").to_owned(),
                 arch: std::env::consts::ARCH.to_string(),
-                os: std::env::consts::OS.to_string(),
-                hardware: String::from("unknown"),
+                system_os: std::env::consts::OS.to_string(),
             },
         }
     }


### PR DESCRIPTION
Add the compile-time name and version to the pcap's Section Header Block as the shb_userappl option, the canonical place for storing the name of the application used to create the pcap.[0]

[0] https://ietf-opsawg-wg.github.io/draft-ietf-opsawg-pcap/draft-ietf-opsawg-pcapng.html#section-4.1-10

Addresses issue #146 

Note: Because https://github.com/EFForg/rayhunter/blob/main/lib/Cargo.toml#L3 hasn't been updated with each release, it still reads `0.1.0`. Same for rayhunter-daemon's cargo manifest.

It may be worth plumbing the version number in a different way. (e.g., should this be the rayhunter lib's version number or the daemon's? I'm inclined to think the lib, but that's just my 2¢)

It may also be worth adding the operating system and particularly the hardware field. I can happily do this easily, but I wanted to keep this PR tightly scoped to just addressing the issue to start.

This is what displays in Wireshark's `Statistics > Capture File Properties` screen now: 
![wireshark_capture_application_rayhunter](https://github.com/user-attachments/assets/109c8cf6-a140-4cb7-85b4-b265d7e7dca1)

I've tested this on an Orbic RC400L.