### PR TITLE
feat(tools): extract and redact mobile identities from captures

### DIFF
--- a/.cargo/config.toml
+++ b/.cargo/config.toml
@@ -1,5 +1,5 @@
 [target.armv7-unknown-linux-gnueabihf]
-linker = "arm-linux-gnueabihf-gcc"
+linker = "armv7l-unknown-linux-gnueabihf-gcc"
 rustflags = ["-C", "target-feature=+crt-static"]
 
 # optimizations to reduce the binary size

--- a/shell.nix
+++ b/shell.nix
@@ -1,0 +1,18 @@
+with import <nixpkgs>
+{
+  crossSystem = {
+    config = "armv7l-unknown-linux-gnueabihf";
+    arch = "arm";
+    bigEndian = false;
+    libc = "glibc";
+  };
+};
+  mkShell {
+    buildInputs = [
+      glibc.static
+      stdenv
+      gcc
+    ];
+
+    inputsFrom = [glibc cargo];
+  }

--- a/tools/extract.py
+++ b/tools/extract.py
@@ -1,0 +1,76 @@
+import sys
+
+import pycrate_core.elt
+from pycrate_mobile import TS24301_EMM
+from scapy.layers.inet import UDP
+from scapy.packet import Raw
+from scapy.utils import rdpcap
+
+from nasparse import parse_nas_message
+
+
+EPS_IMSI_ATTACH = 2
+
+
+def heur_ue_id_sent(msg):
+    if type(msg) not in [
+        TS24301_EMM.EMMAttachRequest,
+        TS24301_EMM.EMMSecProtNASMessage,
+        TS24301_EMM.EMMSecurityModeComplete,
+    ]:
+        return (False, None)
+
+    # TODO: handle SecurityModeComplete in Security Protected messages
+    if isinstance(msg, TS24301_EMM.EMMSecProtNASMessage):
+        try:
+            msg = msg["EMMAttachRequest"]
+        except pycrate_core.elt.EltErr:
+            return (False, None)
+
+    if (
+        isinstance(msg, TS24301_EMM.EMMAttachRequest)
+        and msg["EPSAttachType"]["V"].to_int() == EPS_IMSI_ATTACH
+    ):  # EPSAttachType Value is 'Combined EPS/IMSI Attach (2)'
+        try:
+            t, i = msg["EPSID"]["EPSID"].decode()
+            if i == str(0xA):
+                return (False, "This was previously redacted.")
+            else:
+                return (True, (t, i))
+        except pycrate_core.elt.EltErr:
+            return (False, None)
+    elif isinstance(msg, TS24301_EMM.EMMSecurityModeComplete):
+        try:
+            t, i = msg["IMEISV"]["ID"].decode()
+            if i == str(0xA):
+                return (False, "This was previously redacted.")
+            else:
+                return (True, (t, i))
+        except pycrate_core.elt.EltErr:
+            return (False, None)
+    return (False, None)
+
+
+def main(packets):
+    idents = []
+    for gsmtap in packets:
+        try:
+            # gsmtap header is always 16 bytes
+            # if this isn't true, the second byte is the length in 32-bit words
+            msg = parse_nas_message(gsmtap[UDP][Raw].load[16:].hex())
+            triggered, message = heur_ue_id_sent(msg)
+            if triggered:
+                print(message, gsmtap.load.hex())
+                idents.extend([message])
+        except TypeError:
+            pass
+    return idents
+
+
+if __name__ == "__main__":
+    if len(sys.argv) != 2:
+        print("usage: extract.py PCAP")
+        exit(1)
+
+    packets = rdpcap(sys.argv[1])
+    print(main(packets))

