### PR TITLE
Add firmware-devel profile to cargo config

### DIFF
--- a/.cargo/config.toml
+++ b/.cargo/config.toml
@@ -36,6 +36,11 @@ lto = "fat"
 opt-level = "z"
 strip = "debuginfo"
 
+[profile.firmware-devel]
+inherits = "release"
+opt-level = "s"
+lto = false
+
 # optimizations to reduce the binary size of firmware binaries
 [profile.firmware]
 inherits = "release"


### PR DESCRIPTION
This speeds up compile time in exchange for binary size, which is often a worthy trade-off in development when iteration speed matters.

This is mostly for my own convenience.

## Pull Request Checklist

- [ ] The Rayhunter team has recently expressed interest in reviewing a PR for this. If not, this PR may be closed due our limited resources and need to prioritize how we spend them.
- [ ] Added or updated any documentation as needed to support the changes in this PR.
- [ ] Code has been linted and run through `cargo fmt`
- [ ] If any new functionality has been added, unit tests were also added
