### PR TITLE
daemon: if we fail to parse the QMDL manifest, make a new one

### DIFF
--- a/bin/src/qmdl_store.rs
+++ b/bin/src/qmdl_store.rs
@@ -330,6 +330,20 @@ mod tests {
     }
 
     #[tokio::test]
+    async fn test_create_on_existing_store() {
+        let dir = make_temp_dir();
+        let mut store = RecordingStore::create(dir.path()).await.unwrap();
+        let _ = store.new_entry().await.unwrap();
+        let entry_index = store.current_entry.unwrap();
+        store
+            .update_entry_qmdl_size(entry_index, 1000)
+            .await
+            .unwrap();
+        let store = RecordingStore::create(dir.path()).await.unwrap();
+        assert_eq!(store.manifest.entries.len(), 0);
+    }
+
+    #[tokio::test]
     async fn test_repeated_new_entries() {
         let dir = make_temp_dir();
         let mut store = RecordingStore::create(dir.path()).await.unwrap();


### PR DESCRIPTION
If rayhunter doesn't exit cleanly (e.g. during a battery outage), the QMDL manifest may end up in a corrupted state. If that's the case, rayhunter should try to recover by creating a new manifest. This'll let it continue, and will preserve previous recordings, but they won't be visible through the UI.

Fixes #151 