### PR TITLE
docs: misc typo fixes

### DIFF
--- a/doc/installing-from-release-windows.md
+++ b/doc/installing-from-release-windows.md
@@ -25,7 +25,7 @@ Windows support in Rayhunter's installer is a work-in-progress. Depending on the
 2. Download the latest `rayhunter-vX.X.X.zip` from the [Rayhunter releases page](https://github.com/EFForg/rayhunter/releases). The version you download will have numbers instead of X
 3. Unzip `rayhunter-vX.X.X` .
 1. Open a powershell terminal by pressing Win+R and typing `powershell` and hitting enter. 
-5. Type `cd ~\Downloads\rayhunter-v<x.x.x>\installer-windows-x86_64` (**Replace <x.x.x> with the rayhunter version you just unzipped**) and hit enter.
+5. Type `cd ~\Downloads\rayhunter-v<x.x.x>\installer-windows-x86_64` (**Replace <x.x.x> with the Rayhunter version you just unzipped**) and hit enter.
 5. Run the install script: `.\installer.exe orbic` and hit enter.
     - The device will restart multiple times over the next few minutes.
     - You will know it is done when you see terminal output that says `checking for rayhunter server...success!`

--- a/doc/installing-from-release.md
+++ b/doc/installing-from-release.md
@@ -18,10 +18,10 @@ Make sure you've got one of Rayhunter's [supported devices](./supported-devices.
 4. Run the install script for your operating system:
 
     First, enter the correct subfolder for your operating system:
-    - for Ubuntu on x64 arhitecture: `cd installer-ubuntu-24`
-    - for Ubuntu on ARM64 arhitecture: `cd installer-ubuntu-24-aarch64`
+    - for Ubuntu on x64 architecture: `cd installer-ubuntu-24`
+    - for Ubuntu on ARM64 architecture: `cd installer-ubuntu-24-aarch64`
     - for MacOS on Intel (old macbooks) architecture: `cd installer-macos-intel`
-    - for MacOS on ARM (M1/M2 etc.) achitecture: `cd installer-macos-arm`
+    - for MacOS on ARM (M1/M2 etc.) architecture: `cd installer-macos-arm`
     - for Windows: `cd installer-windows-x86_64`
 
     ```bash
@@ -45,5 +45,7 @@ Make sure you've got one of Rayhunter's [supported devices](./supported-devices.
 
 * On MacOS if you encounter an error that says "No Orbic device found," it may because you have the "Allow accessories to connect" security setting set to "Ask for approval." You may need to temporarily change it to "Always" for the script to run. Make sure to change it back to a more secure setting when you're done.
 
+```bash
 ./installer --help
 ./installer util --help
+```

--- a/doc/installing-from-source.md
+++ b/doc/installing-from-source.md
@@ -15,7 +15,7 @@ Building Rayhunter from source, either for development or because the install sc
 
 [Install Rust the usual way](https://www.rust-lang.org/tools/install). Then,
 
-- install the cross-compilation target for the device rayhunter will run on:
+- install the cross-compilation target for the device Rayhunter will run on:
 ```sh
 rustup target add armv7-unknown-linux-musleabihf
 ```

--- a/doc/introduction.md
+++ b/doc/introduction.md
@@ -4,7 +4,7 @@
 
 Rayhunter is a project for detecting IMSI catchers, also known as cell-site simulators or stingrays. It's designed to run on a cheap mobile hotspot called the Orbic RC400L, but thanks to community efforts can [support some other devices as well](./supported-devices.md).
 
-It's also designed to be as easy to install and use as possible, regardless of you level of technical skills. This guide should provide you all you need to acquire a compatible device, install Rayhunter, and start catching IMSI catchers.
+It's also designed to be as easy to install and use as possible, regardless of your level of technical skills. This guide should provide you all you need to acquire a compatible device, install Rayhunter, and start catching IMSI catchers.
 
 To learn more about the aim of the project, and about IMSI catchers in general, please check out our [introductory blog post](https://www.eff.org/deeplinks/2025/03/meet-rayhunter-new-open-source-tool-eff-detect-cellular-spying). Otherwise, check out the [installation guide](./installation.md) to get started.
 

--- a/doc/orbic.md
+++ b/doc/orbic.md
@@ -1,6 +1,6 @@
 # Orbic RC400L
 
-The Orbic RC400L is an inexpensive LTE modem primarily designed for the US marked, and the original device for which Rayhunter is developed.
+The Orbic RC400L is an inexpensive LTE modem primarily designed for the US market, and the original device for which Rayhunter is developed.
 
 You can buy an Orbic [using bezos
 bucks](https://www.amazon.com/Orbic-Verizon-Hotspot-Connect-Enabled/dp/B08N3CHC4Y),

--- a/doc/tplink-m7350.md
+++ b/doc/tplink-m7350.md
@@ -61,7 +61,7 @@ add two port triggers. You can look at `Settings > NAT Settings > Port
 Triggers` in TP-Link's admin UI to see them.
 
 1. One port trigger "rayhunter-root" to launch the telnet shell. This is only needed for installation, and can be removed after upgrade. You can reinstall it using `./installer util tplink-start-telnet`.
-2. One port trigger "rayhunter-daemon" to auto-start rayhunter on boot. If you remove this, rayhunter will have to be started manually from shell.
+2. One port trigger "rayhunter-daemon" to auto-start Rayhunter on boot. If you remove this, Rayhunter will have to be started manually from shell.
 
 ## Other links
 

--- a/doc/updating-rayhunter.md
+++ b/doc/updating-rayhunter.md
@@ -1,3 +1,3 @@
 # Updating Rayhunter
 
-Great news: if you've successfully installed rayhunter, you already know how to update it! Our update process is identical to the installation process: simply repeat the steps for installing Rayhunter via a [release](./installing-from-release.md) or from [source](./installing-from-source.md).
+Great news: if you've successfully installed Rayhunter, you already know how to update it! Our update process is identical to the installation process: simply repeat the steps for installing Rayhunter via a [release](./installing-from-release.md) or from [source](./installing-from-source.md).

--- a/doc/wingtech-ct2mhs01.md
+++ b/doc/wingtech-ct2mhs01.md
@@ -47,7 +47,7 @@ Connect to the Wingtech's network over wifi or usb tethering, then run the insta
 ```
 
 ## Obtaining a shell
-Even when rayhunter is running, for security reasons the Wingtech will not have telnet or adb enabled during normal operation.
+Even when Rayhunter is running, for security reasons the Wingtech will not have telnet or adb enabled during normal operation.
 
 Use either command below to enable telnet or adb access:
 


### PR DESCRIPTION
The PR adds miscellaneous small documentation fixes.
Fixes some typos like misspellings or missing code blocks.
Standardizes references to the software and project as **R**ayhunter (with a capital R).
Rayhunter standardization does not change any paths or commands where casing matters.


## Pull Request Checklist

- [ ] The Rayhunter team has recently expressed interest in reviewing a PR for this. If not, this PR may be closed due our limited resources and need to prioritize how we spend them.
- [x] Added or updated any documentation as needed to support the changes in this PR.
- [x] Code has been linted and run through `cargo fmt` (N/A, no markdown formatter)
- [x] If any new functionality has been added, unit tests were also added (N/A, no code changes)
