### PR TITLE
Always run all builds with -p

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -217,7 +217,7 @@ jobs:
           targets: armv7-unknown-linux-musleabihf
       - uses: Swatinem/rust-cache@v2
       - name: Build rootshell (armv7)
-        run: cargo build --bin rootshell --target armv7-unknown-linux-musleabihf --profile=firmware
+        run: cargo build -p rootshell --bin rootshell --target armv7-unknown-linux-musleabihf --profile=firmware
       - uses: actions/upload-artifact@v4
         with:
           name: rootshell

--- a/doc/installing-from-source.md
+++ b/doc/installing-from-source.md
@@ -38,13 +38,13 @@ Now you can root your device and install Rayhunter by running:
 ```sh
 # Profile can be changed to 'firmware-devel' when building for development.
 # Build time will decrease at the expense of binary size.
-cargo build --bin rayhunter-daemon --target armv7-unknown-linux-musleabihf --profile firmware
+cargo build -p rayhunter-daemon --bin rayhunter-daemon --target armv7-unknown-linux-musleabihf --profile firmware
 
-cargo build --bin rootshell --target armv7-unknown-linux-musleabihf --profile firmware
+cargo build -p rootshell --bin rootshell --target armv7-unknown-linux-musleabihf --profile firmware
 
 # Replace 'orbic' with your device type if different.
-# A list possible values can be found with 'cargo run --bin installer help'.
-cargo run --bin installer orbic
+# A list of possible values can be found with 'cargo run --bin installer help'.
+cargo run -p installer --bin installer orbic
 ```
 
 ### If you're on Windows or can't run the install scripts


### PR DESCRIPTION
Running without -p can confuse cargo to enable the wrong set of
featureflags.

Fix #581
