### PR TITLE
feat: support Tmobile TMOHS1 hotspot

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -12,6 +12,7 @@ env:
   FILE_ROOTSHELL: ../../rootshell/rootshell
   FILE_RAYHUNTER_DAEMON_ORBIC: ../../rayhunter-daemon-orbic/rayhunter-daemon
   FILE_RAYHUNTER_DAEMON_TPLINK: ../../rayhunter-daemon-tplink/rayhunter-daemon
+  FILE_RAYHUNTER_DAEMON_TMOBILE: ../../rayhunter-daemon-tmobile/rayhunter-daemon
   FILE_RAYHUNTER_DAEMON_WINGTECH: ../../rayhunter-daemon-wingtech/rayhunter-daemon
   RUSTFLAGS: "-Dwarnings"
 
@@ -107,6 +108,7 @@ jobs:
           - name: orbic
           - name: tplink
           - name: wingtech
+          - name: tmobile
     runs-on: ubuntu-latest
     permissions:
       contents: read
@@ -245,6 +247,7 @@ jobs:
           - name: orbic
           - name: tplink
           - name: wingtech
+          - name: tmobile
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4

--- a/daemon/Cargo.toml
+++ b/daemon/Cargo.toml
@@ -6,6 +6,7 @@ edition = "2024"
 [features]
 # These feature flags are mutually exclusive, and exactly one must be enabled.
 orbic = ["rayhunter/orbic"]
+tmobile = ["rayhunter/tmobile"]
 tplink = ["rayhunter/tplink"]
 wingtech = ["rayhunter/wingtech"]
 

--- a/daemon/src/display/mod.rs
+++ b/daemon/src/display/mod.rs
@@ -1,4 +1,10 @@
+#[cfg(any(feature = "orbic", feature = "tplink", feature = "wingtech"))]
 mod generic_framebuffer;
+
+#[cfg(feature = "tmobile")]
+mod tmobile;
+#[cfg(feature = "tmobile")]
+pub use tmobile::update_ui;
 
 #[cfg(feature = "tplink")]
 mod tplink;
@@ -20,6 +26,7 @@ mod wingtech;
 #[cfg(feature = "wingtech")]
 pub use wingtech::update_ui;
 
