### PR TITLE
Add delete buttons to web ui

### DIFF
--- a/bin/src/daemon.rs
+++ b/bin/src/daemon.rs
@@ -20,7 +20,7 @@ use crate::framebuffer::Framebuffer;
 
 use analysis::{get_analysis_status, run_analysis_thread, start_analysis, AnalysisCtrlMessage, AnalysisStatus};
 use axum::response::Redirect;
-use diag::{get_analysis_report, start_recording, stop_recording, DiagDeviceCtrlMessage};
+use diag::{delete_recording, get_analysis_report, start_recording, stop_recording, DiagDeviceCtrlMessage};
 use log::{info, error};
 use qmdl_store::RecordingStoreError;
 use rayhunter::diag_device::DiagDevice;
@@ -56,6 +56,7 @@ async fn run_server(
         .route("/api/qmdl-manifest", get(get_qmdl_manifest))
         .route("/api/start-recording", post(start_recording))
         .route("/api/stop-recording", post(stop_recording))
+        .route("/api/delete-recording/*name", post(delete_recording))
         .route("/api/analysis-report/*name", get(get_analysis_report))
         .route("/api/analysis", get(get_analysis_status))
         .route("/api/analysis/*name", post(start_analysis))

--- a/bin/src/daemon.rs
+++ b/bin/src/daemon.rs
@@ -20,7 +20,7 @@ use crate::framebuffer::Framebuffer;
 
 use analysis::{get_analysis_status, run_analysis_thread, start_analysis, AnalysisCtrlMessage, AnalysisStatus};
 use axum::response::Redirect;
-use diag::{delete_recording, get_analysis_report, start_recording, stop_recording, DiagDeviceCtrlMessage};
+use diag::{delete_all_recordings, delete_recording, get_analysis_report, start_recording, stop_recording, DiagDeviceCtrlMessage};
 use log::{info, error};
 use qmdl_store::RecordingStoreError;
 use rayhunter::diag_device::DiagDevice;
@@ -57,6 +57,7 @@ async fn run_server(
         .route("/api/start-recording", post(start_recording))
         .route("/api/stop-recording", post(stop_recording))
         .route("/api/delete-recording/*name", post(delete_recording))
+        .route("/api/delete-all-recordings", post(delete_all_recordings))
         .route("/api/analysis-report/*name", get(get_analysis_report))
         .route("/api/analysis", get(get_analysis_status))
         .route("/api/analysis/*name", post(start_analysis))

--- a/bin/src/diag.rs
+++ b/bin/src/diag.rs
@@ -175,6 +175,20 @@ pub async fn delete_recording(
     Ok((StatusCode::ACCEPTED, "ok".to_string()))
 }
 
+pub async fn delete_all_recordings(State(state): State<Arc<ServerState>>) -> Result<(StatusCode, String), (StatusCode, String)> {
+    if state.debug_mode {
+        return Err((StatusCode::FORBIDDEN, "server is in debug mode".to_string()));
+    }
+    let mut qmdl_store = state.qmdl_store_lock.write().await;
+    qmdl_store.delete_all_entries().await
+        .map_err(|e| (StatusCode::INTERNAL_SERVER_ERROR, format!("couldn't delete all recordings: {}", e)))?;
+    state.diag_device_ctrl_sender.send(DiagDeviceCtrlMessage::StopRecording).await
+        .map_err(|e| (StatusCode::INTERNAL_SERVER_ERROR, format!("couldn't send stop recording message: {}", e)))?;
+    state.ui_update_sender.send(framebuffer::DisplayState::Paused).await
+        .map_err(|e| (StatusCode::INTERNAL_SERVER_ERROR, format!("couldn't send ui update message: {}", e)))?;
+    Ok((StatusCode::ACCEPTED, "ok".to_string()))
+}
+
 pub async fn get_analysis_report(State(state): State<Arc<ServerState>>, Path(qmdl_name): Path<String>) -> Result<Response, (StatusCode, String)> {
     let qmdl_store = state.qmdl_store_lock.read().await;
     let (entry_index, _) = if qmdl_name == "live" {

--- a/bin/static/index.html
+++ b/bin/static/index.html
@@ -18,6 +18,7 @@
     <div>
         <button onclick="startRecording()">Start Recording</button>
         <button onclick="stopRecording()">Stop Recording</button>
+        <button onclick="deleteAllRecodings()">Delete All Recordings</button>
     </div>
     <table id="qmdl-manifest-table">
         <thead>

--- a/bin/static/index.html
+++ b/bin/static/index.html
@@ -29,6 +29,7 @@
                 <th scope="col">PCAP</th>
                 <th scope="col">QMDL</th>
                 <th scope="col">Analysis Result</th>
+                <th scope="col">Actions</th>
             </tr>
         </thead>
     </table>

--- a/bin/static/js/main.js
+++ b/bin/static/js/main.js
@@ -125,6 +125,16 @@ function createLink(uri, text) {
     return link;
 }
 
+function createButton(uri, text) {
+    const link = document.createElement('button');
+    link.innerText = text;
+    link.onclick = async () => {
+        await req('POST', uri);
+        populateDivs();
+    };
+    return link;
+}
+
 function createEntryRow(entry, isCurrent) {
     const row = document.createElement('tr');
     const name = document.createElement('th');
@@ -152,6 +162,10 @@ function createEntryRow(entry, isCurrent) {
         row.classList.add("warning");
     }
     row.appendChild(analysisResult);
+
+    const actionsButtons = document.createElement('td');
+    actionsButtons.appendChild(createButton(`/api/delete-recording/${entry.name}`, 'Delete'));
+    row.appendChild(actionsButtons);
 
     return row;
 }

--- a/bin/static/js/main.js
+++ b/bin/static/js/main.js
@@ -215,6 +215,13 @@ async function stopRecording() {
     populateDivs();
 }
 
+async function deleteAllRecodings() {
+    if (window.confirm("Are you sure you want to permanently delete all of your recordings?")) {
+        await req('POST', '/api/delete-all-recordings');
+        populateDivs();
+    }
+}
+
 async function req(method, url) {
     const response = await fetch(url, {
         method: method,


### PR DESCRIPTION
This PR adds a delete button to each row of the recordings table and a delete all button along side the start and stop buttons. The delete all button asks for confirmation before deleting, the row delete buttons do now.

I believe someone else was working on a revamp of the web ui, but I was able to throw this together in an evening, so we can have the feature while we wait.

![image](https://github.com/user-attachments/assets/7db4d3c2-d59c-46b9-b6cc-648b64174405)

Fixes #191 