### PR TITLE
Fix rendering of last_message_time in UI

### DIFF
--- a/bin/static/index.html
+++ b/bin/static/index.html
@@ -1,3 +1,4 @@
+<!DOCTYPE html>
 <html>
 <head>
     <title>rayhunter</title>

--- a/bin/static/js/main.js
+++ b/bin/static/js/main.js
@@ -170,24 +170,25 @@ async function getSystemStats() {
 async function getQmdlManifest() {
     const manifest = JSON.parse(await req('GET', '/api/qmdl-manifest'));
     if (manifest.current_entry) {
-        manifest.current_entry.status = STATUS_NEEDS_UPDATE;
-        manifest.current_entry.analysis_result = 'Waiting...';
-        manifest.current_entry.start_time = new Date(manifest.current_entry.start_time);
-        if (manifest.current_entry.last_message_time === undefined) {
-            manifest.current_entry.last_message_time = "N/A";
-        } else {
-            manifest.current_entry.last_message_time = new Date(manifest.current_entry.last_message_time);
-        }
+        parseQmdlEntry(manifest.current_entry);
     }
     for (entry of manifest.entries) {
-        entry.status = STATUS_NEEDS_UPDATE;
-        entry.analysis_result = 'Waiting...';
-        entry.start_time = new Date(entry.start_time);
-        entry.last_message_time = new Date(entry.last_message_time);
+        parseQmdlEntry(entry);
     }
     // sort them in reverse chronological order
     manifest.entries.reverse();
     return manifest;
+}
+
+function parseQmdlEntry(entry) {
+    entry.status = STATUS_NEEDS_UPDATE;
+    entry.analysis_result = 'Waiting...';
+    entry.start_time = new Date(entry.start_time);
+    if (entry.last_message_time === null) {
+        entry.last_message_time = "N/A";
+    } else {
+        entry.last_message_time = new Date(entry.last_message_time);
+    }
 }
 
 async function startRecording() {


### PR DESCRIPTION
* last_message_time is shown inconsistently for current entry vs other
  entries -- deduplicate code
* last_message_time is N/A for undefined -- but the API response was
  null instead of undefined, rendering Jan 01 1970 instead of N/A:

![image](https://github.com/user-attachments/assets/14fe7f19-a49f-4c03-8815-994507bf0d58)
