### PR TITLE
Fixes for TP-Link M7350 v9

### DIFF
--- a/doc/tplink-m7350.md
+++ b/doc/tplink-m7350.md
@@ -7,10 +7,10 @@ The TP-Link M7350 is supported by Rayhunter from 0.3.0 release. TP-Link M7350 su
 The TP-Link comes in many different *hardware versions*. Support for installation varies:
 
 * `1.0`, `2.0`: **Not suported**, probably impossible to obtain anymore (even second-hand), however there is one report that installation is possible on `1.0` (but no reports if it is working or not)
-* `3.0`, `3.2`, `5.0`, `5.2`, `7.0`, `8.0`: **Tested, no known issues.**
+* `3.0`, `3.2`, `5.0`, `5.2`, `7.0`, `8.0`: **Tested, no known issues since 0.3.0.**
 * `6.2`: **One user reported it is working**
-* `4.0`: **Not working yet** ([issue](https://github.com/EFForg/rayhunter/issues/332)), however [it could be installed manually](https://github.com/m0veax/rayhunter-tplink-m7350/))
-* `9.0`: **Not working yet** ([issue](https://github.com/EFForg/rayhunter/issues/325), however opening/rooting works, Rayhunter could be installed manually, but does not work because of [IOCTL error](#302))
+* `4.0`: **Manual firmware downgrade required** ([issue](https://github.com/EFForg/rayhunter/issues/332))
+* `9.0`: **Working since 0.3.2.**
 
 TP-Link versions newer than `3.0` have cyan packaging and a color display. Version `3.0` has a one-bit display and white packaging.
 
@@ -61,6 +61,15 @@ You can change the `port` (default is `8080`) where Rayhunter is listening for i
 
 By default the device will go to sleep after N minutes of no devices being connected. In that mode it will also turn off connections to cell phone towers.
 In order for Rayhunter to record continuously, you have to turn off this sleep mode in TP-Link's admin panel (go to **Advanced** - **Power Saving**) or keep e.g. your phone connectd on the TP-Link's WiFi.
+
+## Port triggers
+
+On hardware revisions starting with v4.0, the installer will modify settings to
+add two port triggers. You can look at `Settings > NAT Settings > Port
+Triggers` in TP-Link's admin UI to see them.
+
+1. One port trigger "rayhunter-root" to launch the telnet shell. This is only needed for installation, and can be removed after upgrade. You can reinstall it using `./installer util tplink-start-telnet`.
+2. One port trigger "rayhunter-daemon" to auto-start rayhunter on boot. If you remove this, rayhunter will have to be started manually from shell.
 
 ## Other links
 

--- a/doc/uninstalling.md
+++ b/doc/uninstalling.md
@@ -16,4 +16,9 @@ Your device is now Rayhunter-free, and should no longer be in a rooted ADB-enabl
 
 ## TPLink
 
-TODO
+1. Run `./installer util tplink-start-telnet`
+2. Telnet into the device `telnet 192.168.0.1`
+3. `rm /data/rayhunter /etc/init.d/rayhunter_daemon`
+4. `update-rc.d rayhunter_daemon remove`
+5. (hardware revision v4.0+ only) In `Settings > NAT Settings > Port Triggers` in TP-Link's admin UI, remove any leftover port triggers.
+

--- a/installer/src/main.rs
+++ b/installer/src/main.rs
@@ -34,6 +34,17 @@ struct InstallTpLink {
     /// IP address for TP-Link admin interface, if custom.
     #[arg(long, default_value = "192.168.0.1")]
     admin_ip: String,
+
+    /// For advanced users: Specify the path of the SD card to be mounted explicitly.
+    ///
+    /// The default (empty string) is to use whichever sdcard path the device would use natively to
+    /// mount storage on. On most TP-Link this is /media/card, but on hardware versions 9+ this is
+    /// /media/sdcard
+    ///
+    /// Only override this when the installer does not work on your hardware version, as otherwise
+    /// your custom path may conflict with the builtin storage functionality.
+    #[arg(long, default_value = "")]
+    sdcard_path: String,
 }
 
 #[derive(Parser, Debug)]

--- a/lib/src/diag_device.rs
+++ b/lib/src/diag_device.rs
@@ -251,6 +251,7 @@ impl DiagDevice {
 //
 // TPLINK M7350 v5 source code can be downloaded at https://www.tp-link.com/de/support/gpl-code/?app=omada
 #[repr(C)]
+#[derive(Debug, Clone, Copy)]
 struct diag_logging_mode_param_t {
     req_mode: u32,
     peripheral_mask: u32,
@@ -261,30 +262,41 @@ struct diag_logging_mode_param_t {
 fn enable_frame_readwrite(fd: i32, mode: u32) -> DiagResult<()> {
     unsafe {
         if libc::ioctl(fd, DIAG_IOCTL_SWITCH_LOGGING, mode, 0, 0, 0) < 0 {
-            let mut params = if cfg!(feature = "tplink") {
+            let try_params: &[diag_logging_mode_param_t] = &[
+                // tplink M7350 HW revision 3-8 need this mode
+                #[cfg(feature = "tplink")]
                 diag_logging_mode_param_t {
                     req_mode: mode,
                     peripheral_mask: 0,
                     mode_param: 1,
-                }
-            } else {
+                },
+                // tplink M7350 HW revision v9 requires the same parameters as orbic
                 diag_logging_mode_param_t {
                     req_mode: mode,
                     peripheral_mask: u32::MAX,
                     mode_param: 0,
-                }
-            };
+                },
+            ];
 
-            let ret = libc::ioctl(
-                fd,
-                DIAG_IOCTL_SWITCH_LOGGING,
-                &mut params as *mut _,
-                std::mem::size_of::<diag_logging_mode_param_t>(),
-                0,
-                0,
-                0,
-                0,
-            );
+            let mut ret = 0;
+
+            for params in try_params {
+                let mut params = *params;
+                ret = libc::ioctl(
+                    fd,
+                    DIAG_IOCTL_SWITCH_LOGGING,
+                    &mut params as *mut diag_logging_mode_param_t,
+                    std::mem::size_of::<diag_logging_mode_param_t>(),
+                    0,
+                    0,
+                    0,
+                    0,
+                );
+                if ret == 0 {
+                    break;
+                }
+            }
+
             if ret < 0 {
                 let msg = format!(
                     "DIAG_IOCTL_SWITCH_LOGGING ioctl failed with error code {}",


### PR DESCRIPTION
* Fix autostart by adding another port trigger for rayhunter-daemon
* Use Orbic's IOCTL params as fallback
* Fix sdcard path and make it configurable
* Update docs to indicate support
* Add uninstalling instructions for TP-Link

Fix #325