### PR TITLE
ci: use rust-lld for all release targets

### DIFF
--- a/.cargo/config.toml
+++ b/.cargo/config.toml
@@ -6,8 +6,9 @@ rustflags = ["-C", "target-feature=+crt-static"]
 linker = "rust-lld"
 rustflags = ["-C", "target-feature=+crt-static"]
 
+# apt install build-essential libc6-armhf-cross libc6-dev-armhf-cross gcc-arm-linux-gnueabihf
 [target.armv7-unknown-linux-gnueabihf]
-linker = "armv7l-unknown-linux-gnueabihf-gcc"
+linker = "arm-linux-gnueabihf-gcc"
 rustflags = ["-C", "target-feature=+crt-static"]
 
 [target.armv7-unknown-linux-musleabihf]

--- a/.cargo/config.toml
+++ b/.cargo/config.toml
@@ -1,5 +1,25 @@
+[target.aarch64-apple-darwin]
+linker = "rust-lld"
+rustflags = ["-C", "target-feature=+crt-static"]
+
+[target.aarch64-unknown-linux-musl]
+linker = "rust-lld"
+rustflags = ["-C", "target-feature=+crt-static"]
+
 [target.armv7-unknown-linux-gnueabihf]
-linker = "arm-linux-gnueabihf-gcc"
+linker = "armv7l-unknown-linux-gnueabihf-gcc"
+rustflags = ["-C", "target-feature=+crt-static"]
+
+[target.armv7-unknown-linux-musleabihf]
+linker = "rust-lld"
+rustflags = ["-C", "target-feature=+crt-static"]
+
+[target.x86_64-apple-darwin]
+linker = "rust-lld"
+rustflags = ["-C", "target-feature=+crt-static"]
+
+[target.x86_64-unknown-linux-musl]
+linker = "rust-lld"
 rustflags = ["-C", "target-feature=+crt-static"]
 
 # optimizations to reduce the binary size

--- a/.github/workflows/build-release.yml
+++ b/.github/workflows/build-release.yml
@@ -56,18 +56,13 @@ jobs:
       - uses: actions/checkout@v4
       - uses: dtolnay/rust-toolchain@stable
         with:
-          targets: armv7-unknown-linux-gnueabihf
-      - name: Install cross-compilation dependencies
-        uses: awalsh128/cache-apt-pkgs-action@latest
-        with:
-          packages: build-essential libc6-armhf-cross libc6-dev-armhf-cross gcc-arm-linux-gnueabihf
-          version: 1.0
+          targets: armv7-unknown-linux-musleabihf
       - name: Build rootshell (arm32)
-        run: cargo build --bin rootshell --target armv7-unknown-linux-gnueabihf --release
+        run: cargo build --bin rootshell --target armv7-unknown-linux-musleabihf --release
       - uses: actions/upload-artifact@v4
         with:
           name: rootshell
-          path: target/armv7-unknown-linux-gnueabihf/release/rootshell
+          path: target/armv7-unknown-linux-musleabihf/release/rootshell
           if-no-files-found: error
   build_rayhunter:
     strategy:
@@ -81,18 +76,13 @@ jobs:
       - uses: actions/checkout@v4
       - uses: dtolnay/rust-toolchain@stable
         with:
-          targets: armv7-unknown-linux-gnueabihf
-      - name: Install cross-compilation dependencies
-        uses: awalsh128/cache-apt-pkgs-action@latest
-        with:
-          packages: build-essential libc6-armhf-cross libc6-dev-armhf-cross gcc-arm-linux-gnueabihf
-          version: 1.0
+          targets: armv7-unknown-linux-musleabihf
       - name: Build rayhunter-daemon (arm32)
-        run: cargo build --bin rayhunter-daemon --target armv7-unknown-linux-gnueabihf --release --no-default-features --features ${{ matrix.device.name }}
+        run: cargo build --bin rayhunter-daemon --target armv7-unknown-linux-musleabihf --release --no-default-features --features ${{ matrix.device.name }}
       - uses: actions/upload-artifact@v4
         with:
           name: rayhunter-daemon-${{ matrix.device.name }}
-          path: target/armv7-unknown-linux-gnueabihf/release/rayhunter-daemon
+          path: target/armv7-unknown-linux-musleabihf/release/rayhunter-daemon
           if-no-files-found: error
   build_release_zip:
     needs:

