### PR TITLE
Bump hampi to 0.7.1

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -168,8 +168,9 @@ checksum = "7c02d123df017efcdfbd739ef81735b36c5ba83ec3c59c80a9d7ecc718f92e50"
 
 [[package]]
 name = "asn1-codecs"
-version = "0.7.0"
-source = "git+https://github.com/ystero-dev/hampi?rev=67f3283764eda20022d190c3d3d6edd1a88047e0#67f3283764eda20022d190c3d3d6edd1a88047e0"
+version = "0.7.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3eb148e3886345ed6c20c984393359bfda8220c82114ac5d12fcd54c0f393e91"
 dependencies = [
  "bitvec",
  "log",
@@ -179,8 +180,9 @@ dependencies = [
 
 [[package]]
 name = "asn1-compiler"
-version = "0.7.0"
-source = "git+https://github.com/ystero-dev/hampi?rev=67f3283764eda20022d190c3d3d6edd1a88047e0#67f3283764eda20022d190c3d3d6edd1a88047e0"
+version = "0.7.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7a0ab1fb91f80ed8e751a8cb3d38dc822031dbfb769731e9d4a8bc184a39a230"
 dependencies = [
  "anyhow",
  "bitvec",
@@ -197,8 +199,9 @@ dependencies = [
 
 [[package]]
 name = "asn1_codecs_derive"
-version = "0.7.0"
-source = "git+https://github.com/ystero-dev/hampi?rev=67f3283764eda20022d190c3d3d6edd1a88047e0#67f3283764eda20022d190c3d3d6edd1a88047e0"
+version = "0.7.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "129a9f02b40e743766102dbbb93464b5868fb5e264a02a10d87fb45c472dd4b7"
 dependencies = [
  "asn1-codecs",
  "bitvec",

--- a/telcom-parser/Cargo.toml
+++ b/telcom-parser/Cargo.toml
@@ -6,10 +6,9 @@ edition = "2021"
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 
 [dependencies]
-# FIXME: When this branch is merged into main point this at the release version of hampi again
-asn1-compiler = { git = "https://github.com/ystero-dev/hampi", rev = "67f3283764eda20022d190c3d3d6edd1a88047e0" }
-asn1-codecs = { git = "https://github.com/ystero-dev/hampi", rev = "67f3283764eda20022d190c3d3d6edd1a88047e0" }
-asn1_codecs_derive = { git = "https://github.com/ystero-dev/hampi", rev = "67f3283764eda20022d190c3d3d6edd1a88047e0" }
+asn1-compiler = "0.7.1"
+asn1-codecs = "0.7.1"
+asn1_codecs_derive = "0.7.1"
 bitvec = { version = "1.0", features = ["serde"] }
 log = "0.4"
 thiserror = "1.0.56"


### PR DESCRIPTION
It's not clear for how long this revision will exist upstream now that
the PR is (squash) merged
