### PR TITLE
Allow enabling/disabling analyzers from config file

### DIFF
--- a/bin/src/check.rs
+++ b/bin/src/check.rs
@@ -2,7 +2,7 @@ use clap::Parser;
 use futures::TryStreamExt;
 use log::{info, warn};
 use rayhunter::{
-    analysis::analyzer::{EventType, Harness},
+    analysis::analyzer::{AnalyzerConfig, EventType, Harness},
     diag::DataType,
     gsmtap_parser,
     pcap::GsmtapPcapWriter,
@@ -33,7 +33,7 @@ struct Args {
 }
 
 async fn analyze_file(enable_dummy_analyzer: bool, qmdl_path: &str, show_skipped: bool) {
-    let mut harness = Harness::new_with_all_analyzers();
+    let mut harness = Harness::new_with_config(&AnalyzerConfig::default());
     if enable_dummy_analyzer {
         harness.add_analyzer(Box::new(dummy_analyzer::TestAnalyzer { count: 0 }));
     }
@@ -141,7 +141,7 @@ async fn main() {
         .unwrap();
     info!("Analyzers:");
 
-    let mut harness = Harness::new_with_all_analyzers();
+    let mut harness = Harness::new_with_config(&AnalyzerConfig::default());
     if args.enable_dummy_analyzer {
         harness.add_analyzer(Box::new(dummy_analyzer::TestAnalyzer { count: 0 }));
     }

--- a/bin/src/config.rs
+++ b/bin/src/config.rs
@@ -1,6 +1,8 @@
-use crate::error::RayhunterError;
-
 use serde::Deserialize;
+
+use rayhunter::analysis::analyzer::AnalyzerConfig;
+
+use crate::error::RayhunterError;
 
 #[derive(Debug, Deserialize)]
 #[serde(default)]
@@ -12,6 +14,7 @@ pub struct Config {
     pub enable_dummy_analyzer: bool,
     pub colorblind_mode: bool,
     pub key_input_mode: u8,
+    pub analyzers: AnalyzerConfig,
 }
 
 impl Default for Config {
@@ -24,6 +27,7 @@ impl Default for Config {
             enable_dummy_analyzer: false,
             colorblind_mode: false,
             key_input_mode: 1,
+            analyzers: AnalyzerConfig::default(),
         }
     }
 }

--- a/bin/src/daemon.rs
+++ b/bin/src/daemon.rs
@@ -199,6 +199,7 @@ async fn main() -> Result<(), RayhunterError> {
             qmdl_store_lock.clone(),
             analysis_tx.clone(),
             config.enable_dummy_analyzer,
+            config.analyzers.clone(),
         );
         info!("Starting UI");
         display::update_ui(&task_tracker, &config, ui_shutdown_rx, ui_update_rx);
@@ -215,6 +216,7 @@ async fn main() -> Result<(), RayhunterError> {
         qmdl_store_lock.clone(),
         analysis_status_lock.clone(),
         config.enable_dummy_analyzer,
+        config.analyzers.clone(),
     );
     run_ctrl_c_thread(
         &task_tracker,

--- a/dist/config.toml.example
+++ b/dist/config.toml.example
@@ -20,3 +20,12 @@ ui_level = 1
 # 0 = rayhunter does not read button presses
 # 1 = double-tapping the power button starts/stops recordings
 key_input_mode = 1
+
+# Analyzer Configuration
+# Enable/disable specific IMSI catcher detection heuristics
+# See https://github.com/EFForg/rayhunter/blob/main/doc/heuristics.md for details
+[analyzers]
+imsi_requested = true
+connection_redirect_2g_downgrade = true
+lte_sib6_and_7_downgrade = true
+null_cipher = false

--- a/doc/heuristics.md
+++ b/doc/heuristics.md
@@ -1,3 +1,18 @@
 # Heuristics
 
-TODO
+Rayhunter includes several analyzers to detect potential IMSI catcher activity. These can be enabled and disabled in your [config.toml](https://github.com/EFForg/rayhunter/blob/main/dist/config.toml.example) file.
+
+## Available Analyzers
+
+- **IMSI Requested**: Tests whether the ME sends an IMSI Identity Request NAS message
+- **Connection Release/Redirected Carrier 2G Downgrade**: Tests if a cell
+  releases our connection and redirects us to a 2G cell. This heuristic only
+  makes sense in the US, european users may want to disable it.
+- **LTE SIB6/7 Downgrade**: Tests for LTE cells broadcasting a SIB type 6 and 7
+  which include 2G/3G frequencies with higher priorities
+
+### Disabled by default
+
+- **Null Cipher**: Tests whether the cell suggests using a null cipher (EEA0).
+  This is currently disabled by default due to a parsing bug triggering false
+  positives.


### PR DESCRIPTION
This is just a simple way to be able to use the 2G analyzer in europe,
and to disable maybe IMSI requests if they are too noisy.

In a later version we can:

* expose config editing in the UI (this is already ongoing)
* make the level configurable
* add ability to define presets (though i think people could just copy
  configs from the docs or github issues)

Also fill out heuristics.md with some basic information.
