### PR TITLE
doc: add how to disable wifi entirely to the faq

### DIFF
--- a/doc/faq.md
+++ b/doc/faq.md
@@ -37,3 +37,20 @@ installer util shell reboot
 ```
 
 See `/data/usb/boot_hsusb_composition` for a list of USB modes and Android USB gadget settings.
+
+
+### How do I disable the WiFi hotspot on the Orbic RC400L?
+
+To disable both WiFi bands:
+
+```sh
+adb shell
+/bin/rootshell -c "sed -i 's/<wlan><Feature><state>1<\/state>/<wlan><Feature><state>0<\/state>/g' /usrdata/data/usr/wlan/wlan_conf_6174.xml && reboot"
+```
+
+To re-enable WiFi:
+
+```sh
+adb shell
+/bin/rootshell -c "sed -i 's/<wlan><Feature><state>0<\/state>/<wlan><Feature><state>1<\/state>/g' /usrdata/data/usr/wlan/wlan_conf_6174.xml && reboot"
+```


### PR DESCRIPTION
Fixes #234

This is assuming we don't want to wrap this functionality into a `util` command or the daemon. I feel like it's not necessary functionality to implement, so I'm in favour of just keeping the commands in the FAQ.