### PR TITLE
Update documentation and fix broken links

### DIFF
--- a/book.toml
+++ b/book.toml
@@ -3,3 +3,6 @@ authors = ["The Rayhunter Team"]
 language = "en"
 src = "doc"
 title = "Rayhunter - An IMSI Catcher Catcher"
+
+[output.html]
+edit-url-template = "https://github.com/efforg/rayhunter/edit/main/{path}"

--- a/doc/SUMMARY.md
+++ b/doc/SUMMARY.md
@@ -6,6 +6,7 @@
     - [Installing from the latest release (Windows)](./installing-from-release-windows.md)
   - [Installing from source](./installing-from-source.md)
   - [Updating Rayhunter](./updating-rayhunter.md)
+- [Configuration](./configuration.md)
 - [Uninstalling](./uninstalling.md)
 - [Using Rayhunter](./using-rayhunter.md)
   - [Rayhunter's heuristics](./heuristics.md)

--- a/doc/configuration.md
+++ b/doc/configuration.md
@@ -1,0 +1,5 @@
+# Configuration
+
+Rayhunter can be configured by editing `/data/rayhunter/config.toml` on the device. You can obtain a shell on [orbic](./orbic.md#obtaining-a-shell) and [tplink](./tplink-m7350.md#obtaining-a-shell) and edit the file manually. In future versions the web UI will allow you to edit the config as well.
+
+View the [default configuration file on GitHub](https://github.com/EFForg/rayhunter/blob/main/dist/config.toml.example).

--- a/doc/heuristics.md
+++ b/doc/heuristics.md
@@ -1,6 +1,6 @@
 # Heuristics
 
-Rayhunter includes several analyzers to detect potential IMSI catcher activity. These can be enabled and disabled in your [config.toml](https://github.com/EFForg/rayhunter/blob/main/dist/config.toml.example) file.
+Rayhunter includes several analyzers to detect potential IMSI catcher activity. These can be enabled and disabled in your [config.toml](./configuration.md) file.
 
 ## Available Analyzers
 

--- a/doc/installing-from-release-windows.md
+++ b/doc/installing-from-release-windows.md
@@ -29,4 +29,4 @@ Windows support in Rayhunter's installer is a work-in-progress. Depending on the
 5. Run the install script: `.\installer.exe orbic` and hit enter.
     - The device will restart multiple times over the next few minutes.
     - You will know it is done when you see terminal output that says `checking for rayhunter server...success!`
-6. Rayhunter should now be running! You can verify this by following the instructions below to [view the web UI](#usage-viewing-the-web-ui). You should also see a green line flash along the top of top the display on the device.
+6. Rayhunter should now be running! You can verify this by following the instructions below to [view the web UI](./using-rayhunter.md#the-web-ui). You should also see a green line flash along the top of top the display on the device.

--- a/doc/installing-from-release.md
+++ b/doc/installing-from-release.md
@@ -12,8 +12,8 @@ Make sure you've got one of Rayhunter's [supported devices](./supported-devices.
 
 3. Turn on your device by holding the power button on the front.
 
-  * For the Orbic, connect the device using a USB-C cable.
-  * For TP-Link, connect to its network using either WiFi or USB Tethering.
+   * For the Orbic, connect the device using a USB-C cable.
+   * For TP-Link, connect to its network using either WiFi or USB Tethering.
 
 4. Run the install script for your operating system:
 
@@ -38,7 +38,7 @@ Make sure you've got one of Rayhunter's [supported devices](./supported-devices.
 
     You will know it is done when you see terminal output that says `Testing Rayhunter... done`
 
-5. Rayhunter should now be running! You can verify this by [viewing Rayhunter's web UI](./using-rayhunter). You should also see a green line flash along the top of top the display on the device.
+5. Rayhunter should now be running! You can verify this by [viewing Rayhunter's web UI](./using-rayhunter.md). You should also see a green line flash along the top of top the display on the device.
 
 ## Troubleshooting
 

--- a/doc/introduction.md
+++ b/doc/introduction.md
@@ -1,6 +1,6 @@
-![Rayhunter Logo - An Orca taking a bite out of a cellular signal bar](https://www.eff.org/files/styles/media_browser_preview/public/banner_library/rayhunter-banner.png)
-
 # Rayhunter
+
+<img style="display: block; margin: 0 auto" alt="Rayhunter Logo - An Orca taking a bite out of a cellular signal bar" src="https://www.eff.org/files/styles/media_browser_preview/public/banner_library/rayhunter-banner.png" />
 
 Rayhunter is a project for detecting IMSI catchers, also known as cell-site simulators or stingrays. It's designed to run on a cheap mobile hotspot called the Orbic RC400L, but thanks to community efforts can [support some other devices as well](./supported-devices.md).
 

--- a/doc/orbic.md
+++ b/doc/orbic.md
@@ -18,3 +18,9 @@ or on [eBay](https://www.ebay.com/sch/i.html?_nkw=orbic+rc400l).
 | Wifi 2.4Ghz | b/g/n |
 | Wifi 5Ghz | a/ac/ax |
 | Wifi 6 | 🮱 |
+
+## Obtaining a shell
+
+After running through the installation procedure, you can obtain a root shell
+by running `adb shell` or `./installer util shell`. Then, inside of that shell
+you can run `/bin/rootshell` to obtain "fakeroot."

--- a/doc/tplink-m7350.md
+++ b/doc/tplink-m7350.md
@@ -1,14 +1,14 @@
 # TP-Link M7350
 
-The TP-Link M7350 is supported by Rayhunter from 0.3.0 release. TP-Link M7350 supports many more frequency bands than Orbic and therefore works in Europe and also in some Asian and African countries.
+The TP-Link M7350 is **supported by Rayhunter since 0.3.0**. TP-Link M7350 supports many more frequency bands than Orbic and therefore works in Europe and also in some Asian and African countries.
 
 ## Hardware versions
 
 The TP-Link comes in many different *hardware versions*. Support for installation varies:
 
-* `1.0`, `2.0`: **Not suported**, probably impossible to obtain anymore (even second-hand), however there is one report that installation is possible on `1.0` (but no reports if it is working or not)
+* `1.0`, `2.0`: **Not supported**, devs are not able to obtain a device
 * `3.0`, `3.2`, `5.0`, `5.2`, `7.0`, `8.0`: **Tested, no known issues since 0.3.0.**
-* `6.2`: **One user reported it is working**
+* `6.2`: **One user reported it is working, not tested**
 * `4.0`: **Manual firmware downgrade required** ([issue](https://github.com/EFForg/rayhunter/issues/332))
 * `9.0`: **Working since 0.3.2.**
 
@@ -20,13 +20,15 @@ When filing bug reports, particularly with the installer, please always specify 
 
 You can get your TP-Link M7350 from:
 
-* First check for used offers on Ebay or equivalent, sometimes it's much cheaper there.
+* First check for used offers on local sites, sometimes it's much cheaper there.
 * [Geizhals price comparison](https://geizhals.eu/?fs=tp-link+m7350)
 * [Ebay](https://www.ebay.com/sch/i.html?_nkw=tp-link+m7350&_sacat=0&_from=R40&_trksid=p4432023.m570.l1313)
 
 ## Installation & Usage
 
 Follow the [release installation guide](./installing-from-release.md). Substitute `./installer orbic` for `./installer tplink` in other documentation. The Rayhunter UI will be available at [http://192.168.0.1:8080](http://192.168.0.1:8080).
+
+## Obtaining a shell
 
 Unlike on Orbic, the installer will not enable ADB. Instead, you can obtain a root shell with the following command:
 
@@ -44,18 +46,6 @@ If your device has a one-bit (black-and-white) display, Rayhunter will instead s
 * `!` means "warning (potential IMSI catcher)"
 * `:)` (smiling) means "recording"
 * `:` (face with no mouth) means "paused"
-
-## Configuration
-
-Displaying status can be changed in the configuration (`config.toml`) file, where UI level (`ui_level` variable) could be changed to:
-- `0`: invisible mode, no indicator that Rayhunter is running
-- `1`: subtle mode, display a green line at the top of the screen when Rayhunter is running
-- `2`: demo mode, display a fun Orca GIF
-- `3`: display the EFF logo
-
-You can also change `colorblind_mode` (default is `false`) to `true`. In that case there will be blue line instead of green line.
-
-You can change the `port` (default is `8080`) where Rayhunter is listening for incoming connections and more advanced users can change the variables `qmdl_store_path` and `debug_mode`. However, change those variables only if you know what you are doing.
 
 ## Power-saving mode/sleep
 

--- a/doc/using-rayhunter.md
+++ b/doc/using-rayhunter.md
@@ -1,6 +1,6 @@
 # Using Rayhunter
 
-Once installed, Rayhunter will run automatically whenever your device is running. You'll see a green line on top of the device's display to indicate that it's running and recording. [The line will turn red](#red) once a potential IMSI catcher has been found, until the device is rebooted or a new recording is started through the web UI.
+Once installed, Rayhunter will run automatically whenever your device is running. You'll see a green line on top of the device's display to indicate that it's running and recording. [The line will turn red](./faq.md#red) once a potential IMSI catcher has been found, until the device is rebooted or a new recording is started through the web UI.
 
 ![Rayhunter_0 3 2](./Rayhunter_0.3.2.png)
 
@@ -29,3 +29,5 @@ You can access this UI in one of two ways:
 ## Key shortcuts
 
 As of 0.3.3, you can start a new recording by double-tapping the power button. Any current recording will be stopped and a new recording will be started, resetting the red line as well.
+
+**This feature is disabled by default since 0.4.0** and needs to be enabled through [configuration](./configuration.md).


### PR DESCRIPTION
* Add a new configuration page and move content out from TP-Link. The
  Configuration section in TP-Link is duplicating what is already in
  config.toml.example, and given that we have recently added a lot of
  new options I don't want to maintain multiple copies.

* Lots of anchor links were broken since we moved docs from README into
  mdbook. Fix them all ~and shamelessly plug my own GitHub action to
  prevent that from happening again (mdbook does not seem to have
  anything builtin)~

* Document that the key input feature is disabled since 0.4.0.

* Smaller cosmetic changes:

  * Make TP-Link M7350 page consistent with TP-Link M7310 page.
  * Fix indentation on some bullet points.
  * Center-align the rayhunter logo in introduction.md to calm my soul.
    It is still misaligned with the page title above itself.
  * Add "edit on github" link in mdbook settings.
