### PR TITLE
cargo/config: strip debuginfo from --release bins for a significantly smaller installer size

### DIFF
--- a/.cargo/config.toml
+++ b/.cargo/config.toml
@@ -28,6 +28,7 @@ rustflags = ["-C", "target-feature=+crt-static"]
 # keep line numbers in stack traces for non-firmware binaries
 [profile.release]
 debug = "limited"
+strip = "debuginfo"
 
 # optimizations to reduce the binary size of firmware binaries
 [profile.firmware]
@@ -38,4 +39,3 @@ lto = true
 codegen-units = 1
 panic = "abort"
 debug = false
-

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -36,7 +36,7 @@ jobs:
           lcommit=${{ github.event.pull_request.base.sha || 'origin/main' }}
 
           # If we are on main, or if these workflow files are being changed, run everything
-          if [ ${{ github.ref }} = 'refs/heads/main' ] || git diff --name-only $lcommit..HEAD | grep -qe ^.github/workflows/
+          if [ ${{ github.ref }} = 'refs/heads/main' ] || git diff --name-only $lcommit..HEAD | grep -qe ^.github/workflows/ -e ^.cargo
           then
             echo "building everything"
             echo code_count=forced >> "$GITHUB_OUTPUT"


### PR DESCRIPTION
rustc -C strip=debuginfo leaves the symbol table intact, meaning RUST_BACKTRACE=1 on the installer still produces helpful output.

This significantly reduces the binary size, eg the amd64 installer goes from 93M to 21M. Stripping the symbol table only reclaims a further ~2M.


## strip = debuginfo (this PR)
```
 % RUST_BACKTRACE=1 ./target/release/installer wingtech --admin-password 1234
 Starting telnet ... 
 Failed to install rayhunter on the Wingtech CT2MHS01

 Caused by:
     0: error sending request
     1: client error (Connect)
     2: tcp connect error
     3: Network is unreachable (os error 101)

 Stack backtrace:
    0: anyhow::error::<impl core::convert::From<E> for anyhow::Error>::from
    1: installer::wingtech::run_command::{{closure}}
    2: installer::run::{{closure}}
    3: tokio::runtime::park::CachedParkThread::block_on
    4: tokio::runtime::context::runtime::enter_runtime
    5: tokio::runtime::runtime::Runtime::block_on
    6: installer::main
    7: std::sys::backtrace::__rust_begin_short_backtrace
    8: std::rt::lang_start::{{closure}}
    9: std::rt::lang_start_internal
   10: main
   11: <unknown>
   12: __libc_start_main
   13: _start
```

