### PR TITLE
Script to install via Docker

### DIFF
--- a/tools/docker-install.sh
+++ b/tools/docker-install.sh
@@ -1,0 +1,23 @@
+#!/usr/bin/env bash
+#
+# Use a privileged docker container to install Rayhunter.  The --privilege
+# flag is necessary for USB port access.
+#
+
+docker run --privileged ubuntu /bin/bash -l -c '
+  set -e
+
+  apt-get update
+  apt-get -y install curl adb
+  mkdir /tmp/rayhunter
+  cd /tmp/rayhunter
+  curl -LOs "https://github.com/EFForg/rayhunter/releases/latest/download/release.tar"
+  curl -LOs "https://github.com/EFForg/rayhunter/releases/latest/download/release.tar.sha256"
+  if ! sha256sum -c --quiet release.tar.sha256; then
+      echo "Download corrupted! (╯°□°)╯︵ ┻━┻"
+      exit 1
+  fi
+
+  tar -xf release.tar
+  ./install.sh
+'

--- a/tools/install-dev.sh
+++ b/tools/install-dev.sh
@@ -12,7 +12,7 @@ if ! sha256sum -c --quiet release.tar.sha256; then
 fi
 
 tar -xf release.tar
-./install-linux.sh
+./install.sh
 
 cd ..
 rm -rf build


### PR DESCRIPTION
- **Fix for install-dev.sh**
- **Script for installing via Docker**

This allows me to install the last release from NixOS, which can't use the
dynamically linked binaries.  It's also nice that it doesn't install adb
on my system.

## Pull Request Checklist

- [ ] The Rayhunter team has recently expressed interest in reviewing a PR for this. If not, this PR may be closed due our limited resources and need to prioritize how we spend them.
- [ ] Added or updated any documentation as needed to support the changes in this PR.
- [-] Code has been linted and run through `cargo fmt` (no Rust code changes)
- [-] If any new functionality has been added, unit tests were also added (no new functionality)
