### PR TITLE
Added FAQ entry on how to use the rootshell to delete data from the device

### DIFF
--- a/README.md
+++ b/README.md
@@ -55,6 +55,9 @@ Once installed, Rayhunter will run automatically whenever your Orbic device is r
 If you want to use a non verizon SIM card you will probably need an unlocked device. But it's not clear how locked the locked devices are nor how to unlock them, we welcome any experimentation and information regarding the use of unlocked devices.
 ### Does Rayhunter work on any other devices besides the Orbic RC400L?
 **Maybe**. We have not tested Rayhunter on any other hardware but we would love to expand the supported platforms. We will consider giving official support to any hardware platform that can be bought for around $20-30USD. The Rayhunter daemon should theoretically work on any linux/android device that has a qualcomm chip with a /dev/diag interface and root access, though our installer script has only been tested with an Orbic. If you get it working on another device, please let us know!
+### How do I delete capture files from the Rayhunter device?
+You can get a shell on the device by inputting `adb shell` to a terminal with the device connected, you can check if it is detected with `adb devices`.
+The capture files are located at */data/rayhunter/qmdl* but you will need root access to modify or delete them. From the adb shell run `/bin/rootshell` and you can now use commands like 'rm' as root to modify and delete entries in the */data/rayhunter/qmdl* directory. **Be careful not to delete important files in other directories as you may seriously damage the device**.
 
 ## Development
 * Install ADB on your computer using the instructions above, and make sure it's in your terminal's PATH


### PR DESCRIPTION
Added this text to the FAQ to explain to users to access the device filesystem using the pre-built rootshell. 

```### How do I delete capture files from the Rayhunter device?
You can get a shell on the device by inputting `adb shell` to a terminal with the device connected, you can check if it is detected with `adb devices`.
The capture files are located at */data/rayhunter/qmdl* but you will need root access to modify or delete them. From the adb shell run `/bin/rootshell` and you can now use commands like 'rm' as root to modify and delete entries in the */data/rayhunter/qmdl* directory. **Be careful not to delete important files in other directories as you may seriously damage the device**.```