### PR TITLE
Remove unused import due to e79dc4a

### DIFF
--- a/lib/src/analysis/analyzer.rs
+++ b/lib/src/analysis/analyzer.rs
@@ -10,7 +10,6 @@ use super::{
     information_element::InformationElement,
     connection_redirect_downgrade::ConnectionRedirect2GDowngradeAnalyzer,
     priority_2g_downgrade::LteSib6And7DowngradeAnalyzer,
-    null_cipher::NullCipherAnalyzer,
 };
 
 /// Qualitative measure of how severe a Warning event type is.


### PR DESCRIPTION
e79dc4a commented out the one usage of NullCipherAnalyzer but didn't remove the import, causing a compiler warning.