### PR TITLE
Add support for TP-Link M7310

### DIFF
--- a/doc/SUMMARY.md
+++ b/doc/SUMMARY.md
@@ -12,6 +12,7 @@
   - [How we analyze a capture](./analyzing-a-capture.md)
 - [Supported devices](./supported-devices.md)
   - [TP-Link M7350](./tplink-m7350.md)
+  - [TP-Link M7310](./tplink-m7310.md)
   - [Orbic RC400L](./orbic.md)
 - [Support, feedback, and community](./support-feedback-community.md)
   - [Frequently Asked Questions](./faq.md)

--- a/doc/supported-devices.md
+++ b/doc/supported-devices.md
@@ -6,3 +6,4 @@ If you have a device in mind which you'd like Rayhunter to support, please [open
 
 - [Orbic RC400L](./orbic.md)
 - [TP-Link M7350](./tplink-m7350.md)
+- [TP-Link M7310](./tplink-m7310.md)

--- a/doc/tplink-m7310.md
+++ b/doc/tplink-m7310.md
@@ -1,0 +1,6 @@
+# TP-Link M7310
+
+The TP-Link M7310 is **supported by Rayhunter since 0.3.5**. The device
+works similarly to the [M7350](./tplink-m7350.md) and is essentially an older,
+more expensive version of it. Hardware version v1.0 has been successfully
+tested, later versions may work as well.


### PR DESCRIPTION
The device is very similar to the M7350, and might as well just be
another hardware version. The exploit for M7350 v3 works for M7310,
all I had to do is to change the URL slightly. So now the installer
tries both URLs.