### PR TITLE
installer: tokio runtime flavor current_thread

### DIFF
--- a/installer/Cargo.toml
+++ b/installer/Cargo.toml
@@ -19,7 +19,7 @@ nusb = "0.1.13"
 reqwest = { version = "0.12.15", features = ["json"], default-features = false }
 serde = { version = "1.0.219", features = ["derive"] }
 sha2 = "0.10.8"
-tokio = { version = "1.44.2", features = ["io-util", "macros", "rt-multi-thread"], default-features = false }
+tokio = { version = "1.44.2", features = ["io-util", "macros", "rt"], default-features = false }
 tokio-retry2 = "0.5.7"
 tokio-stream = "0.1.17"
 

--- a/installer/src/main.rs
+++ b/installer/src/main.rs
@@ -142,7 +142,7 @@ async fn run() -> Result<(), Error> {
     Ok(())
 }
 
-#[tokio::main]
+#[tokio::main(flavor = "current_thread")]
 async fn main() {
     if let Err(e) = run().await {
         eprintln!("{e:?}");


### PR DESCRIPTION
Slightly reduce binary size by using the smaller 'rt' feature and the current_thread runtime flavor in the installer, since there is no benefit to true multithreading.

This also gives a small compile time boost on my system.