--- a/README.md
+++ b/README.md
@@ -108,15 +108,27 @@ Follow these instructions if you need to build Rayhunter from source rather than
     * [linux](https://askubuntu.com/questions/652936/adding-android-sdk-platform-tools-to-path-downloaded-from-umake)
     * [macOS](https://www.repeato.app/setting-up-adb-on-macos-a-step-by-step-guide/)
     * [Windows](https://medium.com/@yadav-ajay/a-step-by-step-guide-to-setting-up-adb-path-on-windows-0b833faebf18)
+* Install `curl` on your computer to run the install scripts. It is not needed to build binaries.
 
-### If you're on x86 linux
+### Install Rust targets
 
-Install Rust the usual way and then install cross compiling dependences:
+[Install Rust the usual way](https://www.rust-lang.org/tools/install). Then,
 
-```bash
-sudo apt install curl build-essential libc6-armhf-cross libc6-dev-armhf-cross gcc-arm-linux-gnueabihf
-rustup target add x86_64-unknown-linux-gnu
-rustup target add armv7-unknown-linux-gnueabihf
+- install the cross-compilation target for the device rayhunter will run on:
+```sh
+rustup target add armv7-unknown-linux-musleabihf
+```
+
+- install the statically compiled target for your host machine to build the binary installer [`serial`](./serial).
+```sh
+# check which toolchain you have installed by default with
+rustup show
+# now install the correct variant for your host platform, one of:
+rustup target add x86_64-unknown-linux-musl
+rustup target add aarch64-unknown-linux-musl
+rustup target add aarch64-apple-darwin
+rustup target add x86_64-apple-darwin
+rustup target add x86_64-pc-windows-gnu
 ```
 
 Now you can root your device and install Rayhunter by running `./tools/install-dev.sh`

--- a/lib/src/diag_device.rs
+++ b/lib/src/diag_device.rs
@@ -59,18 +59,22 @@ pub const LOG_CODES_FOR_RAW_PACKET_LOGGING: [u32; 11] = [
 const BUFFER_LEN: usize = 1024 * 1024 * 10;
 const MEMORY_DEVICE_MODE: u32 = 2;
 
-#[cfg(target_arch = "arm")]
+#[cfg(target_env = "musl")]
+const DIAG_IOCTL_REMOTE_DEV: i32 = 32;
+#[cfg(all(not(target_env = "musl"), target_arch = "arm"))]
 const DIAG_IOCTL_REMOTE_DEV: u32 = 32;
-#[cfg(target_arch = "x86_64")]
+#[cfg(all(not(target_env = "musl"), target_arch = "x86_64"))]
 const DIAG_IOCTL_REMOTE_DEV: u64 = 32;
-#[cfg(target_arch = "aarch64")]
+#[cfg(all(not(target_env = "musl"), target_arch = "aarch64"))]
 const DIAG_IOCTL_REMOTE_DEV: u64 = 32;
 
-#[cfg(target_arch = "arm")]
+#[cfg(target_env = "musl")]
+const DIAG_IOCTL_SWITCH_LOGGING: i32 = 7;
+#[cfg(all(not(target_env = "musl"), target_arch = "arm"))]
 const DIAG_IOCTL_SWITCH_LOGGING: u32 = 7;
-#[cfg(target_arch = "x86_64")]
+#[cfg(all(not(target_env = "musl"), target_arch = "x86_64"))]
 const DIAG_IOCTL_SWITCH_LOGGING: u64 = 7;
-#[cfg(target_arch = "aarch64")]
+#[cfg(all(not(target_env = "musl"), target_arch = "aarch64"))]
 const DIAG_IOCTL_SWITCH_LOGGING: u64 = 7;
 
 pub struct DiagDevice {

--- a/make.sh
+++ b/make.sh
@@ -1,6 +1,6 @@
 #!/bin/sh
-cargo build --release --target="armv7-unknown-linux-gnueabihf" #--features debug
+cargo build --release --target="armv7-unknown-linux-musleabihf" #--features debug
 adb shell '/bin/rootshell -c "/etc/init.d/rayhunter_daemon stop"'
-adb push target/armv7-unknown-linux-gnueabihf/release/rayhunter-daemon /data/rayhunter/rayhunter-daemon
+adb push target/armv7-unknown-linux-musleabihf/release/rayhunter-daemon /data/rayhunter/rayhunter-daemon
 echo "rebooting the device..."
 adb shell '/bin/rootshell -c "reboot"'

--- a/tools/devenv.dockerfile
+++ b/tools/devenv.dockerfile
@@ -1,5 +1,3 @@
 FROM rust:1.86-bullseye
 
-RUN apt-get update
-RUN apt-get install -y build-essential libc6-armhf-cross libc6-dev-armhf-cross gcc-arm-linux-gnueabihf
-RUN rustup target add armv7-unknown-linux-gnueabihf
+RUN rustup target add armv7-unknown-linux-musleabihf

--- a/tools/run-docker-devenv
+++ b/tools/run-docker-devenv
@@ -9,9 +9,9 @@
 # ./tools/run-docker-devenv
 #
 # Inside the shell:
-# cargo build --bin rayhunter-daemon --target armv7-unknown-linux-gnueabihf --release
+# cargo build --bin rayhunter-daemon --target armv7-unknown-linux-musleabihf --release
 #
-# Your output binary is in ./target/armv7-unknown-linux-gnueabihf/release/rayhunter-daemon
+# Your output binary is in ./target/armv7-unknown-linux-musleabihf/release/rayhunter-daemon
 
 docker build -t rayhunter-devenv -f tools/devenv.dockerfile .
 exec docker run --user $UID:$GID -v ./:/workdir -w /workdir -it rayhunter-devenv "$@"


### PR DESCRIPTION
Aims to solve "I can't build on $platform".

Removes dependency on gcc-based cross-compilation toolchain.

This branch allows development on any machine that can install rustup toolchains. No special debian packages are needed to build any of the binaries, only what's installed by rustup.

Updates `.cargo/config.toml`, `make.sh`, tools/devenv, github actions, and the README to use the musl/rust-lld targets.

## Pull Request Checklist

- [ ] The Rayhunter team has recently expressed interest in reviewing a PR for this. If not, this PR may be closed due our limited resources and need to prioritize how we spend them.
- [x] Added or updated any documentation as needed to support the changes in this PR.
- [x] Code has been linted and run through `cargo fmt`
