### PR TITLE
chore: bump all Cargo.toml versions to 0.2.6

### DIFF
--- a/lib/Cargo.toml
+++ b/lib/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "rayhunter"
-version = "0.1.0"
+version = "0.2.6"
 edition = "2021"
 description = "Realtime cellular data decoding and analysis for IMSI catcher detection"
 

--- a/rootshell/Cargo.toml
+++ b/rootshell/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "rootshell"
-version = "0.1.0"
+version = "0.2.6"
 edition = "2021"
 
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html

--- a/serial/Cargo.toml
+++ b/serial/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "serial"
-version = "0.1.0"
+version = "0.2.6"
 edition = "2021"
 
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html

--- a/telcom-parser/Cargo.toml
+++ b/telcom-parser/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "telcom-parser"
-version = "0.1.0"
+version = "0.2.6"
 edition = "2021"
 
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html


### PR DESCRIPTION
Don't forget these! The lib one is what's printed in pcap files, for example.