### PR TITLE
Support for running on the PinePhone's Quectel modem

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1502,7 +1502,8 @@ dependencies = [
  "env_logger 0.11.8",
  "hyper",
  "hyper-util",
- "md5",
+ "md5 0.7.0",
+ "md5crypt",
  "nusb",
  "reqwest",
  "serde",
@@ -1743,6 +1744,21 @@ name = "md5"
 version = "0.7.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "490cc448043f947bae3cbee9c203358d62dbee0db12107a74be5c30ccfd09771"
+
+[[package]]
+name = "md5"
+version = "0.8.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ae960838283323069879657ca3de837e9f7bbb4c7bf6ea7f1b290d5e9476d2e0"
+
+[[package]]
+name = "md5crypt"
+version = "1.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9c8db1a978f99f584f2e72601860f68bb2cea9c09f4408f5e83f805db3434fb0"
+dependencies = [
+ "md5 0.8.0",
+]
 
 [[package]]
 name = "mdns-sd"

--- a/daemon/src/display/headless.rs
+++ b/daemon/src/display/headless.rs
@@ -1,0 +1,16 @@
+use log::info;
+use tokio::sync::mpsc::Receiver;
+use tokio::sync::oneshot;
+use tokio_util::task::TaskTracker;
+
+use crate::config;
+use crate::display::DisplayState;
+
+pub fn update_ui(
+    _task_tracker: &TaskTracker,
+    _config: &config::Config,
+    _ui_shutdown_rx: oneshot::Receiver<()>,
+    _ui_update_rx: Receiver<DisplayState>,
+) {
+    info!("Headless mode, not spawning UI.");
+}

--- a/daemon/src/display/mod.rs
+++ b/daemon/src/display/mod.rs
@@ -1,6 +1,7 @@
 mod generic_framebuffer;
 
 pub mod orbic;
+pub mod headless;
 pub mod tmobile;
 pub mod tplink;
 pub mod tplink_framebuffer;

--- a/daemon/src/display/mod.rs
+++ b/daemon/src/display/mod.rs
@@ -1,7 +1,7 @@
 mod generic_framebuffer;
 
-pub mod orbic;
 pub mod headless;
+pub mod orbic;
 pub mod tmobile;
 pub mod tplink;
 pub mod tplink_framebuffer;

--- a/daemon/src/main.rs
+++ b/daemon/src/main.rs
@@ -241,6 +241,7 @@ async fn run_with_config(
             Device::Tplink => display::tplink::update_ui,
             Device::Tmobile => display::tmobile::update_ui,
             Device::Wingtech => display::wingtech::update_ui,
+            Device::Pinephone => display::headless::update_ui,
         };
         update_ui(&task_tracker, &config, ui_shutdown_rx, ui_update_rx);
 

--- a/doc/SUMMARY.md
+++ b/doc/SUMMARY.md
@@ -17,5 +17,6 @@
   - [TP-Link M7310](./tplink-m7310.md)
   - [Tmobile TMOHS1](./tmobile-tmohs1.md)
   - [Wingtech CT2MHS01](./wingtech-ct2mhs01.md)
+  - [PinePhone and PinePhone Pro](./pinephone.md)
 - [Support, feedback, and community](./support-feedback-community.md)
   - [Frequently Asked Questions](./faq.md)

--- a/doc/pinephone.md
+++ b/doc/pinephone.md
@@ -1,0 +1,62 @@
+# PinePhone and PinePhone Pro
+
+The PinePhone and PinePhone Pro both use a Qualcomm mdm9607 modem as part of their [Quectel EG25-G LTE module](https://www.quectel.com/product/lte-eg25-g/). The EG25-G has global LTE band support and contains a GNSS positioning module. Rayhunter does not currently make direct use of GNSS.
+
+The modem is fully capable of running Rayhunter, but lacks both a screen and a network connection. The modem exposes an AT interface that can enable adb.
+
+## Hardware
+- <https://pine64.org/devices/pinephone/>
+- <https://pine64.org/devices/pinephone_pro/>
+
+## Supported bands
+
+| Band | Frequency         |
+| ---- | ----------------- |
+|    1 | 2100 MHz (IMT)    |
+|    2 | 1900 MHz (PCS)    |
+|    3 | 1800 MHz (DCS)    |
+|    4 | 1700 MHz (AWS-1)  |
+|    5 | 850 MHz (CLR)     |
+|    7 | 2600 MHz (IMT-E)  |
+|    8 | 900 MHz (E-GSM)   |
+|   12 | 700 MHz (LSMH)    |
+|   13 | 700 MHz (USMH)    |
+|   18 | 850 MHz (LSMH)    |
+|   19 | 850 MHz (L800)    |
+|   20 | 800 MHz (DD)      |
+|   25 | 1900 MHz (E-PCS)  |
+|   26 | 850 MHz (E-CLR)   |
+|   28 | 700 MHz (APT)     |
+|   38 | 2600 MHz (IMT-E)  |
+|   39 | 850 MHz (E-CLR)   |
+|   40 | 2300 MHz (S-Band) |
+|   41 | 2500 MHz (BRS)    |
+
+Note that the Quectel EG25-G does not support LTE band 48 (CBRS 3500MHz), used in the US for unlicensed 4G/5G connectivity.
+
+## Installing
+```sh
+./installer pinephone
+```
+
+## Accessing rayhunter
+Because the modem does not have its own display or network interface, rayhunter is only accessible on the pinephone by forwarding tcp over adb.
+
+```sh
+adb forward tcp:8080 tcp:8080
+```
+
+## Shell access
+Use this command to enable adb access:
+
+```sh
+./installer util pinephone-start-adb
+adb shell
+```
+
+## Power saving (disable adb)
+The modem won't be able to sleep (power save) with adb enabled, even if Rayhunter is stopped. Disable adb with the following command:
+
+```sh
+./installer util pinephone-stop-adb
+```

--- a/doc/supported-devices.md
+++ b/doc/supported-devices.md
@@ -23,6 +23,7 @@ Rayhunter is confirmed to work on these devices.
 | [Wingtech CT2MHS01](./wingtech-ct2mhs01.md) | Americas |
 | [Tmobile TMOHS1](./tmobile-tmohs1.md) | Americas |
 | [TP-Link M7310](./tplink-m7310.md) | Africa, Europe, Middle East |
+| [PinePhone and PinePhone Pro](./pinephone.md) | Global |
 
 ## Adding new devices
 Rayhunter was built and tested primarily on the Orbic RC400L mobile hotspot, but the community has been working hard at adding support for other devices. Theoretically, if a device runs a Qualcomm modem and exposes a `/dev/diag` interface, Rayhunter may work on it.

--- a/installer/Cargo.toml
+++ b/installer/Cargo.toml
@@ -15,6 +15,7 @@ env_logger = "0.11.8"
 hyper = "1.6.0"
 hyper-util = "0.1.11"
 md5 = "0.7.0"
+md5crypt = "1.0.0"
 nusb = "0.1.13"
 reqwest = { version = "0.12.15", features = ["json"], default-features = false }
 serde = { version = "1.0.219", features = ["derive"] }

--- a/installer/src/main.rs
+++ b/installer/src/main.rs
@@ -77,7 +77,7 @@ enum UtilSubCommand {
     /// Send a serial command to the Orbic.
     Serial(Serial),
     /// Start an ADB shell
-    Shell(NoArgs),
+    Shell,
     /// Root the Tmobile and launch adb.
     TmobileStartAdb(TmobileArgs),
     /// Root the Tmobile and launch telnetd.
@@ -89,9 +89,9 @@ enum UtilSubCommand {
     /// Root the Wingtech and launch adb.
     WingtechStartAdb(WingtechArgs),
     /// Unlock the Pinephone's modem and start adb.
-    PinephoneStartAdb(NoArgs),
+    PinephoneStartAdb,
     /// Lock the Pinephone's modem and stop adb.
-    PinephoneStopAdb(NoArgs),
+    PinephoneStopAdb,
     /// Send a file to the TP-Link device over telnet.
     ///
     /// Before running this utility, you need to make telnet accessible with `installer util
@@ -162,9 +162,6 @@ struct Serial {
     command: Vec<String>,
 }
 
-#[derive(Parser, Debug)]
-struct NoArgs {}
-
 async fn run() -> Result<(), Error> {
     env_logger::Builder::from_env(Env::default().default_filter_or("off")).init();
     let Args { command } = Args::parse();
@@ -195,7 +192,7 @@ async fn run() -> Result<(), Error> {
                     }
                 }
             }
-            UtilSubCommand::Shell(_) => orbic::shell().await.context("\nFailed to open shell on Orbic RC400L")?,
+            UtilSubCommand::Shell => orbic::shell().await.context("\nFailed to open shell on Orbic RC400L")?,
             UtilSubCommand::TmobileStartTelnet(args) => wingtech::start_telnet(&args.admin_ip, &args.admin_password).await.context("\nFailed to start telnet on the Tmobile TMOHS1")?,
             UtilSubCommand::TmobileStartAdb(args) => wingtech::start_adb(&args.admin_ip, &args.admin_password).await.context("\nFailed to start adb on the Tmobile TMOHS1")?,
             UtilSubCommand::TplinkStartTelnet(options) => {
@@ -209,8 +206,8 @@ async fn run() -> Result<(), Error> {
             }
             UtilSubCommand::WingtechStartTelnet(args) => wingtech::start_telnet(&args.admin_ip, &args.admin_password).await.context("\nFailed to start telnet on the Wingtech CT2MHS01")?,
             UtilSubCommand::WingtechStartAdb(args) => wingtech::start_adb(&args.admin_ip, &args.admin_password).await.context("\nFailed to start adb on the Wingtech CT2MHS01")?,
-            UtilSubCommand::PinephoneStartAdb(_) => pinephone::start_adb().await.context("\nFailed to start adb on the PinePhone's modem")?,
-            UtilSubCommand::PinephoneStopAdb(_) => pinephone::stop_adb().await.context("\nFailed to stop adb on the PinePhone's modem")?,
+            UtilSubCommand::PinephoneStartAdb => pinephone::start_adb().await.context("\nFailed to start adb on the PinePhone's modem")?,
+            UtilSubCommand::PinephoneStopAdb => pinephone::stop_adb().await.context("\nFailed to stop adb on the PinePhone's modem")?,
         }
     }
 

--- a/installer/src/pinephone.rs
+++ b/installer/src/pinephone.rs
@@ -1,0 +1,276 @@
+use std::io::Write;
+use std::path::Path;
+use std::time::Duration;
+
+use adb_client::{ADBDeviceExt, ADBUSBDevice};
+use anyhow::{Context, Result, anyhow, bail};
+use md5::compute as md5_compute;
+use md5crypt::md5crypt;
+use nusb::Interface;
+use nusb::transfer::{Control, ControlType, Recipient, RequestBuffer};
+use tokio::time::sleep;
+
+use crate::orbic::test_rayhunter;
+use crate::util::{echo, open_usb_device};
+use crate::{CONFIG_TOML, RAYHUNTER_DAEMON_INIT};
+
+const USB_VENDOR_ID: u16 = 0x2C7C;
+const USB_PRODUCT_ID: u16 = 0x125;
+const USB_INTERFACE_NUMBER: u8 = 2;
+
+pub async fn install() -> Result<()> {
+    echo!("Unlocking modem ... ");
+    start_adb().await?;
+    sleep(Duration::from_secs(3)).await;
+    let mut adb = ADBUSBDevice::new(USB_VENDOR_ID, USB_PRODUCT_ID).unwrap();
+    println!("ok");
+
+    adb.run_command(&["mount", "-o", "remount,rw", "/"], "exit code 0")?;
+    adb.run_command(&["mkdir", "-p", "/data/rayhunter"], "exit code 0")?;
+
+    let rayhunter_daemon_bin = include_bytes!(env!("FILE_RAYHUNTER_DAEMON"));
+    adb.install_file("/data/rayhunter/rayhunter-daemon", rayhunter_daemon_bin)?;
+    adb.install_file(
+        "/data/rayhunter/config.toml",
+        CONFIG_TOML
+            .replace("#device = \"orbic\"", "device = \"pinephone\"")
+            .as_bytes(),
+    )?;
+    adb.install_file(
+        "/etc/init.d/rayhunter_daemon",
+        RAYHUNTER_DAEMON_INIT.as_bytes(),
+    )?;
+    adb.install_file(
+        "/etc/init.d/misc-daemon",
+        include_bytes!("../../dist/scripts/misc-daemon"),
+    )?;
+    adb.run_command(
+        &["chmod", "755", "/etc/init.d/rayhunter_daemon"],
+        "exit code 0",
+    )?;
+    adb.run_command(&["chmod", "755", "/etc/init.d/misc-daemon"], "exit code 0")?;
+
+    println!("Rebooting device and waiting 30 seconds for it to start up.");
+    adb.run_command(&["shutdown -r -t 1 now"], "exit code 0")?;
+    sleep(Duration::from_secs(30)).await;
+
+    echo!("Unlocking modem ... ");
+    start_adb().await?;
+    sleep(Duration::from_secs(3)).await;
+    let mut adb = ADBUSBDevice::new(USB_VENDOR_ID, USB_PRODUCT_ID).unwrap();
+    println!("ok");
+
+    echo!("Testing rayhunter ... ");
+    test_rayhunter(&mut adb).await?;
+    println!("ok");
+    println!("rayhunter is running on the modem. Use adb to access the web interface.");
+
+    Ok(())
+}
+
+struct Qusbcfg {
+    vendor_id: u16,
+    product_id: u16,
+    diag: u8,
+    nmea: u8,
+    at: u8,
+    modem: u8,
+    net: u8,
+    adb: u8,
+    audio: u8,
+}
+
+impl Default for Qusbcfg {
+    fn default() -> Self {
+        Qusbcfg {
+            vendor_id: USB_VENDOR_ID,
+            product_id: USB_PRODUCT_ID,
+            diag: 1,
+            nmea: 1,
+            at: 1,
+            modem: 1,
+            net: 1,
+            adb: 0,
+            audio: 0,
+        }
+    }
+}
+
+impl std::fmt::Display for Qusbcfg {
+    fn fmt(&self, fmt: &mut std::fmt::Formatter) -> std::fmt::Result {
+        fmt.write_str(&format!(
+            "AT+QCFG=\"usbcfg\",{:#X},{:#X},{},{},{},{},{},{},{}",
+            self.vendor_id,
+            self.product_id,
+            self.diag,
+            self.nmea,
+            self.at,
+            self.modem,
+            self.net,
+            self.adb,
+            self.audio
+        ))?;
+        Ok(())
+    }
+}
+
+/// Start the adb daemon on the Quectel modem.
+/// A reimplementation of qadbkey-unlock.c by "igem, 2019 ;)"
+pub async fn start_adb() -> Result<()> {
+    let tty = serial_interface()?.unwrap();
+
+    let get_qadbkey = tty
+        .send_at_command("AT+QADBKEY?")
+        .await
+        .context("Failed to request QADBKEY")?;
+    let resp = String::from_utf8_lossy(&get_qadbkey);
+    if !resp.contains("\r\nOK\r\n") {
+        bail!("Received unexpected response: {0}", resp);
+    }
+    let salt = match resp.find("+QADBKEY: ") {
+        Some(i) => &resp[i + 10..i + 18],
+        None => bail!("Received unexpected response: {0}", resp),
+    };
+
+    let hashed = &md5crypt(b"SH_adb_quectel", salt.as_bytes())[12..28];
+    let hashed = String::from_utf8_lossy(hashed);
+
+    let unlock = tty
+        .send_at_command(&format!("AT+QADBKEY=\"{hashed}\""))
+        .await
+        .context("Failed to send AT+QADBKEY")?;
+    let resp = String::from_utf8_lossy(&unlock);
+    if !resp.contains("\r\nOK\r\n") {
+        bail!("Received unexpected response: {0}", resp);
+    }
+
+    let adb_enable = Qusbcfg {
+        adb: 1,
+        ..Default::default()
+    };
+    let start_adb = tty
+        .send_at_command(&adb_enable.to_string())
+        .await
+        .context("Failed to send enable adb command.")?;
+    let resp = String::from_utf8_lossy(&start_adb);
+    if !resp.contains("\r\nOK\r\n") {
+        bail!("Received unexpected response: {0}", resp);
+    }
+
+    Ok(())
+}
+
+/// Stop the adb daemon on the Quectel modem.
+pub async fn stop_adb() -> Result<()> {
+    let tty = serial_interface()?.unwrap();
+    let adb_disable = Qusbcfg::default();
+    let stop_adb = tty
+        .send_at_command(&adb_disable.to_string())
+        .await
+        .context("Failed to disable adb.")?;
+    let resp = String::from_utf8_lossy(&stop_adb);
+    if !resp.contains("\r\nOK\r\n") {
+        bail!("Received unexpected response: {0}", resp);
+    }
+    Ok(())
+}
+
+trait Install {
+    fn run_command(&mut self, command: &[&str], expected_output: &str) -> Result<()>;
+    fn install_file(&mut self, dest: &str, payload: &[u8]) -> Result<()>;
+}
+
+impl Install for ADBUSBDevice {
+    /// Run an adb shell command, append '; echo exit code $?' to the command and verify its output.
+    fn run_command(&mut self, command: &[&str], expected_output: &str) -> Result<()> {
+        let mut buf = Vec::<u8>::new();
+        let mut cmd = Vec::<&str>::new();
+        cmd.extend_from_slice(command);
+        cmd.extend_from_slice(&[";", "echo", "exit code $?"]);
+        self.shell_command(&cmd, &mut buf)?;
+        let output = String::from_utf8_lossy(&buf);
+        if !output.contains(expected_output) {
+            bail!("{expected_output:?} not found in: {output}");
+        }
+        Ok(())
+    }
+
+    /// Transfer a file to the modem's filesystem with adb push.
+    /// Validates the file sends successfully to /tmp before overwriting the destination.
+    fn install_file(&mut self, dest: &str, mut payload: &[u8]) -> Result<()> {
+        echo!("Sending file {dest} ... ");
+        let file_name = Path::new(dest)
+            .file_name()
+            .ok_or_else(|| anyhow!("{dest} does not have a file name"))?
+            .to_str()
+            .ok_or_else(|| anyhow!("{dest}'s file name is not UTF8"))?
+            .to_owned();
+        let push_tmp_path = format!("/tmp/{file_name}");
+        let file_hash = md5_compute(payload);
+        self.push(&mut payload, &push_tmp_path)?;
+        self.run_command(&["md5sum", &push_tmp_path], &format!("{file_hash:x}"))?;
+        self.run_command(&["mv", &push_tmp_path, dest], "exit code 0")?;
+        println!("ok");
+        Ok(())
+    }
+}
+
+/// Claim the modem's USB interface for sending AT commands.
+fn serial_interface() -> Result<Option<Interface>> {
+    if let Some(device) = open_usb_device(USB_VENDOR_ID, USB_PRODUCT_ID)? {
+        let interface = device
+            .detach_and_claim_interface(USB_INTERFACE_NUMBER)
+            .context("detach_and_claim_interface({USB_INTERFACE_NUMBER}) failed")?;
+        return Ok(Some(interface));
+    }
+    Ok(None)
+}
+
+trait AT {
+    async fn send_at_command(&self, command: &str) -> Result<Vec<u8>>;
+}
+
+impl AT for Interface {
+    /// Send an AT command to the Quectel modem.
+    async fn send_at_command(&self, command: &str) -> Result<Vec<u8>> {
+        let mut data = String::new();
+        data.push_str("\r\n");
+        data.push_str(command);
+        data.push_str("\r\n");
+
+        let timeout = Duration::from_secs(1);
+
+        let enable_serial_port = Control {
+            control_type: ControlType::Class,
+            recipient: Recipient::Interface,
+            request: 0x22,
+            value: 3,
+            index: USB_INTERFACE_NUMBER as u16,
+        };
+
+        self.control_out_blocking(enable_serial_port, &[], timeout)
+            .context("Failed to send control request")?;
+
+        tokio::time::timeout(timeout, self.bulk_out(0x3, data.as_bytes().to_vec()))
+            .await
+            .context("Timed out writing command")?
+            .into_result()
+            .context("Failed to write command")?;
+
+        let response = tokio::time::timeout(timeout, self.bulk_in(0x84, RequestBuffer::new(256)))
+            .await
+            .context("Timed out reading response")?
+            .into_result()
+            .context("Failed to read response")?;
+
+        Ok(response)
+    }
+}
+
+#[test]
+fn test_qadbcfg_fmt() {
+    assert_eq!(
+        Qusbcfg::default().to_string(),
+        "AT+QCFG=\"usbcfg\",0x2C7C,0x125,1,1,1,1,1,0,0"
+    );
+}

--- a/lib/src/lib.rs
+++ b/lib/src/lib.rs
@@ -24,4 +24,5 @@ pub enum Device {
     Tplink,
     Tmobile,
     Wingtech,
+    Pinephone,
 }


### PR DESCRIPTION
I have tested this on the PinePhone 1.2 and PinePhone Pro successfully. Both contain the exact same modem with the exact same product ID. From the pine64 website, all of the PinePhone revisions (1.0, 1.1, &c) use the same modem, so this should work for all PinePhone products.

One of the big advantages to this is the device supports GNSS, making this a good choice for casual wardriving.