### PR TITLE
Skip updating web UI when browser tab isn't visible

### DIFF
--- a/daemon/web/src/routes/+page.svelte
+++ b/daemon/web/src/routes/+page.svelte
@@ -20,6 +20,11 @@
     $effect(() => {
         const interval = setInterval(async () => {
             try {
+                // Don't update UI if browser tab isn't visible
+                if (document.hidden) {
+                    return;
+                }
+
                 await manager.update();
                 let new_manifest = await get_manifest();
                 await new_manifest.set_analysis_status(manager);


### PR DESCRIPTION
This will save bandwith and battery on the hotspot in cases where the UI tab is left open. See #564.
