### PR TITLE
Speed up file transfer for network-based installers

### DIFF
--- a/installer/src/util.rs
+++ b/installer/src/util.rs
@@ -71,8 +71,13 @@ pub async fn telnet_send_file(addr: SocketAddr, filename: &str, payload: &[u8]) 
         sleep(Duration::from_millis(100)).await;
         let mut addr = addr;
         addr.set_port(8081);
-        let mut stream = TcpStream::connect(addr).await?;
-        stream.write_all(payload).await?;
+
+        {
+            let mut stream = TcpStream::connect(addr).await?;
+            stream.write_all(payload).await?;
+            // ensure that stream is dropped before we wait for nc to terminate!
+        }
+
         handle.await??;
     }
     let checksum = md5::compute(payload);


### PR DESCRIPTION
There is a bug in `telnet_send_file` where we never close the connection
to nc, and instead wait for it to time out.

This means every file transfer takes at least 5 seconds.
