### PR TITLE
Re-enable clippy build failures and clean up complaints

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -13,6 +13,7 @@ env:
   FILE_RAYHUNTER_DAEMON_ORBIC: ../../rayhunter-daemon-orbic/rayhunter-daemon
   FILE_RAYHUNTER_DAEMON_TPLINK: ../../rayhunter-daemon-tplink/rayhunter-daemon
   FILE_RAYHUNTER_DAEMON_WINGTECH: ../../rayhunter-daemon-wingtech/rayhunter-daemon
+  RUSTFLAGS: "-Dwarnings"
 
 jobs:
   files_changed:

--- a/bin/src/check.rs
+++ b/bin/src/check.rs
@@ -84,14 +84,13 @@ async fn analyze_file(enable_dummy_analyzer: bool, qmdl_path: &str, show_skipped
         }
     }
     if show_skipped && skipped > 0 {
-        info!("{}: messages skipped:", qmdl_path);
+        info!("{qmdl_path}: messages skipped:");
         for (reason, count) in skipped_reasons.iter() {
-            info!("    - {}: \"{}\"", count, reason);
+            info!("    - {count}: \"{reason}\"");
         }
     }
     info!(
-        "{}: {} messages analyzed, {} warnings, {} messages skipped",
-        qmdl_path, total_messages, warnings, skipped
+        "{qmdl_path}: {total_messages} messages analyzed, {warnings} warnings, {skipped} messages skipped"
     );
 }
 

--- a/bin/src/daemon.rs
+++ b/bin/src/daemon.rs
@@ -122,6 +122,7 @@ async fn init_qmdl_store(config: &config::Config) -> Result<RecordingStore, Rayh
 // Start a thread that'll track when user hits ctrl+c. When that happens,
 // trigger various cleanup tasks, including sending signals to other threads to
 // shutdown