## not stripped (before)
```
 % RUST_BACKTRACE=1 ./target/release/installer wingtech --admin-password 1234
 Starting telnet ...
 Failed to install rayhunter on the Wingtech CT2MHS01

 Caused by:
     0: error sending request
     1: client error (Connect)
     2: tcp connect error
     3: Network is unreachable (os error 101)

 Stack backtrace:
    0: anyhow::error::<impl core::convert::From<E> for anyhow::Error>::from
              at /home/user/.cargo/registry/src/index.crates.io-1949cf8c6b5b557f/anyhow-1.0.98/src/backtrace.rs:27:14
    1: <core::result::Result<T,F> as core::ops::try_trait::FromResidual<core::result::Result<core::convert::Infallible,E>>>::from_residual
              at /home/user/.rustup/toolchains/stable-x86_64-unknown-linux-gnu/lib/rustlib/src/rust/library/core/src/result.rs:2014:27
    2: installer::wingtech::run_command::{{closure}}
              at ./installer/src/wingtech.rs:66:35
    3: installer::wingtech::start_telnet::{{closure}}
              at ./installer/src/wingtech.rs:52:73
    4: installer::wingtech::wingtech_run_install::{{closure}}
              at ./installer/src/wingtech.rs:93:46
    5: installer::wingtech::install::{{closure}}
              at ./installer/src/wingtech.rs:35:52
    6: installer::run::{{closure}}
              at ./installer/src/main.rs:113:60
    7: installer::main::{{closure}}
              at ./installer/src/main.rs:147:27
    8: tokio::runtime::park::CachedParkThread::block_on::{{closure}}
              at /home/user/.cargo/registry/src/index.crates.io-1949cf8c6b5b557f/tokio-1.45.1/src/runtime/park.rs:284:60
    9: tokio::task::coop::with_budget
              at /home/user/.cargo/registry/src/index.crates.io-1949cf8c6b5b557f/tokio-1.45.1/src/task/coop/mod.rs:167:5
   10: tokio::task::coop::budget
              at /home/user/.cargo/registry/src/index.crates.io-1949cf8c6b5b557f/tokio-1.45.1/src/task/coop/mod.rs:133:5
   11: tokio::runtime::park::CachedParkThread::block_on
              at /home/user/.cargo/registry/src/index.crates.io-1949cf8c6b5b557f/tokio-1.45.1/src/runtime/park.rs:284:31
   12: tokio::runtime::context::blocking::BlockingRegionGuard::block_on
              at /home/user/.cargo/registry/src/index.crates.io-1949cf8c6b5b557f/tokio-1.45.1/src/runtime/context/blocking.rs:66:9
   13: tokio::runtime::scheduler::multi_thread::MultiThread::block_on::{{closure}}
              at /home/user/.cargo/registry/src/index.crates.io-1949cf8c6b5b557f/tokio-1.45.1/src/runtime/scheduler/multi_thread/mod.rs:87:22
   14: tokio::runtime::context::runtime::enter_runtime
              at /home/user/.cargo/registry/src/index.crates.io-1949cf8c6b5b557f/tokio-1.45.1/src/runtime/context/runtime.rs:65:16
   15: tokio::runtime::scheduler::multi_thread::MultiThread::block_on
              at /home/user/.cargo/registry/src/index.crates.io-1949cf8c6b5b557f/tokio-1.45.1/src/runtime/scheduler/multi_thread/mod.rs:86:9
   16: tokio::runtime::runtime::Runtime::block_on_inner
              at /home/user/.cargo/registry/src/index.crates.io-1949cf8c6b5b557f/tokio-1.45.1/src/runtime/runtime.rs:358:50
   17: tokio::runtime::runtime::Runtime::block_on
              at /home/user/.cargo/registry/src/index.crates.io-1949cf8c6b5b557f/tokio-1.45.1/src/runtime/runtime.rs:330:13
   18: installer::main
              at ./installer/src/main.rs:147:5
   19: core::ops::function::FnOnce::call_once
              at /home/user/.rustup/toolchains/stable-x86_64-unknown-linux-gnu/lib/rustlib/src/rust/library/core/src/ops/function.rs:250:5
   20: std::sys::backtrace::__rust_begin_short_backtrace
              at /home/user/.rustup/toolchains/stable-x86_64-unknown-linux-gnu/lib/rustlib/src/rust/library/std/src/sys/backtrace.rs:152:18
   21: std::rt::lang_start::{{closure}}
              at /home/user/.rustup/toolchains/stable-x86_64-unknown-linux-gnu/lib/rustlib/src/rust/library/std/src/rt.rs:199:18
   22: core::ops::function::impls::<impl core::ops::function::FnOnce<A> for &F>::call_once
              at /rustc/05f9846f893b09a1be1fc8560e33fc3c815cfecb/library/core/src/ops/function.rs:284:13
   23: std::panicking::try::do_call
              at /rustc/05f9846f893b09a1be1fc8560e33fc3c815cfecb/library/std/src/panicking.rs:587:40
   24: std::panicking::try
              at /rustc/05f9846f893b09a1be1fc8560e33fc3c815cfecb/library/std/src/panicking.rs:550:19
   25: std::panic::catch_unwind
              at /rustc/05f9846f893b09a1be1fc8560e33fc3c815cfecb/library/std/src/panic.rs:358:14
   26: std::rt::lang_start_internal::{{closure}}
              at /rustc/05f9846f893b09a1be1fc8560e33fc3c815cfecb/library/std/src/rt.rs:168:24
   27: std::panicking::try::do_call
              at /rustc/05f9846f893b09a1be1fc8560e33fc3c815cfecb/library/std/src/panicking.rs:587:40
   28: std::panicking::try
              at /rustc/05f9846f893b09a1be1fc8560e33fc3c815cfecb/library/std/src/panicking.rs:550:19
   29: std::panic::catch_unwind
              at /rustc/05f9846f893b09a1be1fc8560e33fc3c815cfecb/library/std/src/panic.rs:358:14
   30: std::rt::lang_start_internal
              at /rustc/05f9846f893b09a1be1fc8560e33fc3c815cfecb/library/std/src/rt.rs:164:5
   31: main
   32: <unknown>
   33: __libc_start_main
   34: _start
```

## strip = true / strip = symbols
```
 % RUST_BACKTRACE=1 ./target/release/installer wingtech --admin-password 1234
 Starting telnet ...
 Failed to install rayhunter on the Wingtech CT2MHS01

 Caused by:
     0: error sending request
     1: client error (Connect)
     2: tcp connect error
     3: Network is unreachable (os error 101)

 Stack backtrace:
    0: <unknown>
    1: <unknown>
    2: <unknown>
    3: <unknown>
    4: <unknown>
    5: <unknown>
    6: <unknown>
    7: <unknown>
    8: <unknown>
    9: <unknown>
   10: <unknown>
   11: <unknown>
   12: __libc_start_main
   13: <unknown>
```