### PR TITLE
ci: statically compile serial binary for linux

### DIFF
--- a/.github/workflows/build-release.yml
+++ b/.github/workflows/build-release.yml
@@ -14,30 +14,37 @@ jobs:
         platform:
           - name: ubuntu-24
             os: ubuntu-latest
+            target: x86_64-unknown-linux-musl
           - name: ubuntu-24-aarch64
             os: ubuntu-24.04-arm
+            target: aarch64-unknown-linux-musl
           - name: macos-arm
             os: macos-latest
+            target: aarch64-apple-darwin
           - name: macos-intel
             os: macos-13
+            target: x86_64-apple-darwin
           - name: windows-x86_64
             os: windows-latest
     runs-on: ${{ matrix.platform.os }}
     steps:
       - uses: actions/checkout@v4
+      - uses: dtolnay/rust-toolchain@stable
+        with:
+          targets: ${{ matrix.platform.target }}
       - name: Build serial
-        run: cargo build --bin serial --release
+        run: cargo build --bin serial --release --target ${{ matrix.platform.target }}
       - uses: actions/upload-artifact@v4
         with:
           name: serial-${{ matrix.platform.name }}
-          path: target/release/serial${{ matrix.platform.os == 'windows-latest' && '.exe' || '' }}
+          path: target/${{ matrix.platform.target }}/release/serial${{ matrix.platform.os == 'windows-latest' && '.exe' || '' }}
           if-no-files-found: error
       - uses: actions/checkout@v4
       - name: Build check
         run: cargo build --bin rayhunter-check --release
       - uses: actions/upload-artifact@v4
         with:
-          name: rayhunter-check-${{ matrix.platform.os }}
+          name: rayhunter-check-${{ matrix.platform.name }}
           path: target/release/rayhunter-check${{ matrix.platform.os == 'windows-latest' && '.exe' || '' }}
           if-no-files-found: error
   build_rootshell_and_rayhunter:


### PR DESCRIPTION
This branch uses each platform's musl target to statically compile the serial binary on linux.

Fixes https://github.com/EFForg/rayhunter/issues/263

## Pull Request Checklist

- [x] The Rayhunter team has recently expressed interest in reviewing a PR for this. If not, this PR may be closed due our limited resources and need to prioritize how we spend them.