+#[allow(clippy::too_many_arguments)]
 fn run_shutdown_thread(
     task_tracker: &TaskTracker,
     diag_device_sender: Sender<DiagDeviceCtrlMessage>,

--- a/bin/src/daemon.rs
+++ b/bin/src/daemon.rs
@@ -108,7 +108,7 @@ async fn init_qmdl_store(config: &config::Config) -> Result<RecordingStore, Rayh
         match RecordingStore::load(&config.qmdl_store_path).await {
             Ok(store) => Ok(store),
             Err(RecordingStoreError::ParseManifestError(err)) => {
-                error!("failed to parse QMDL manifest: {}", err);
+                error!("failed to parse QMDL manifest: {err}");
                 info!("creating new empty manifest...");
                 Ok(RecordingStore::create(&config.qmdl_store_path).await?)
             }
@@ -139,14 +139,14 @@ fn run_shutdown_thread(
         select! {
             res = tokio::signal::ctrl_c() => {
                 if let Err(err) = res {
-                    error!("Unable to listen for shutdown signal: {}", err);
+                    error!("Unable to listen for shutdown signal: {err}");
                 }
 
                 should_restart_flag.store(false, Ordering::Relaxed);
             }
             res = daemon_restart_rx => {
                 if let Err(err) = res {
-                    error!("Unable to listen for shutdown signal: {}", err);
+                    error!("Unable to listen for shutdown signal: {err}");
                 }
 
                 should_restart_flag.store(true, Ordering::Relaxed);

--- a/bin/src/diag.rs
+++ b/bin/src/diag.rs
@@ -54,7 +54,7 @@ pub fn run_diag_read_thread(
                             let (qmdl_file, new_analysis_file) = match qmdl_store.new_entry().await {
                                 Ok(x) => x,
                                 Err(e) => {
-                                    error!("couldn't create new qmdl entry: {}", e);
+                                    error!("couldn't create new qmdl entry: {e}");
                                     continue;
                                 }
                             };
@@ -69,7 +69,7 @@ pub fn run_diag_read_thread(
                                 .expect("failed to write to analysis file"));
 
                             if let Err(e) = ui_update_sender.send(display::DisplayState::Recording).await {
-                                warn!("couldn't send ui update message: {}", e);
+                                warn!("couldn't send ui update message: {e}");
                             }
                         },
                         Some(DiagDeviceCtrlMessage::StopRecording) => {
@@ -80,11 +80,11 @@ pub fn run_diag_read_thread(
                                             entry.name.to_string(),
                                     ))
                                     .await {
-                                        warn!("couldn't send analysis message: {}", e);
+                                        warn!("couldn't send analysis message: {e}");
                                     }
                             }
                             if let Err(e) = qmdl_store.close_current_entry().await {
-                                error!("couldn't close current entry: {}", e);
+                                error!("couldn't close current entry: {e}");
                             }
 
                             maybe_qmdl_writer = None;
@@ -94,7 +94,7 @@ pub fn run_diag_read_thread(
                             maybe_analysis_writer = None;
 
                             if let Err(e) = ui_update_sender.send(display::DisplayState::Paused).await {
-                                warn!("couldn't send ui update message: {}", e);
+                                warn!("couldn't send ui update message: {e}");
                             }
                         },
                         // None means all the Senders have been dropped, so it's
@@ -145,7 +145,7 @@ pub fn run_diag_read_thread(
                             }
                         },
                         Err(err) => {
-                            error!("error reading diag device: {}", err);
+                            error!("error reading diag device: {err}");
                             return Err(err);
                         }
                     }
@@ -169,7 +169,7 @@ pub async fn start_recording(
         .map_err(|e| {
             (
                 StatusCode::INTERNAL_SERVER_ERROR,
-                format!("couldn't send start recording message: {}", e),
+                format!("couldn't send start recording message: {e}"),
             )
         })?;
 
@@ -189,7 +189,7 @@ pub async fn stop_recording(
         .map_err(|e| {
             (
                 StatusCode::INTERNAL_SERVER_ERROR,
-                format!("couldn't send stop recording message: {}", e),
+                format!("couldn't send stop recording message: {e}"),
             )
         })?;
     Ok((StatusCode::ACCEPTED, "ok".to_string()))
@@ -225,7 +225,7 @@ pub async fn delete_recording(
         .map_err(|e| {
             (
                 StatusCode::INTERNAL_SERVER_ERROR,
-                format!("couldn't send stop recording message: {}", e),
+                format!("couldn't send stop recording message: {e}"),
             )
         })?;
     state
@@ -235,7 +235,7 @@ pub async fn delete_recording(
         .map_err(|e| {
             (
                 StatusCode::INTERNAL_SERVER_ERROR,
-                format!("couldn't send ui update message: {}", e),
+                format!("couldn't send ui update message: {e}"),
             )
         })?;
     Ok((StatusCode::ACCEPTED, "ok".to_string()))
@@ -254,14 +254,14 @@ pub async fn delete_all_recordings(
         .map_err(|e| {
             (
                 StatusCode::INTERNAL_SERVER_ERROR,
-                format!("couldn't send stop recording message: {}", e),
+                format!("couldn't send stop recording message: {e}"),
             )
         })?;
     let mut qmdl_store = state.qmdl_store_lock.write().await;
     qmdl_store.delete_all_entries().await.map_err(|e| {
         (
             StatusCode::INTERNAL_SERVER_ERROR,
-            format!("couldn't delete all recordings: {}", e),
+            format!("couldn't delete all recordings: {e}"),
         )
     })?;
     state
@@ -271,7 +271,7 @@ pub async fn delete_all_recordings(
         .map_err(|e| {
             (
                 StatusCode::INTERNAL_SERVER_ERROR,
-                format!("couldn't send ui update message: {}", e),
+                format!("couldn't send ui update message: {e}"),
             )
         })?;
     Ok((StatusCode::ACCEPTED, "ok".to_string()))
@@ -290,13 +290,13 @@ pub async fn get_analysis_report(
     } else {
         qmdl_store.entry_for_name(&qmdl_name).ok_or((
             StatusCode::NOT_FOUND,
-            format!("Couldn't find QMDL entry with name \"{}\"", qmdl_name),
+            format!("Couldn't find QMDL entry with name \"{qmdl_name}\""),
         ))?
     };
     let analysis_file = qmdl_store
         .open_entry_analysis(entry_index)
         .await
-        .map_err(|e| (StatusCode::INTERNAL_SERVER_ERROR, format!("{:?}", e)))?;
+        .map_err(|e| (StatusCode::INTERNAL_SERVER_ERROR, format!("{e:?}")))?;
     let analysis_stream = ReaderStream::new(analysis_file);
 
     let headers = [(CONTENT_TYPE, "application/x-ndjson")];

--- a/bin/src/diag.rs
+++ b/bin/src/diag.rs
@@ -29,6 +29,7 @@ pub enum DiagDeviceCtrlMessage {
     Exit,
 }
 
+#[allow(clippy::too_many_arguments)]
 pub fn run_diag_read_thread(
     task_tracker: &TaskTracker,
     mut dev: DiagDevice,

--- a/bin/src/display/tplink_framebuffer.rs
+++ b/bin/src/display/tplink_framebuffer.rs
@@ -68,7 +68,7 @@ impl GenericFramebuffer for Framebuffer {
             );
 
             if res < 0 {
-                panic!("failed to send FBIORECT_DISPLAY ioctl, {}", res);
+                panic!("failed to send FBIORECT_DISPLAY ioctl, {res}");
             }
         }
     }

--- a/bin/src/display/tplink_onebit.rs
+++ b/bin/src/display/tplink_onebit.rs
@@ -148,7 +148,7 @@ pub fn update_ui(
             // we write the status every second because it may have been overwritten through menu
             // navigation.
             if display_level != 0 {
-                if let Err(e) = fs::write(OLED_PATH, &pixels) {
+                if let Err(e) = fs::write(OLED_PATH, pixels) {
                     error!("failed to write to display: {e}");
                 }
             }

--- a/bin/src/key_input.rs
+++ b/bin/src/key_input.rs
@@ -32,7 +32,7 @@ pub fn run_key_input_thread(
         let mut file = match File::open("/dev/input/event0").await {
             Ok(file) => file,
             Err(e) => {
-                error!("Failed to open /dev/input/event0: {}", e);
+                error!("Failed to open /dev/input/event0: {e}");
                 return;
             }
         };
@@ -49,7 +49,7 @@ pub fn run_key_input_thread(
                 }
                 result = file.read_exact(&mut buffer) => {
                     if let Err(e) = result {
-                        error!("failed to read key input: {}", e);
+                        error!("failed to read key input: {e}");
                         return;
                     }
                 }
@@ -79,12 +79,12 @@ pub fn run_key_input_thread(
                         {
                             if let Err(e) = diag_tx.send(DiagDeviceCtrlMessage::StopRecording).await
                             {
-                                error!("Failed to send StopRecording: {}", e);
+                                error!("Failed to send StopRecording: {e}");
                             }
                             if let Err(e) =
                                 diag_tx.send(DiagDeviceCtrlMessage::StartRecording).await
                             {
-                                error!("Failed to send StartRecording: {}", e);
+                                error!("Failed to send StartRecording: {e}");
                             }
                             last_keyup = None;
                             continue;

--- a/bin/src/pcap.rs
+++ b/bin/src/pcap.rs
@@ -28,7 +28,7 @@ pub async fn get_pcap(
     }
     let (entry_index, entry) = qmdl_store.entry_for_name(&qmdl_name).ok_or((
         StatusCode::NOT_FOUND,
-        format!("couldn't find manifest entry with name {}", qmdl_name),
+        format!("couldn't find manifest entry with name {qmdl_name}"),
     ))?;
     if entry.qmdl_size_bytes == 0 {
         return Err((
@@ -40,14 +40,14 @@ pub async fn get_pcap(
     let qmdl_file = qmdl_store
         .open_entry_qmdl(entry_index)
         .await
-        .map_err(|e| (StatusCode::INTERNAL_SERVER_ERROR, format!("{:?}", e)))?;
+        .map_err(|e| (StatusCode::INTERNAL_SERVER_ERROR, format!("{e:?}")))?;
     // the QMDL reader should stop at the last successfully written data chunk
     // (entry.size_bytes)
     let (reader, writer) = duplex(1024);
 
     tokio::spawn(async move {
         if let Err(e) = generate_pcap_data(writer, qmdl_file, qmdl_size_bytes).await {
-            error!("failed to generate PCAP: {:?}", e);
+            error!("failed to generate PCAP: {e:?}");
         }
     });
 
@@ -84,7 +84,7 @@ where
                             .await?;
                     }
                 }
-                Err(e) => error!("error parsing message: {:?}", e),
+                Err(e) => error!("error parsing message: {e:?}"),
             }
         }
     }

--- a/bin/src/server.rs
+++ b/bin/src/server.rs
@@ -44,7 +44,7 @@ pub async fn get_qmdl(
     let qmdl_store = state.qmdl_store_lock.read().await;
     let (entry_index, entry) = qmdl_store.entry_for_name(qmdl_idx).ok_or((
         StatusCode::NOT_FOUND,
-        format!("couldn't find qmdl file with name {}", qmdl_idx),
+        format!("couldn't find qmdl file with name {qmdl_idx}"),
     ))?;
     let qmdl_file = qmdl_store
         .open_entry_qmdl(entry_index)
@@ -52,7 +52,7 @@ pub async fn get_qmdl(
         .map_err(|err| {
             (
                 StatusCode::INTERNAL_SERVER_ERROR,
-                format!("error opening QMDL file: {}", err),
+                format!("error opening QMDL file: {err}"),
             )
         })?;
     let limited_qmdl_file = qmdl_file.take(entry.qmdl_size_bytes as u64);
@@ -105,14 +105,14 @@ pub async fn set_config(
     let config_str = toml::to_string_pretty(&config).map_err(|err| {
         (
             StatusCode::INTERNAL_SERVER_ERROR,
-            format!("failed to serialize config as TOML: {}", err),
+            format!("failed to serialize config as TOML: {err}"),
         )
     })?;
 
     write(&state.config_path, config_str).await.map_err(|err| {
         (
             StatusCode::INTERNAL_SERVER_ERROR,
-            format!("failed to write config file: {}", err),
+            format!("failed to write config file: {err}"),
         )
     })?;
 
@@ -146,7 +146,7 @@ pub async fn get_zip(
         let qmdl_store = state.qmdl_store_lock.read().await;
         let (entry_index, entry) = qmdl_store.entry_for_name(&qmdl_idx).ok_or((
             StatusCode::NOT_FOUND,
-            format!("couldn't find entry with name {}", qmdl_idx),
+            format!("couldn't find entry with name {qmdl_idx}"),
         ))?;
 
         if entry.qmdl_size_bytes == 0 {
@@ -207,7 +207,7 @@ pub async fn get_zip(
                 {
                     // if we fail to generate the PCAP file, we should still continue and give the
                     // user the QMDL.
-                    error!("Failed to generate PCAP: {:?}", e);
+                    error!("Failed to generate PCAP: {e:?}");
                 }
 
                 entry_writer.into_inner().close().await?;
@@ -219,7 +219,7 @@ pub async fn get_zip(
         .await;
 
         if let Err(e) = result {
-            error!("Error generating ZIP file: {:?}", e);
+            error!("Error generating ZIP file: {e:?}");
         }
     });
 
@@ -283,7 +283,7 @@ mod tests {
 
         let analysis_status = {
             let store = store_lock.try_read().unwrap();
-            crate::analysis::AnalysisStatus::new(&*store)
+            crate::analysis::AnalysisStatus::new(&store)
         };
 
         Arc::new(ServerState {

--- a/bin/src/stats.rs
+++ b/bin/src/stats.rs
@@ -102,7 +102,7 @@ impl MemoryStats {
 // turns a number of kilobytes (like 28293) into a human-readable string (like "28.3M")
 fn humanize_kb(kb: usize) -> String {
     if kb < 1000 {
-        return format!("{}K", kb);
+        return format!("{kb}K");
     }
     format!("{:.1}M", kb as f64 / 1024.0)
 }
@@ -114,7 +114,7 @@ pub async fn get_system_stats(
     match SystemStats::new(qmdl_store.path.to_str().unwrap()).await {
         Ok(stats) => Ok(Json(stats)),
         Err(err) => {
-            error!("error getting system stats: {}", err);
+            error!("error getting system stats: {err}");
             Err((
                 StatusCode::INTERNAL_SERVER_ERROR,
                 "error getting system stats".to_string(),

--- a/lib/src/analysis/analyzer.rs
+++ b/lib/src/analysis/analyzer.rs
@@ -175,7 +175,7 @@ impl Harness {
             let qmdl_message = match maybe_qmdl_message {
                 Ok(msg) => msg,
                 Err(err) => {
-                    row.skipped_message_reasons.push(format!("{:?}", err));
+                    row.skipped_message_reasons.push(format!("{err:?}"));
                     continue;
                 }
             };
@@ -183,7 +183,7 @@ impl Harness {
             let gsmtap_message = match gsmtap_parser::parse(qmdl_message) {
                 Ok(msg) => msg,
                 Err(err) => {
-                    row.skipped_message_reasons.push(format!("{:?}", err));
+                    row.skipped_message_reasons.push(format!("{err:?}"));
                     continue;
                 }
             };
@@ -195,7 +195,7 @@ impl Harness {
             let element = match InformationElement::try_from(&gsmtap_msg) {
                 Ok(element) => element,
                 Err(err) => {
-                    row.skipped_message_reasons.push(format!("{:?}", err));
+                    row.skipped_message_reasons.push(format!("{err:?}"));
                     continue;
                 }
             };

--- a/lib/src/analysis/connection_redirect_downgrade.rs
+++ b/lib/src/analysis/connection_redirect_downgrade.rs
@@ -42,7 +42,7 @@ impl Analyzer for ConnectionRedirect2GDowngradeAnalyzer {
             }),
             _ => Some(Event {
                 event_type: EventType::Informational,
-                message: format!("RRCConnectionRelease CarrierInfo: {:?}", carrier_info),
+                message: format!("RRCConnectionRelease CarrierInfo: {carrier_info:?}"),
             }),
         }
     }

--- a/lib/src/analysis/imsi_requested.rs
+++ b/lib/src/analysis/imsi_requested.rs
@@ -1,8 +1,7 @@
-use std::any::Any;
 use std::borrow::Cow;
 
 use pycrate_rs::nas::emm::EMMMessage;
-use pycrate_rs::nas::generated::emm::emm_identity_request::{EMMIdentityRequest, IDTypeV};
+use pycrate_rs::nas::generated::emm::emm_identity_request::IDTypeV;
 use pycrate_rs::nas::NASMessage;
 
 use super::analyzer::{Analyzer, Event, EventType, Severity};
@@ -54,10 +53,9 @@ impl Analyzer for ImsiRequestedAnalyzer {
                         },
                         message: format!(
                             "NAS IMSI identity request detected, however it was within \
-                            the first {} packets of this analysis. If you just \
+                            the first {PACKET_THRESHHOLD} packets of this analysis. If you just \
                             turned your device on, this is likely a \
-                            false-positive.",
-                            PACKET_THRESHHOLD
+                            false-positive."
                         ),
                     });
                 } else {

--- a/lib/src/diag_device.rs
+++ b/lib/src/diag_device.rs
@@ -104,8 +104,7 @@ impl DiagDevice {
             match Self::try_new().await {
                 Ok(device) => {
                     info!(
-                        "Diag device initialization succeeded after {} retries",
-                        num_retries
+                        "Diag device initialization succeeded after {num_retries} retries"
                     );
                     return Ok(device);
                 }
@@ -113,15 +112,13 @@ impl DiagDevice {
                     num_retries += 1;
                     if start_time.elapsed() >= max_duration {
                         error!(
-                            "Failed to initialize diag device after {:?}: {}",
-                            max_duration, e
+                            "Failed to initialize diag device after {max_duration:?}: {e}"
                         );
                         return Err(e);
                     }
 
                     info!(
-                        "Diag device initialization failed {} times, retrying in {:?}: {}",
-                        num_retries, delay, e
+                        "Diag device initialization failed {num_retries} times, retrying in {delay:?}: {e}"
                     );
                     sleep(delay).await;
 
@@ -240,7 +237,7 @@ impl DiagDevice {
                     }
                     _ => info!("skipping non-LogConfigResponse response..."),
                 },
-                Err(e) => error!("error parsing message: {:?}", e),
+                Err(e) => error!("error parsing message: {e:?}"),
             }
         }
 
@@ -268,7 +265,7 @@ impl DiagDevice {
                         return Ok(());
                     }
                 }
-                Err(e) => error!("error parsing message: {:?}", e),
+                Err(e) => error!("error parsing message: {e:?}"),
             }
         }
 
@@ -282,7 +279,7 @@ impl DiagDevice {
         for (log_type, &log_mask_bitsize) in log_mask_sizes.iter().enumerate() {
             if log_mask_bitsize > 0 {
                 self.set_log_mask(log_type as u32, log_mask_bitsize).await?;
-                info!("enabled logging for log type {}", log_type);
+                info!("enabled logging for log type {log_type}");
             }
         }
 
@@ -347,8 +344,7 @@ fn enable_frame_readwrite(fd: i32, mode: u32) -> DiagResult<()> {
 
             if ret < 0 {
                 let msg = format!(
-                    "DIAG_IOCTL_SWITCH_LOGGING ioctl failed with error code {}",
-                    ret
+                    "DIAG_IOCTL_SWITCH_LOGGING ioctl failed with error code {ret}"
                 );
                 return Err(DiagDeviceError::InitializationFailed(msg));
             }

--- a/lib/src/diag_device.rs
+++ b/lib/src/diag_device.rs
@@ -103,17 +103,13 @@ impl DiagDevice {
         loop {
             match Self::try_new().await {
                 Ok(device) => {
-                    info!(
-                        "Diag device initialization succeeded after {num_retries} retries"
-                    );
+                    info!("Diag device initialization succeeded after {num_retries} retries");
                     return Ok(device);
                 }
                 Err(e) => {
                     num_retries += 1;
                     if start_time.elapsed() >= max_duration {
-                        error!(
-                            "Failed to initialize diag device after {max_duration:?}: {e}"
-                        );
+                        error!("Failed to initialize diag device after {max_duration:?}: {e}");
                         return Err(e);
                     }
 
@@ -343,9 +339,7 @@ fn enable_frame_readwrite(fd: i32, mode: u32) -> DiagResult<()> {
             }
 
             if ret < 0 {
-                let msg = format!(
-                    "DIAG_IOCTL_SWITCH_LOGGING ioctl failed with error code {ret}"
-                );
+                let msg = format!("DIAG_IOCTL_SWITCH_LOGGING ioctl failed with error code {ret}");
                 return Err(DiagDeviceError::InitializationFailed(msg));
             }
         }

--- a/lib/src/gsmtap_parser.rs
+++ b/lib/src/gsmtap_parser.rs
@@ -153,7 +153,7 @@ fn log_to_gsmtap(value: LogBody) -> Result<Option<GsmtapMessage>, GsmtapParserEr
             }))
         }
         _ => {
-            error!("gsmtap_sink: ignoring unhandled log type: {:?}", value);
+            error!("gsmtap_sink: ignoring unhandled log type: {value:?}");
             Ok(None)
         }
     }


### PR DESCRIPTION
These are almost entirely just moving variables into format strings. There are two left unfixed, both function calls with two many arguments.

Also fixes the two lint errors that were previously going to be fixed in #425.