### PR TITLE
Fix last_message_time showing as 1970 when capture is 0 bytes

### DIFF
--- a/bin/web/src/lib/components/ManifestCard.svelte
+++ b/bin/web/src/lib/components/ManifestCard.svelte
@@ -54,7 +54,7 @@
     </div>
     <div class="flex flex-col">
         <span class="">Start: {date_formatter.format(entry.start_time)}</span>
-        <span class="">Last Message: {date_formatter.format(entry.last_message_time)}</span>
+        <span class="">Last Message: {entry.last_message_time && date_formatter.format(entry.last_message_time) || "N/A"}</span>
     </div>
     <div class="flex flex-row justify-between lg:justify-end gap-2 mt-2">
         <DownloadLink url={entry.get_pcap_url()} text="pcap" full_button=true />

--- a/bin/web/src/lib/components/ManifestTableRow.svelte
+++ b/bin/web/src/lib/components/ManifestTableRow.svelte
@@ -32,7 +32,7 @@
 <tr class="{status_row_color} drop-shadow">
     <td class="p-2">{entry.name}</td>
     <td class="p-2">{date_formatter.format(entry.start_time)}</td>
-    <td class="p-2">{date_formatter.format(entry.last_message_time)}</td>
+    <td class="p-2">{entry.last_message_time && date_formatter.format(entry.last_message_time) || "N/A"}</td>
     <td class="p-2">{entry.get_readable_qmdl_size()}</td>
     <td class="p-2"><DownloadLink url={entry.get_pcap_url()} text="pcap" /></td>
     <td class="p-2"><DownloadLink url={entry.get_qmdl_url()} text="qmdl" /></td>

--- a/bin/web/src/lib/manifest.svelte.ts
+++ b/bin/web/src/lib/manifest.svelte.ts
@@ -64,7 +64,7 @@ export class ManifestEntry {
         this.qmdl_size_bytes = json.qmdl_size_bytes;
         this.analysis_size_bytes = json.analysis_size_bytes;
         this.start_time = new Date(json.start_time);
-        if (json.last_message_time !== undefined) {
+        if (json.last_message_time) {
             this.last_message_time = new Date(json.last_message_time);
         }
     }


### PR DESCRIPTION
This is the same bug as #224, but regressed in the new UI
