### PR TITLE
Loosen up issue templates

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug.yaml
+++ b/.github/ISSUE_TEMPLATE/bug.yaml
@@ -1,59 +1,19 @@
 name: Bug Report
 description: File a bug report.
-title: "[Bug]: "
+labels: ["bug"]
 body:
-  - type: markdown
-    attributes:
-      value: |
-        Thanks for taking the time to fill out this bug report!
-  - type: input
-    attributes:
-      label: Rayhunter Version
-      description: |
-        Which version did you install?
-      placeholder:  "v0.2.6"
-  - type: input
-    attributes:
-      label: Capture Date
-      description: |
-        YYYY-MM-DD
-      placeholder: "2025-05-01"
-    validations:
-      required: true
-  - type: input
-    attributes:
-      label: Capture Location
-      description: |
-        (If comfortable disclosing) What region or country were you in? 
-      placeholder: Washington State
-  - type: input
-    attributes:
-      label: Device and Model
-      description: |
-        Device you installed Rayhunter on to.
-      placeholder: Orbic RC400L 
-    validations:
-      required: true
   - type: textarea
-    id: what-happened
     attributes:
-      label: What happened?
+      label: Bug Report Details
       description: |
-        What steps did you take to get to your issue?
-      placeholder: "Tell us what you see!"
+        Please provide the following information, if applicable:
+      placeholder: |
+        • **Rayhunter Version**: (e.g., v0.2.6)
+        • **Capture Date**: (YYYY-MM-DD, e.g., 2025-05-01)
+        • **Capture Location**: (If comfortable disclosing, what region or country were you in? e.g., Washington State)
+        • **Device and Model**: (Device you installed Rayhunter on, e.g., Orbic RC400L)
+        • **What happened?**: (What steps did you take to get to your issue? Tell us what you see!)
+        • **Expected behavior**: (Rayhunter's behavior differed from what I expected because...)
+        • **Relevant log output**: (Rayhunter data captures - QMDL and PCAP logs - or error codes)
     validations:
       required: true
-  - type: textarea
-    id: expected
-    attributes:
-      label: Expected behavior
-      description: Rayhunter's behavior differed from what I expected because.
-      placeholder: "What was expected?"
-    validations:
-      required: true
-  - type: textarea
-    id: logs
-    attributes:
-      label: Relevant log output
-      description: Rayhunter data captures (QMDL and PCAP logs) or error codes
-      render: shell

--- a/.github/ISSUE_TEMPLATE/config.yml
+++ b/.github/ISSUE_TEMPLATE/config.yml
@@ -1,4 +1,4 @@
-blank_issues_enabled: false
+blank_issues_enabled: true
 contact_links:
   - name: Rayhunter Mattermost
     url: https://opensource.eff.org/signup_user_complete/?id=6iqur37ucfrctfswrs14iscobw&md=link&sbr=su

--- a/.github/ISSUE_TEMPLATE/feature.yaml
+++ b/.github/ISSUE_TEMPLATE/feature.yaml
@@ -1,6 +1,5 @@
 name: Feature Request
 description: Suggest a new feature or improvement to Rayhunter
-title: "[Feature Request]: "
 labels: ["enhancement"]
 body:
   - type: textarea


### PR DESCRIPTION
A lot of the bug report we receive are about the web UI or the installer
failing, and there things like capture date just don't matter. We could
create separate templates for these types of bugs, but I'd think it's
probably better to just have one textbox with a few "reminder" questions
that are all optional and can be removed entirely if they don't make sense.

We could also make all form fields in the template optional, but the
resulting issues would be cluttered with N/A.

Feature request template I think doesn't have this issue.

Also allow the creation of blank issues, because some issues are more
related to CI or devenv and don't neatly fit in any category. Let's just
hope nobody abuses that?
