### PR TITLE
docs: publish mdbook in doc to github pages

### DIFF
--- a/.github/workflows/mdbook.yaml
+++ b/.github/workflows/mdbook.yaml
@@ -1,0 +1,47 @@
+# On Repository Settings > Pages > Build and deployment
+# Set "Source" to GitHub Actions.
+name: Documentation
+on:
+  push:
+    branches: ["main"]
+  pull_request:
+    branches: ["main"]
+
+jobs:
+  mdbook_test:
+    name: Test mdBook Documentation builds
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - name: Install mdBook
+        run: |
+          cargo install mdbook --no-default-features --features search --vers "^0.4" --locked
+      - name: Test mdBook
+        run: mdbook test
+
+  mdbook_publish:
+    if: ${{ github.event_name != 'pull_request' }}
+    needs: mdbook_test
+    permissions:
+      pages: write
+      contents: write
+      id-token: write
+    name: Publish mdBook to Github Pages
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - name: Install mdBook
+        run: |
+          cargo install mdbook --no-default-features --features search --vers "^0.4" --locked
+
+      - name: Build mdBook
+        run: mdbook build
+
+      - name: Setup Pages
+        uses: actions/configure-pages@v4
+      - name: Upload artifact
+        uses: actions/upload-pages-artifact@v3
+        with:
+          path: book
+      - name: Deploy to Github Pages
+        uses: actions/deploy-pages@v4

--- a/.gitignore
+++ b/.gitignore
@@ -1,1 +1,2 @@
 /target
+/book

--- a/book.toml
+++ b/book.toml
@@ -1,0 +1,5 @@
+[book]
+authors = ["the rayhunter Authors"]
+language = "en"
+src = "doc"
+title = "rayhunter Documentation"

--- a/doc/SUMMARY.md
+++ b/doc/SUMMARY.md
@@ -1,0 +1,4 @@
+# Summary
+
+- [Installation](./installation.md)
+- [Supported Devices](./supported_devices.md)

--- a/doc/installation.md
+++ b/doc/installation.md
@@ -1,0 +1,1 @@
+# Chapter 1

--- a/doc/supported_devices.md
+++ b/doc/supported_devices.md
@@ -1,0 +1,4 @@
+# Supported devices
+
+- Orbic RC400L
+- TPLink M7350 HW rev. 3, 5, 9


### PR DESCRIPTION
This branch adds an mdbook for rayhunter documentation in `doc`, and actions workflows to publish that documentation to github pages.
    
This branch configures actions to publish to pages via artifact uploads, but can be adjusted to publish based solely on a branch.[0] This was chosen to allow for future flexibility in generating multiple outputs (such as a single page html document or pdf).
    
[0] https://docs.github.com/en/pages/getting-started-with-github-pages/configuring-a-publishing-source-for-your-github-pages-site

## Pull Request Checklist

- [x] The Rayhunter team has recently expressed interest in reviewing a PR for this. If not, this PR may be closed due our limited resources and need to prioritize how we spend them.
- [ ] Added or updated any documentation as needed to support the changes in this PR.
- [x] If any new functionality has been added, unit tests were also added