--- a/tools/redact.py
+++ b/tools/redact.py
@@ -1,0 +1,121 @@
+import sys
+
+import yara_x as yara
+from scapy.utils import rdpcap
+from scapy.error import Scapy_Exception
+from pycrate_mobile.TS24008_IE import encode_bcd
+from pycrate_mobile.TS24301_IE import IDTYPE_IMSI, IDTYPE_IMEISV
+
+from extract import main as extract_identities
+
+
+def identity_octets(idtype: IDTYPE_IMSI | IDTYPE_IMEISV, ident: str) -> str:
+    """
+    idtype: the EPS identity type:
+     1 = IMSI
+     3 = IMEISV
+     6 = GUTI (unsupported)
+    ident: a string of digits representing the IMSI or IMEISV
+
+    Returns hex octets representing the mobile identity, as an int.
+    """
+    type_and_parity = str(idtype + 8 * (len(ident) % 2))
+    return int(ident[0] + type_and_parity + encode_bcd(ident[1:]).hex(), 16)
+
+
+def yara_rules(typ: str, ident: str) -> str:
+    ident_octets = identity_octets(int(typ), ident)
+    # NAS messages encoded in LTE RRC UL-DCCH-Messages as the
+    # dedicatedInfoNAS field may not be aligned within the frame.
+    shift1 = f"{ident_octets << 1:x}"
+    shift2 = f"{ident_octets << 2:x}"
+    shift3 = f"{ident_octets << 3:x}"
+    # mark don't care nibbles, where the value could change depending on the
+    # surrounding bits or the type_and_parity nibble.
+    shift1 = "??" + shift1[2:-1] + "?"
+    shift2 = "??" + shift2[2:-1] + "?"
+    shift3 = "0" + shift3[0] + "??" + shift3[3:-1] + "?"
+    return f"""
+rule mobile_id_type{typ}
+xx
+    meta:
+        description = "The NAS PDU may not be aligned within the entire frame."
+    strings:
+        $ident{typ} = xx {ident_octets:x} yy
+        $shift1 = xx {shift1} yy
+        $shift2 = xx {shift2} yy
+        $shift3 = xx {shift3} yy
+    condition:
+        $ident{typ} or $shift1 or $shift2 or $shift3
+yy""".replace("xx", "{").replace("yy", "}")
+
+
+def scan(needle: str, haystack: str):
+    rules = yara.compile(needle)
+    return yara.Scanner(rules).scan_file(haystack)
+
+
+def matches_from(results) -> list:
+    matches = []
+    for mr in results.matching_rules:
+        for p in mr.patterns:
+            for m in p.matches:
+                print(f"{m.offset:x}:{m.length:x}:{p.identifier}")
+                matches.append(m)
+    return sorted(matches, key=lambda m: m.offset)
+
+
+def overwrite_file(filename: list, matches: str, with_bytes: bytes):
+    with open(filename, "r+b") as f:
+        for m in matches:
+            f.seek(m.offset)
+            print(
+                f"{filename}: overwriting 0x{m.length:x} bytes at 0x{m.offset:x} with {with_bytes}"
+            )
+            f.write(m.length * with_bytes)
+
+
+def main(haystacks: list[str]):
+    "Redact sensitive values from haystack files."
+
+    _EXIT = 0
+
+    idents = set()
+    for h in haystacks:
+        print(h)
+        try:
+            packets = rdpcap(h)
+            for i in extract_identities(packets):
+                idents.add(i)
+        except Scapy_Exception as e:
+            print(f"{h}: {e}")
+
+    needle = "\n".join(yara_rules(*i) for i in idents)
+    print(needle)
+    print()
+
+    for h in haystacks:
+        print(h)
+        before = matches_from(scan(needle, h))
+        if before == []:
+            print(f"{h}: no mobile identities found")
+            continue
+
+        overwrite_file(h, before, b"\xaa")
+
+        after = scan(needle, h)
+        if len(after.matching_rules) > 0:
+            print(f"{h}: error: redaction unsuccessful")
+            _EXIT = 2
+        else:
+            print(f"{h}: verified")
+
+    exit(_EXIT)
+
+
+if __name__ == "__main__":
+    if len(sys.argv) < 2 or sys.argv[1] in ("-h", "--help"):
+        print("usage: redact.py FILE [FILE...]")
+        print("redact mobile identity values from FILE ...")
+        exit(1)
+    main(sys.argv[1:])

--- a/tools/requirements.txt
+++ b/tools/requirements.txt
@@ -3,3 +3,5 @@ bitstruct==8.19.0
 diskcache==5.6.3
 pycrate==0.7.8
 pyparsing==3.1.2
+scapy==2.6.1
+yara-x==0.13.0


### PR DESCRIPTION
# Description
This branch adds two python scripts:

extract.py:
- read mobile identities in TS24.301 NAS EPS Mobility Management messages from pcap files, as strings of digits and their id type.

redact.py:
- redact TS24.008 bcd encoded mobile identities from any file type with bytes containing 0xAA.
- uses yara-x to detect identities and prints the yara rules to stdout.

Note that when TS24.301 NAS messages are encapsulated in TS 36.331 LTE RRC messages, they may change byte alignment. redact.py attempts to correct for this by calculating several bit shifted versions of the identities.

This commit makes no attempt to identify encrypted identities or redact encrypted messages.

Users just need to run `redact.py *.qmdl *.pcap` or equivalent. extract.py is just for developers.

# Notes

fixes #154 

Because the redaction logic is decoupled from the detection logic, and because redact doesn't inherently require parsing, it would actually be pretty easy to add this to the qmdl/pcap writers in Rust. yara-x itself is written in Rust, and redacting is just overwriting a stream. I chose to have this operate on files in place because that seemed the most useful, but the logic should work with just in-memory edits.