### PR TITLE
Fix typo in heuristics.md phoen ➜ phone

### DIFF
--- a/doc/heuristics.md
+++ b/doc/heuristics.md
@@ -21,7 +21,7 @@ What we consider suspicious is the following chain of events:
 * Phone connects to a new tower. 
 * Tower asks for phones identity (IMEI or IMSI.)
 * Authentication does *NOT* happen. 
-* Tower requests phoen to disconnect. 
+* Tower requests phone to disconnect. 
 
 Looking for this chain of events is much less prone to false positives than naively looking for any time the IMSI/IMEI is sent. We do still sometimes get false positives when users are in an airplane that is coming in for a landing however. This is likely do to having been disconnected for a while and then being over towers that are not able to route to your home network, but we are still researching.
 


### PR DESCRIPTION
Fix typo in `doc/heuristics.md` `phoen` ➜ `phone`, add missing new line at EOF.

## Pull Request Checklist

- [ ] The Rayhunter team has recently expressed interest in reviewing a PR for this. If not, this PR may be closed due our limited resources and need to prioritize how we spend them.
- [x] Added or updated any documentation as needed to support the changes in this PR.
- [x] Code has been linted and run through `cargo fmt`
- [x] If any new functionality has been added, unit tests were also added
