### PR TITLE
Hide error count in error toast if there is only 1 error

### DIFF
--- a/daemon/web/src/lib/components/ActionErrors.svelte
+++ b/daemon/web/src/lib/components/ActionErrors.svelte
@@ -43,29 +43,43 @@
                 Error Completing Action {current_error.times > 1 ? `x${current_error.times}` : ''}
             </span>
             <div class="flex items-center mb-2">
-                <span>{pos + 1}/{action_errors.length}</span>
-                <button title="previous error" aria-label="previous error" onclick={prev_error}>
-                    <svg aria-hidden="true" width="24" height="24" fill="none" viewBox="0 0 24 24">
-                        <path
-                            stroke="currentColor"
-                            stroke-linecap="round"
-                            stroke-linejoin="round"
-                            stroke-width="2"
-                            d="m 15.499979,19.499979 -6.9999997,-7 6.9999997,-6.9999997"
-                        />
-                    </svg>
-                </button>
-                <button title="next error" aria-label="next error" onclick={next_error}>
-                    <svg aria-hidden="true" width="24" height="24" fill="none" viewBox="0 0 24 24">
-                        <path
-                            stroke="currentColor"
-                            stroke-linecap="round"
-                            stroke-linejoin="round"
-                            stroke-width="2"
-                            d="m 8.5000207,5.4999793 7.0000003,6.9999997 -7.0000003,7"
-                        />
-                    </svg>
-                </button>
+                {#if action_errors.length > 1}
+                    <span>{pos + 1}/{action_errors.length}</span>
+                    <button title="previous error" aria-label="previous error" onclick={prev_error}>
+                        <svg
+                            aria-hidden="true"
+                            width="24"
+                            height="24"
+                            fill="none"
+                            viewBox="0 0 24 24"
+                        >
+                            <path
+                                stroke="currentColor"
+                                stroke-linecap="round"
+                                stroke-linejoin="round"
+                                stroke-width="2"
+                                d="m 15.499979,19.499979 -6.9999997,-7 6.9999997,-6.9999997"
+                            />
+                        </svg>
+                    </button>
+                    <button title="next error" aria-label="next error" onclick={next_error}>
+                        <svg
+                            aria-hidden="true"
+                            width="24"
+                            height="24"
+                            fill="none"
+                            viewBox="0 0 24 24"
+                        >
+                            <path
+                                stroke="currentColor"
+                                stroke-linecap="round"
+                                stroke-linejoin="round"
+                                stroke-width="2"
+                                d="m 8.5000207,5.4999793 7.0000003,6.9999997 -7.0000003,7"
+                            />
+                        </svg>
+                    </button>
+                {/if}
                 <button title="clear errors" aria-label="clear errors" onclick={clear_errors}>
                     <svg style="width:24px;height:24px" viewBox="0 0 24 24">
                         <path


### PR DESCRIPTION
It's a little silly to show the 1/1 error count:

<img width="902" height="268" alt="image" src="https://github.com/user-attachments/assets/6ced2810-fada-47c8-a517-09972232d898" />

So we hide it unless there is more than 1 error:

<img width="756" height="270" alt="image" src="https://github.com/user-attachments/assets/3d3e1d10-20b4-42f8-8435-2cfc79757165" />
