### PR TITLE
ci: installer for ubuntu-24.04-arm (aarch64)

### DIFF
--- a/.github/workflows/build-release.yml
+++ b/.github/workflows/build-release.yml
@@ -14,6 +14,8 @@ jobs:
         platform:
           - name: ubuntu-24
             os: ubuntu-latest
+          - name: ubuntu-24-aarch64
+            os: ubuntu-24.04-arm
           - name: macos-arm
             os: macos-latest
           - name: macos-intel

--- a/dist/install.sh
+++ b/dist/install.sh
@@ -100,7 +100,11 @@ test_rayhunter() {
 ##### Main  #####
 ##### ##### #####
 if [[ `uname -s` == "Linux" ]]; then
-    export SERIAL_PATH="./serial-ubuntu-24/serial"
+    if [[ `uname -m` == "arm64" ]]; then
+        export SERIAL_PATH="./serial-ubuntu-24-aarch64/serial"
+    elif [[ `uname -m` == "x86_64" ]]; then
+        export SERIAL_PATH="./serial-ubuntu-24/serial"
+    fi
     export PLATFORM_TOOLS="platform-tools-latest-linux.zip"
 elif [[ `uname -s` == "Darwin" ]]; then
     if [[ `uname -m` == "arm64" ]]; then


### PR DESCRIPTION
This branch builds the serial binary, rayhunter-check, and install.sh for Linux on arm64.