### PR TITLE
Remove RecordingCBM

### DIFF
--- a/bin/src/daemon.rs
+++ b/bin/src/daemon.rs
@@ -16,7 +16,7 @@ use crate::server::{ServerState, get_qmdl, serve_static};
 use crate::pcap::get_pcap;
 use crate::stats::get_system_stats;
 use crate::error::RayhunterError;
-use crate::framebuffer::Framebuffer;
+use crate::framebuffer::{Color565, Framebuffer};
 
 use analysis::{get_analysis_status, run_analysis_thread, start_analysis, AnalysisCtrlMessage, AnalysisStatus};
 use axum::response::Redirect;
@@ -144,7 +144,7 @@ fn run_ctrl_c_thread(
     })
 }
 
-fn update_ui(task_tracker: &TaskTracker,  config: &config::Config, mut ui_shutdown_rx: oneshot::Receiver<()>, mut ui_update_rx: Receiver<framebuffer::DisplayState>) -> JoinHandle<()> {
+fn update_ui(task_tracker: &TaskTracker, config: &config::Config, mut ui_shutdown_rx: oneshot::Receiver<()>, mut ui_update_rx: Receiver<framebuffer::DisplayState>) -> JoinHandle<()> {
     static IMAGE_DIR: Dir<'_> = include_dir!("$CARGO_MANIFEST_DIR/static/images/");
     let mut display_color: framebuffer::Color565;
     let display_level = config.ui_level;
@@ -152,7 +152,9 @@ fn update_ui(task_tracker: &TaskTracker,  config: &config::Config, mut ui_shutdo
         info!("Invisible mode, not spawning UI.");
     }
 
-    if config.colorblind_mode {
+    let colorblind_mode = config.colorblind_mode;
+
+    if colorblind_mode {
         display_color = framebuffer::Color565::Blue;
     } else {
         display_color = framebuffer::Color565::Green;
@@ -178,7 +180,7 @@ fn update_ui(task_tracker: &TaskTracker,  config: &config::Config, mut ui_shutdo
             }
             match ui_update_rx.try_recv() {
                     Ok(state) => {
-                        display_color = state.into();
+                        display_color = Color565::from_display_state(state, colorblind_mode);
                     },
                     Err(tokio::sync::mpsc::error::TryRecvError::Empty) => {},
                     Err(e) => error!("error receiving framebuffer update message: {e}")
@@ -250,7 +252,6 @@ async fn main() -> Result<(), RayhunterError> {
         debug_mode: config.debug_mode,
         analysis_status_lock,
         analysis_sender: analysis_tx,
-        colorblind_mode: config.colorblind_mode,
     });
     run_server(&task_tracker, &config, state, server_shutdown_rx).await;
 

--- a/bin/src/diag.rs
+++ b/bin/src/diag.rs
@@ -130,11 +130,7 @@ pub async fn start_recording(State(state): State<Arc<ServerState>>) -> Result<(S
     state.diag_device_ctrl_sender.send(DiagDeviceCtrlMessage::StartRecording((qmdl_writer, analysis_file))).await
         .map_err(|e| (StatusCode::INTERNAL_SERVER_ERROR, format!("couldn't send stop recording message: {}", e)))?;
 
-    let display_state = if state.colorblind_mode { 
-        framebuffer::DisplayState::RecordingCBM
-    } else {
-        framebuffer::DisplayState::Recording
-    };
+    let display_state = framebuffer::DisplayState::Recording;
     state.ui_update_sender.send(display_state).await
         .map_err(|e| (StatusCode::INTERNAL_SERVER_ERROR, format!("couldn't send ui update message: {}", e)))?;
 

--- a/bin/src/framebuffer.rs
+++ b/bin/src/framebuffer.rs
@@ -27,15 +27,17 @@ pub enum DisplayState {
     Recording,
     Paused,
     WarningDetected,
-    RecordingCBM,
 }
 
-impl From<DisplayState> for Color565 {
-    fn from(state: DisplayState) -> Self {
+impl Color565 {
+    pub fn from_display_state(state: DisplayState, colorblind: bool) -> Self {
         match state {
             DisplayState::Paused => Color565::White,
-            DisplayState::Recording => Color565::Green, 
-            DisplayState::RecordingCBM => Color565::Blue, 
+            DisplayState::Recording => if colorblind {
+                Color565::Green
+            } else {
+                Color565::Blue
+            },
             DisplayState::WarningDetected => Color565::Red,
         }
     }

--- a/bin/src/server.rs
+++ b/bin/src/server.rs
@@ -23,7 +23,6 @@ pub struct ServerState {
     pub analysis_status_lock: Arc<RwLock<AnalysisStatus>>,
     pub analysis_sender: Sender<AnalysisCtrlMessage>,
     pub debug_mode: bool,
-    pub colorblind_mode: bool,
 }
 
 pub async fn get_qmdl(State(state): State<Arc<ServerState>>, Path(qmdl_name): Path<String>) -> Result<Response, (StatusCode, String)> {


### PR DESCRIPTION
Colorblind mode is a property of the respective display, and decision
whether to display something in colorblind mode should lie with the
display thread. The display thread already needs to know about
colorblind mode for the initial state.

In #226, there are multiple implementations of display thread, and at
least one of them is dealing with a one-bit display anyway.

Aside, I think rayhunter should send an initial DisplayState on startup,
UI threads should not assume that the device is already recording. But
this can be discussed separately.
