### PR TITLE
Smaller installer

### DIFF
--- a/.cargo/config.toml
+++ b/.cargo/config.toml
@@ -25,9 +25,10 @@ rustflags = ["-C", "target-feature=+crt-static"]
 linker = "rust-lld"
 rustflags = ["-C", "target-feature=+crt-static"]
 
-# keep line numbers in stack traces for non-firmware binaries
 [profile.release]
+# keep line numbers in stack traces for non-firmware binaries
 debug = "limited"
+lto = "fat"
 strip = "debuginfo"
 
 # optimizations to reduce the binary size of firmware binaries
@@ -35,7 +36,7 @@ strip = "debuginfo"
 inherits = "release"
 strip = true
 opt-level = "z"
-lto = true
+lto = "fat"
 codegen-units = 1
 panic = "abort"
 debug = false

--- a/.cargo/config.toml
+++ b/.cargo/config.toml
@@ -29,6 +29,7 @@ rustflags = ["-C", "target-feature=+crt-static"]
 # keep line numbers in stack traces for non-firmware binaries
 debug = "limited"
 lto = "fat"
+opt-level = "z"
 strip = "debuginfo"
 
 # optimizations to reduce the binary size of firmware binaries

--- a/.cargo/config.toml
+++ b/.cargo/config.toml
@@ -36,8 +36,6 @@ strip = "debuginfo"
 [profile.firmware]
 inherits = "release"
 strip = true
-opt-level = "z"
-lto = "fat"
 codegen-units = 1
 panic = "abort"
 debug = false

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -309,7 +309,6 @@ checksum = "021e862c184ae977658b36c4500f7feac3221ca5da43e3f25bd04ab6c79a29b5"
 dependencies = [
  "axum-core",
  "bytes",
- "form_urlencoded",
  "futures-util",
  "http",
  "http-body",
@@ -326,13 +325,11 @@ dependencies = [
  "serde",
  "serde_json",
  "serde_path_to_error",
- "serde_urlencoded",
  "sync_wrapper",
  "tokio",
  "tower",
  "tower-layer",
  "tower-service",
- "tracing",
 ]
 
 [[package]]
@@ -352,7 +349,6 @@ dependencies = [
  "sync_wrapper",
  "tower-layer",
  "tower-service",
- "tracing",
 ]
 
 [[package]]
@@ -1991,29 +1987,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f38d5652c16fde515bb1ecef450ab0f6a219d619a7274976324d5e377f7dceba"
 
 [[package]]
-name = "parking_lot"
-version = "0.12.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f1bf18183cf54e8d6059647fc3063646a1801cf30896933ec2311622cc4b9a27"
-dependencies = [
- "lock_api",
- "parking_lot_core",
-]
-
-[[package]]
-name = "parking_lot_core"
-version = "0.9.10"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1e401f977ab385c9e4e3ab30627d6f26d00e2c73eef317493c4ec6d468726cf8"
-dependencies = [
- "cfg-if",
- "libc",
- "redox_syscall",
- "smallvec",
- "windows-targets 0.52.6",
-]
-
-[[package]]
 name = "paste"
 version = "1.0.15"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2448,15 +2421,6 @@ checksum = "1465873a3dfdaa8ae7cb14b4383657caab0b3e8a0aa9ae8e04b044854c8dfce2"
 dependencies = [
  "crossbeam-deque",
  "crossbeam-utils",
-]
-
-[[package]]
-name = "redox_syscall"
-version = "0.5.12"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "928fca9cf2aa042393a8325b9ead81d2f0df4cb12e1e24cef072922ccd99c5af"
-dependencies = [
- "bitflags 2.9.1",
 ]
 
 [[package]]
@@ -3042,7 +3006,6 @@ dependencies = [
  "bytes",
  "libc",
  "mio",
- "parking_lot",
  "pin-project-lite",
  "signal-hook-registry",
  "socket2",
@@ -3168,7 +3131,6 @@ dependencies = [
  "tokio",
  "tower-layer",
  "tower-service",
- "tracing",
 ]
 
 [[package]]
@@ -3189,7 +3151,6 @@ version = "0.1.41"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "784e0ac535deb450455cbfa28a6f0df145ea1bb7ae51b821cf5e7927fdcfbdd0"
 dependencies = [
- "log",
  "pin-project-lite",
  "tracing-core",
 ]

--- a/installer/Cargo.toml
+++ b/installer/Cargo.toml
@@ -6,7 +6,7 @@ edition = "2024"
 [dependencies]
 aes = "0.8.4"
 anyhow = "1.0.98"
-axum = "0.8.3"
+axum = { version = "0.8.3", features = ["http1", "tokio"], default-features = false }
 base64_light = "0.1.5"
 block-padding = "0.3.3"
 bytes = "1.10.1"
@@ -19,7 +19,7 @@ nusb = "0.1.13"
 reqwest = { version = "0.12.15", features = ["json"], default-features = false }
 serde = { version = "1.0.219", features = ["derive"] }
 sha2 = "0.10.8"
-tokio = { version = "1.44.2", features = ["full"] }
+tokio = { version = "1.44.2", features = ["io-util", "macros", "rt-multi-thread"], default-features = false }
 tokio-retry2 = "0.5.7"
 tokio-stream = "0.1.17"
 


### PR DESCRIPTION
Example release build of `-p installer` with NO_FIRMWARE_BIN on amd64 linux, after `cargo clean --release`:

Before (default lto and opt-levels):
```
Finished `release` profile [optimized + debuginfo] target(s) in 2m 18s
7.8M    ./target/release/installer
```

fat lto, default opt level:
```
Finished `release` profile [optimized + debuginfo] target(s) in 2m 12s
5.6M    ./target/release/installer
```

opt-level z and fat lto:
```
Finished `release` profile [optimized + debuginfo] target(s) in 1m 39s
4.7M    ./target/release/installer
```


TODO:
rayhunter-check benchmarks may inform whether opt-level z introduces a performance hit. Fat LTO is expected to be a performance increase.

There's no reason why rayhunter-check and the installer have to be compiled with the same settings if they need to be optimised differently. rayhunter-check is only used by developers.