### PR TITLE
README: clarify "unzip" instructions

### DIFF
--- a/README.md
+++ b/README.md
@@ -21,6 +21,8 @@ or on [eBay](https://www.ebay.com/sch/i.html?_nkw=orbic+rc400l).
 2. Unzip the `release.tar`. Open the terminal and navigate to the folder
 
     ```bash
+    mkdir ~/Downloads/release
+    tar -xvf ~/Downloads/release.tar -C ~/Downloads/release
     cd ~/Downloads/release
     ```
 


### PR DESCRIPTION
The current `release.tar` (v0.2.7)  lacks a `release` directory -- all files live at the root of the tar archive. But the README's Unzip instructions mention `cd`ing to `~/Downloads/release`, which implies that there is a `release` directory inside the tar.

Rather than verify with `tar --list --file ~/Downloads/release.tar` I made a bad assumption, ran `tar xvf ./release.tar` in my `~/Downloads`, and then had to clean up my `~/Downloads` directory.

This update clarifies that users should create the directory and extract the tar into that directory.

## Pull Request Checklist

- [ ] The Rayhunter team has recently expressed interest in reviewing a PR for this. If not, this PR may be closed due our limited resources and need to prioritize how we spend them.
- [x] Added or updated any documentation as needed to support the changes in this PR.
- NA ~~[ ] Code has been linted and run through `cargo fmt`~~
- [x] If any new functionality has been added, unit tests were also added
