### PR TITLE
wingtech: install without disabling wifi

### DIFF
--- a/doc/wingtech-ct2mhs01.md
+++ b/doc/wingtech-ct2mhs01.md
@@ -67,3 +67,38 @@ WT_HARDWARE_VERSION=89323_1_20
 ```
 
 Please consider sharing the contents of your device's /etc/wt_version file here.
+
+## Troubleshooting
+
+### My hotspot won't turn on after rebooting when installing over WiFi
+
+Reinsert the battery and turn the device back on, Rayhunter should be installed and running. Sometimes the Wingtech hotspot gets stuck off and ignores the power button after a reboot until the battery is reseated.
+
+You do not need to run the installer again.
+
+You'll likely see the following messages, where the installer is stuck at `Testing rayhunter ... `.
+
+```sh
+Starting telnet ... ok
+Connecting via telnet to 192.168.1.1 ... ok
+Sending file /data/rayhunter/config.toml ... ok
+Sending file /data/rayhunter/rayhunter-daemon ... ok
+Sending file /etc/init.d/rayhunter_daemon ... ok
+Rebooting device and waiting 30 seconds for it to start up.
+Testing rayhunter ...
+```
+
+If you eventually see:
+
+```sh
+Testing rayhunter ...
+Failed to install rayhunter on the Wingtech CT2MHS01
+
+Caused by:
+    0: error sending request for url (http://192.168.1.1:8080/index.html)
+    1: client error (Connect)
+    2: tcp connect error: Network is unreachable (os error 101)
+    3: Network is unreachable (os error 101)
+```
+
+Make sure your computer is connected to the hotspot's wifi network.

--- a/installer/src/wingtech.rs
+++ b/installer/src/wingtech.rs
@@ -75,7 +75,7 @@ pub async fn run_command(admin_ip: &str, admin_password: &str, cmd: &str) -> Res
         .context("login did not return a token in response")?;
 
     let command = client.post(&qcmap_web_cgi_endpoint)
-        .body(format!("page=setFWMacFilter&cmd=add&mode=0&mac=50:5A:CA:B5:05||{cmd}&key=50:5A:CA:B5:05:AC&token={token}"))
+        .body(format!("page=setFWMacFilter&cmd=del&mode=0&mac=50:5A:CA:B5:05||{cmd}&key=50:5A:CA:B5:05:AC&token={token}"))
         .send()
         .await?;
     if command.status() != 200 {
@@ -135,7 +135,7 @@ async fn wingtech_run_install(admin_ip: String, admin_password: String) -> Resul
     telnet_send_command(addr, "update-rc.d rayhunter_daemon defaults", "exit code 0").await?;
 
     println!("Rebooting device and waiting 30 seconds for it to start up.");
-    telnet_send_command(addr, "reboot", "exit code 0").await?;
+    telnet_send_command(addr, "shutdown -r -t 1 now", "exit code 0").await?;
     sleep(Duration::from_secs(30)).await;
 
     echo!("Testing rayhunter ... ");


### PR DESCRIPTION
Previously, the unlocking method for the wingtech hotspot would add a invalid mac address to the blocklist. This would prevent the wifi from coming online after rebooting until the invalid mac was removed.

This commit changes the unlocking method to attempt to *remove* an invalid mac, creating a no-op condition that still works for unlocking root access to the hotspot.

This commit also adds documentation for a problem where the hotspot would occasionally not reboot while completely disconnected and installing over wifi.

Fixes #466