+#[derive(Clone, Copy, PartialEq)]
 pub enum DisplayState {
     Recording,
     Paused,

--- a/daemon/src/display/tmobile.rs
+++ b/daemon/src/display/tmobile.rs
@@ -1,0 +1,85 @@
+/// Display module for Tmobile TMOHS1, blink LEDs on the front of the device.
+/// DisplayState::Recording => Signal LED slowly blinks blue.
+/// DisplayState::Paused => WiFi LED blinks white.
+/// DisplayState::WarningDetected => Signal LED slowly blinks red.
+use log::{error, info};
+use tokio::sync::mpsc;
+use tokio::sync::oneshot;
+use tokio_util::task::TaskTracker;
+
+use std::fs::write;
+use std::thread::sleep;
+use std::time::Duration;
+
+use crate::config;
+use crate::display::DisplayState;
+
+macro_rules! led {
+    ($l:expr) => {{
+        format!("/sys/class/leds/led:{}/blink", $l)
+    }};
+}
+
+fn start_blinking(path: String) {
+    write(&path, "1").ok();
+}
+
+fn stop_blinking(path: String) {
+    write(&path, "0").ok();
+}
+
+pub fn update_ui(
+    task_tracker: &TaskTracker,
+    config: &config::Config,
+    mut ui_shutdown_rx: oneshot::Receiver<()>,
+    mut ui_update_rx: mpsc::Receiver<DisplayState>,
+) {
+    let mut invisible: bool = false;
+    if config.ui_level == 0 {
+        info!("Invisible mode, not spawning UI.");
+        invisible = true;
+    }
+    task_tracker.spawn_blocking(move || {
+        let mut state = DisplayState::Recording;
+        let mut last_state = DisplayState::Paused;
+
+        loop {
+            match ui_shutdown_rx.try_recv() {
+                Ok(_) => {
+                    info!("received UI shutdown");
+                    break;
+                }
+                Err(oneshot::error::TryRecvError::Empty) => {}
+                Err(e) => panic!("error receiving shutdown message: {e}"),
+            }
+            match ui_update_rx.try_recv() {
+                Ok(new_state) => state = new_state,
+                Err(mpsc::error::TryRecvError::Empty) => {}
+                Err(e) => error!("error receiving ui update message: {e}"),
+            };
+            if invisible || state == last_state {
+                sleep(Duration::from_secs(1));
+                continue;
+            }
+            match state {
+                DisplayState::Paused => {
+                    stop_blinking(led!("signal_blue"));
+                    stop_blinking(led!("signal_red"));
+                    start_blinking(led!("wlan_white"));
+                }
+                DisplayState::Recording => {
+                    stop_blinking(led!("wlan_white"));
+                    stop_blinking(led!("signal_red"));
+                    start_blinking(led!("signal_blue"));
+                }
+                DisplayState::WarningDetected => {
+                    stop_blinking(led!("wlan_white"));
+                    stop_blinking(led!("signal_blue"));
+                    start_blinking(led!("signal_red"));
+                }
+            }
+            last_state = state;
+            sleep(Duration::from_secs(1));
+        }
+    });
+}

--- a/daemon/src/display/tmobile.rs
+++ b/daemon/src/display/tmobile.rs
@@ -15,9 +15,7 @@ use crate::config;
 use crate::display::DisplayState;
 
 macro_rules! led {
-    ($l:expr) => {{
-        format!("/sys/class/leds/led:{}/blink", $l)
-    }};
+    ($l:expr) => {{ format!("/sys/class/leds/led:{}/blink", $l) }};
 }
 
 fn start_blinking(path: String) {

--- a/doc/SUMMARY.md
+++ b/doc/SUMMARY.md
@@ -15,6 +15,7 @@
   - [Orbic RC400L](./orbic.md)
   - [TP-Link M7350](./tplink-m7350.md)
   - [TP-Link M7310](./tplink-m7310.md)
+  - [Tmobile TMOHS1](./tmobile-tmohs1.md)
   - [Wingtech CT2MHS01](./wingtech-ct2mhs01.md)
 - [Support, feedback, and community](./support-feedback-community.md)
   - [Frequently Asked Questions](./faq.md)

--- a/doc/supported-devices.md
+++ b/doc/supported-devices.md
@@ -21,6 +21,7 @@ Rayhunter is confirmed to work on these devices.
 | Device | Recommended region |
 | ------ | ------ |
 | [Wingtech CT2MHS01](./wingtech-ct2mhs01.md) | Americas |
+| [Tmobile TMOHS1](./tmobile-tmohs1.md) | Americas |
 | [TP-Link M7310](./tplink-m7310.md) | Africa, Europe, Middle East |
 
 ## Adding new devices

--- a/doc/tmobile-tmohs1.md
+++ b/doc/tmobile-tmohs1.md
@@ -34,10 +34,15 @@ According to FCC ID 2APXW-TMOHS1 Test Report No. I20Z61602-WMD02 ([part 1](https
 |   71 | 600 MHz (USDD)   |
 
 ## Installing
-Connect to the TMOHS1's network over wifi or usb tethering, then run the installer:
+Connect to the TMOHS1's network over wifi or usb tethering.
+
+The device will not accept web requests until after the default password is changed.
+If you have not previously logged in, log in using the default password printed under the battery and change the admin password.
+
+Then run the installer:
 
 ```sh
-./installer tmobile --admin-password 12345678  # replace with your own password
+./installer tmobile --admin-password Admin0123! # replace with your own password
 ```
 
 ## LED modes
@@ -53,11 +58,11 @@ Even when rayhunter is running, for security reasons the TMOHS1 will not have te
 Use either command below to enable telnet or adb access:
 
 ```sh
-./installer util tmobile-start-telnet --admin-password 12345678
+./installer util tmobile-start-telnet --admin-password Admin0123!
 telnet 192.168.0.1
 ```
 
 ```sh
-./installer util tmobile-start-adb --admin-password 12345678
+./installer util tmobile-start-adb --admin-password Admin0123!
 adb shell
 ```

--- a/doc/tmobile-tmohs1.md
+++ b/doc/tmobile-tmohs1.md
@@ -20,12 +20,15 @@ Please consider sharing the contents of your device's /etc/wt_version file here.
 
 ## Supported bands
 
-The TMOHS1 is primarily an ITU Region 2 device, although Band 41 (BRS) may be suitable for roaming in region 3.
+The TMOHS1 is primarily an ITU Region 2 device, although Bands 5 (CLR) and 41 (BRS) may be suitable for roaming in Region 3.
 
 According to FCC ID 2APXW-TMOHS1 Test Report No. I20Z61602-WMD02 ([part 1](https://fcc.report/FCC-ID/2APXW-TMOHS1/4987033.pdf), [part 2](https://fcc.report/FCC-ID/2APXW-TMOHS1/4987034.pdf)), the TMOHS1 supports the following LTE bands:
 
 | Band | Frequency        |
 | ---- | ---------------- |
+|    2 | 1900 MHz (PCS)   |
+|    4 | 1700 MHz (AWS-1) |
+|    5 | 850 MHz (CLR)    |
 |   12 | 700 MHz (LSMH)   |
 |   25 | 1900 MHz (E-PCS) |
 |   26 | 850 MHz (E-CLR)  |

--- a/doc/tmobile-tmohs1.md
+++ b/doc/tmobile-tmohs1.md
@@ -1,0 +1,63 @@
+# Tmobile TMOHS1
+
+The Tmobile TMOHS1 hotspot is a Qualcomm mdm9607-based device with many similarities to the Wingtech CT2MHS01 hotspot. The TMOHS1 has no screen, only 5 LEDs, two of which are RGB.
+
+## Hardware
+Cheap used versions of the device can be found easily on Ebay, and also from these sellers:
+- https://www.amazon.com/T-Mobile-TMOHS1-Portable-Hotspot-Connect/dp/B0CD9MX232
+- https://www.walmart.com/ip/T-Mobile-TMOHS1-Portable-Internet-4G-LTE-WIFI-Hotspot/3453542421
+- https://www.metrobyt-mobile.com/hotspot-iot-connected-devices/t-mobile-hotspot
+
+Rayhunter has been tested on:
+
+```sh
+WT_INNER_VERSION=SW_Q89527AA1_V045_M11_TMO_USR_MP
+WT_PRODUCTION_VERSION=TMOHS1_00.05.20
+WT_HARDWARE_VERSION=89527_1_11
+```
+
+Please consider sharing the contents of your device's /etc/wt_version file here.
+
+## Supported bands
+
+The TMOHS1 is primarily an ITU Region 2 device, although Band 41 (BRS) may be suitable for roaming in region 3.
+
+According to FCC ID 2APXW-TMOHS1 Test Report No. I20Z61602-WMD02 ([part 1](https://fcc.report/FCC-ID/2APXW-TMOHS1/4987033.pdf), [part 2](https://fcc.report/FCC-ID/2APXW-TMOHS1/4987034.pdf)), the TMOHS1 supports the following LTE bands:
+
+| Band | Frequency        |
+| ---- | ---------------- |
+|   12 | 700 MHz (LSMH)   |
+|   25 | 1900 MHz (E-PCS) |
+|   26 | 850 MHz (E-CLR)  |
+|   41 | 2500 MHz (BRS)   |
+|   66 | 1700 MHz (E-AWS) |
+|   71 | 600 MHz (USDD)   |
+
+## Installing
+Connect to the TMOHS1's network over wifi or usb tethering, then run the installer:
+
+```sh
+./installer tmobile --admin-password 12345678  # replace with your own password
+```
+
+## LED modes
+| Rayhunter state  | LED indicator                  |
+| ---------------- | ------------------------------ |
+| Recording        | Signal LED slowly blinks blue. |
+| Paused           | WiFi LED blinks white.         |
+| Warning Detected | Signal LED slowly blinks red.  |
+
+## Obtaining a shell
+Even when rayhunter is running, for security reasons the TMOHS1 will not have telnet or adb enabled during normal operation.
+
+Use either command below to enable telnet or adb access:
+
+```sh
+./installer util tmobile-start-telnet --admin-password 12345678
+telnet 192.168.0.1
+```
+
+```sh
+./installer util tmobile-start-adb --admin-password 12345678
+adb shell
+```

--- a/installer/build.rs
+++ b/installer/build.rs
@@ -16,6 +16,11 @@ fn main() {
     );
     set_binary_var(
         include_dir,
+        "FILE_RAYHUNTER_DAEMON_TMOBILE",
+        "rayhunter-daemon",
+    );
+    set_binary_var(
+        include_dir,
         "FILE_RAYHUNTER_DAEMON_TPLINK",
         "rayhunter-daemon",
     );

--- a/installer/src/main.rs
+++ b/installer/src/main.rs
@@ -182,8 +182,8 @@ async fn run() -> Result<(), Error> {
                 }
             }
             UtilSubCommand::Shell(_) => orbic::shell().await.context("\nFailed to open shell on Orbic RC400L")?,
-            UtilSubCommand::TmobileStartTelnet(args) => tmobile::start_telnet(&args.admin_ip, &args.admin_password).await.context("\nFailed to start telnet on the Tmobile TMOHS1")?,
-            UtilSubCommand::TmobileStartAdb(args) => tmobile::start_adb(&args.admin_ip, &args.admin_password).await.context("\nFailed to start adb on the Tmobile TMOHS1")?,
+            UtilSubCommand::TmobileStartTelnet(args) => wingtech::start_telnet(&args.admin_ip, &args.admin_password).await.context("\nFailed to start telnet on the Tmobile TMOHS1")?,
+            UtilSubCommand::TmobileStartAdb(args) => wingtech::start_adb(&args.admin_ip, &args.admin_password).await.context("\nFailed to start adb on the Tmobile TMOHS1")?,
             UtilSubCommand::TplinkStartTelnet(options) => {
                 tplink::start_telnet(&options.admin_ip).await?;
             }

--- a/installer/src/tmobile.rs
+++ b/installer/src/tmobile.rs
@@ -1,0 +1,187 @@
+/// Installer for the TMobile TMOHS1 hotspot.
+///
+/// Tested on (from `/etc/wt_version`):
+///   WT_INNER_VERSION=SW_Q89527AA1_V045_M11_TMO_USR_MP
+///   WT_PRODUCTION_VERSION=TMOHS1_00.05.20
+///   WT_HARDWARE_VERSION=89527_1_11
+use std::io::Write;
+use std::net::SocketAddr;
+use std::str::FromStr;
+use std::time::Duration;
+
+use aes::Aes128;
+use aes::cipher::{BlockEncrypt, KeyInit, generic_array::GenericArray};
+use anyhow::{Result, bail};
+use base64_light::base64_encode_bytes;
+use block_padding::{Padding, Pkcs7};
+use reqwest::Client;
+use tokio::time::sleep;
+
+use crate::TmobileArgs as Args;
+use crate::util::{echo, telnet_send_command, telnet_send_file};
+
+pub async fn install(
+    Args {
+        admin_ip,
+        admin_password,
+    }: Args,
+) -> Result<()> {
+    run_install(admin_ip, admin_password).await
+}
+
+const KEY: &[u8] = b"abcdefghijklmn12";
+
+/// Returns password encrypted in AES128 ECB mode with the key b"abcdefghijklmn12",
+/// with Pkcs7 padding, encoded in base64.
+fn encrypt_password(password: &[u8]) -> Result<String> {
+    let c = Aes128::new_from_slice(KEY)?;
+    let mut b = GenericArray::from([0u8; 16]);
+    b[..password.len()].copy_from_slice(password);
+    Pkcs7::pad(&mut b, password.len());
+    c.encrypt_block(&mut b);
+    Ok(base64_encode_bytes(&b))
+}
+
+pub async fn start_telnet(admin_ip: &str, admin_password: &str) -> Result<()> {
+    run_command(admin_ip, admin_password, "busybox telnetd -l /bin/sh").await
+}
+
+pub async fn start_adb(admin_ip: &str, admin_password: &str) -> Result<()> {
+    run_command(admin_ip, admin_password, "/sbin/usb/compositions/9025").await
+}
+
+async fn run_command(admin_ip: &str, admin_password: &str, cmd: &str) -> Result<()> {
+    let qcmap_auth_endpoint = format!("http://{admin_ip}/cgi-bin/qcmap_auth");
+    let qcmap_web_cgi_endpoint = format!("http://{admin_ip}/cgi-bin/qcmap_web_cgi");
+
+    let encrypted_pw = encrypt_password(admin_password.as_bytes()).ok().unwrap();
+
+    let client = Client::new();
+    let login = client
+        .post(&qcmap_auth_endpoint)
+        .body(format!(
+            "type=login&pwd={encrypted_pw}&timeout=60000&user=admin"
+        ))
+        .send()
+        .await?
+        .text()
+        .await?;
+    let token = match login.find("token") {
+        Some(n) => &login[n + 8..n + 8 + 16],
+        None => bail!("login did not return a token in response: {}", login),
+    };
+
+    let telnet = client.post(&qcmap_web_cgi_endpoint)
+        .body(format!("page=setFWMacFilter&cmd=add&mode=0&mac=50:5A:CA:B5:05||{cmd}&key=50:5A:CA:B5:05:AC&token={token}"))
+        .send()
+        .await?;
+    if telnet.status() != 200 {
+        bail!(
+            "starting telnet failed with status code: {:?}",
+            telnet.status()
+        );
+    }
+
+    Ok(())
+}
+
+async fn run_install(admin_ip: String, admin_password: String) -> Result<()> {
+    echo!("Starting telnet ... ");
+    start_telnet(&admin_ip, &admin_password).await?;
+    println!("ok");
+
+    echo!("Connecting via telnet to {admin_ip} ... ");
+    let addr = SocketAddr::from_str(&format!("{admin_ip}:23")).unwrap();
+    telnet_send_command(addr, "mkdir -p /data/rayhunter", "exit code 0").await?;
+    println!("ok");
+
+    telnet_send_command(addr, "mount -o remount,rw /", "exit code 0").await?;
+
+    telnet_send_file(
+        addr,
+        "/data/rayhunter/config.toml",
+        crate::CONFIG_TOML.as_bytes(),
+    )
+    .await?;
+
+    let rayhunter_daemon_bin = include_bytes!(env!("FILE_RAYHUNTER_DAEMON_TMOBILE"));
+    telnet_send_file(
+        addr,
+        "/data/rayhunter/rayhunter-daemon",
+        rayhunter_daemon_bin,
+    )
+    .await?;
+    telnet_send_command(
+        addr,
+        "chmod 755 /data/rayhunter/rayhunter-daemon",
+        "exit code 0",
+    )
+    .await?;
+    telnet_send_file(
+        addr,
+        "/etc/init.d/misc-daemon",
+        include_bytes!("../../dist/scripts/misc-daemon"),
+    )
+    .await?;
+    telnet_send_command(addr, "chmod 755 /etc/init.d/misc-daemon", "exit code 0").await?;
+    telnet_send_file(
+        addr,
+        "/etc/init.d/rayhunter_daemon",
+        crate::RAYHUNTER_DAEMON_INIT.as_bytes(),
+    )
+    .await?;
+    telnet_send_command(
+        addr,
+        "chmod 755 /etc/init.d/rayhunter_daemon",
+        "exit code 0",
+    )
+    .await?;
+
+    println!("Rebooting device and waiting 30 seconds for it to start up.");
+    telnet_send_command(addr, "reboot", "exit code 0").await?;
+    sleep(Duration::from_secs(30)).await;
+
+    echo!("Testing rayhunter ... ");
+    let max_failures = 10;
+    http_ok_every(
+        format!("http://{admin_ip}:8080/index.html"),
+        Duration::from_secs(3),
+        max_failures,
+    )
+    .await?;
+    println!("ok");
+    println!("rayhunter is running at http://{admin_ip}:8080");
+
+    Ok(())
+}
+
+async fn http_ok_every(rayhunter_url: String, interval: Duration, max_failures: u32) -> Result<()> {
+    let client = Client::new();
+    let mut failures = 0;
+    loop {
+        match client.get(&rayhunter_url).send().await {
+            Ok(test) => match test.status().is_success() {
+                true => break,
+                false => bail!(
+                    "request for url ({rayhunter_url}) failed with status code: {:?}",
+                    test.status()
+                ),
+            },
+            Err(e) => match failures > max_failures {
+                true => return Err(e.into()),
+                false => failures += 1,
+            },
+        }
+        sleep(interval).await;
+    }
+
+    Ok(())
+}
+
+#[test]
+fn test_encrypt_password() {
+    let p = b"80536913";
+    let s = encrypt_password(p).ok();
+    let expected = Some("5brvd8xl732cSoFTAy67ig==".to_string());
+    assert_eq!(s, expected);
+}

--- a/installer/src/tmobile.rs
+++ b/installer/src/tmobile.rs
@@ -28,6 +28,7 @@ pub async fn install(
 async fn run_install(admin_ip: String, admin_password: String) -> Result<()> {
     echo!("Starting telnet ... ");
     start_telnet(&admin_ip, &admin_password).await?;
+    sleep(Duration::from_millis(200)).await;
     println!("ok");
 
     echo!("Connecting via telnet to {admin_ip} ... ");

--- a/installer/src/util.rs
+++ b/installer/src/util.rs
@@ -107,7 +107,11 @@ pub async fn send_file(admin_ip: &str, local_path: &str, remote_path: &str) -> R
     Ok(())
 }
 
-pub async fn http_ok_every(rayhunter_url: String, interval: Duration, max_failures: u32) -> Result<()> {
+pub async fn http_ok_every(
+    rayhunter_url: String,
+    interval: Duration,
+    max_failures: u32,
+) -> Result<()> {
     let client = Client::new();
     let mut failures = 0;
     loop {

--- a/lib/Cargo.toml
+++ b/lib/Cargo.toml
@@ -12,6 +12,7 @@ path = "src/lib.rs"
 [features]
 default = []
 orbic = []
+tmobile = []
 tplink = []
 wingtech = []
 


### PR DESCRIPTION
Add support for the Tmobile TMOHS1, a Wingtech CT2MHS01-based hotspot with a Qualcomm mdm9607. The TMOHS1 has no screen, only 5 LEDs, two of which are RGB.

This pull request is a draft until https://github.com/EFForg/rayhunter/pull/387 is merged, because it uses common installer code and makes modifications to some of the same files (like `display/src/mod.rs`).

I will refactor out some of the other commonalities in the installer between this and the Wingtech before merging.