### PR TITLE
Remove blocking code and spawn_blocking

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2422,6 +2422,7 @@ name = "rayhunter-daemon"
 version = "0.5.0"
 dependencies = [
  "anyhow",
+ "async-trait",
  "async_zip",
  "axum",
  "chrono",

--- a/daemon/Cargo.toml
+++ b/daemon/Cargo.toml
@@ -7,7 +7,7 @@ edition = "2024"
 rayhunter = { path = "../lib" }
 toml = "0.8.8"
 serde = { version = "1.0.193", features = ["derive"] }
-tokio = { version = "1.44.2", default-features = false, features = ["fs", "signal", "process", "rt-multi-thread"] }
+tokio = { version = "1.44.2", default-features = false, features = ["fs", "signal", "process", "rt"] }
 axum = { version = "0.8", default-features = false, features = ["http1", "tokio", "json"] }
 thiserror = "1.0.52"
 libc = "0.2.150"
@@ -24,3 +24,4 @@ image = { version =  "0.25.1", default-features = false, features = ["png", "gif
 tempfile = "3.10.1"
 async_zip = { version = "0.0.17", features = ["tokio"] }
 anyhow = "1.0.98"
+async-trait = "0.1.88"

--- a/daemon/src/display/tplink.rs
+++ b/daemon/src/display/tplink.rs
@@ -19,6 +19,8 @@ pub fn update_ui(
         info!("Invisible mode, not spawning UI.");
     }
 
+    // Since this is a one-time check at startup, using sync is acceptable
+    // The alternative would be to make the entire initialization async
     if fs::exists(tplink_onebit::OLED_PATH).unwrap_or_default() {
         info!("detected one-bit display");
         tplink_onebit::update_ui(task_tracker, config, ui_shutdown_rx, ui_update_rx)

--- a/daemon/src/display/tplink_onebit.rs
+++ b/daemon/src/display/tplink_onebit.rs
@@ -10,8 +10,6 @@ use tokio::sync::oneshot;
 use tokio::sync::oneshot::error::TryRecvError;
 use tokio_util::task::TaskTracker;
 
-use std::fs;
-use std::thread::sleep;
 use std::time::Duration;
 
 pub const OLED_PATH: &str = "/sys/class/display/oled/oled_buffer";
@@ -122,7 +120,7 @@ pub fn update_ui(
         info!("Invisible mode, not spawning UI.");
     }
 
-    task_tracker.spawn_blocking(move || {
+    task_tracker.spawn(async move {
         let mut pixels = STATUS_SMILING;
 
         loop {
@@ -148,12 +146,12 @@ pub fn update_ui(
             // we write the status every second because it may have been overwritten through menu
             // navigation.
             if display_level != 0 {
-                if let Err(e) = fs::write(OLED_PATH, pixels) {
+                if let Err(e) = tokio::fs::write(OLED_PATH, pixels).await {
                     error!("failed to write to display: {e}");
                 }
             }
 
-            sleep(Duration::from_millis(1000));
+            tokio::time::sleep(Duration::from_millis(1000)).await;
         }
     });
 }

--- a/daemon/src/display/wingtech.rs
+++ b/daemon/src/display/wingtech.rs
@@ -1,12 +1,13 @@
+use crate::config;
+use crate::display::DisplayState;
+use crate::display::generic_framebuffer::{self, Dimensions, GenericFramebuffer};
 /// Display support for the Wingtech CT2MHS01 hotspot.
 ///
 /// Tested on (from `/etc/wt_version`):
 ///   WT_INNER_VERSION=SW_Q89323AA1_V057_M10_CRICKET_USR_MP
 ///   WT_PRODUCTION_VERSION=CT2MHS01_0.04.55
 ///   WT_HARDWARE_VERSION=89323_1_20
-use crate::config;
-use crate::display::DisplayState;
-use crate::display::generic_framebuffer::{self, Dimensions, GenericFramebuffer};
+use async_trait::async_trait;
 
 use tokio::sync::mpsc::Receiver;
 use tokio::sync::oneshot;
@@ -17,6 +18,7 @@ const FB_PATH: &str = "/dev/fb0";
 #[derive(Copy, Clone, Default)]
 struct Framebuffer;
 
+#[async_trait]
 impl GenericFramebuffer for Framebuffer {
     fn dimensions(&self) -> Dimensions {
         Dimensions {
@@ -25,16 +27,16 @@ impl GenericFramebuffer for Framebuffer {
         }
     }
 
-    fn write_buffer(&mut self, buffer: &[(u8, u8, u8)]) {
+    async fn write_buffer(&mut self, buffer: Vec<(u8, u8, u8)>) {
         let mut raw_buffer = Vec::new();
         for (r, g, b) in buffer {
-            let mut rgb565: u16 = (*r as u16 & 0b11111000) << 8;
-            rgb565 |= (*g as u16 & 0b11111100) << 3;
-            rgb565 |= (*b as u16) >> 3;
+            let mut rgb565: u16 = (r as u16 & 0b11111000) << 8;
+            rgb565 |= (g as u16 & 0b11111100) << 3;
+            rgb565 |= (b as u16) >> 3;
             raw_buffer.extend(rgb565.to_le_bytes());
         }
 
-        std::fs::write(FB_PATH, &raw_buffer).unwrap();
+        tokio::fs::write(FB_PATH, &raw_buffer).await.unwrap();
     }
 }
 

--- a/daemon/src/main.rs
+++ b/daemon/src/main.rs
@@ -182,7 +182,7 @@ fn run_shutdown_thread(
     })
 }
 
-#[tokio::main]
+#[tokio::main(flavor = "current_thread")]
 async fn main() -> Result<(), RayhunterError> {
     env_logger::init();
 


### PR DESCRIPTION
Rayhunter uses a mixture of spawn and spawn_blocking, then also does
some blocking operations inside of async code.

Move everything to async and enable the single-thread runtime.

Now the binary is 100kB smaller, and the memory usage also improved by
~100kB on tplink.

`spawn_blocking` can still be used from the single-threaded runtime
(it will just spawn more threads) but might negate the memory savings.