### PR TITLE
Update rayhunter_daemon for TPLINK Compatibility

### DIFF
--- a/dist/scripts/rayhunter_daemon
+++ b/dist/scripts/rayhunter_daemon
@@ -1,4 +1,4 @@
-#! /bin/bash
+#! /bin/sh
 
 set -e
 
@@ -6,7 +6,7 @@ case "$1" in
 start)
     echo -n "Starting rayhunter: "
     start-stop-daemon -S -b --make-pidfile --pidfile /tmp/rayhunter.pid \
-    --startas /bin/bash -- -c "RUST_LOG=info exec /data/rayhunter/rayhunter-daemon /data/rayhunter/config.toml > /data/rayhunter/rayhunter.log 2>&1"
+    --startas /bin/sh -- -c "RUST_LOG=info exec /data/rayhunter/rayhunter-daemon /data/rayhunter/config.toml > /data/rayhunter/rayhunter.log 2>&1"
     echo "done"
     ;;
   stop)


### PR DESCRIPTION
TPLink devices dont have bash - only sh. This change fixes issue https://github.com/EFForg/rayhunter/issues/193 and enables the daemon to start with the device

