### PR TITLE
Update make.sh

### DIFF
--- a/make.sh
+++ b/make.sh
@@ -2,4 +2,5 @@
 cargo build --release --target="armv7-unknown-linux-gnueabihf" #--features debug
 adb shell '/bin/rootshell -c "/etc/init.d/rayhunter_daemon stop"'
 adb push target/armv7-unknown-linux-gnueabihf/release/rayhunter-daemon /data/rayhunter/rayhunter-daemon
-adb shell '/bin/rootshell -c "/etc/init.d/rayhunter_daemon start"'
+echo "rebooting the device..."
+adb shell '/bin/rootshell -c "reboot"'


### PR DESCRIPTION
reboot the orbic instead of starting up the process again, since rootshell seems to have insufficient privileges to start rayhunter