### PR TITLE
Enhancement: adds UI filter to incoming events

### DIFF
--- a/daemon/web/src/routes/+page.svelte
+++ b/daemon/web/src/routes/+page.svelte
@@ -14,6 +14,7 @@
 
     let manager: AnalysisManager = new AnalysisManager();
     let loaded = $state(false);
+    let filter_threshold: boolean = $state(false);
     let entries: ManifestEntry[] = $state([]);
     let current_entry: ManifestEntry | undefined = $state(undefined);
     let system_stats: SystemStats | undefined = $state(undefined);
@@ -30,7 +31,10 @@
                 await manager.update();
                 let new_manifest = await get_manifest();
                 await new_manifest.set_analysis_status(manager);
-                entries = new_manifest.entries;
+                entries = filter_threshold
+                    ? new_manifest.entries.filter((e) => e.get_num_warnings())
+                    : new_manifest.entries;
+
                 current_entry = new_manifest.current_entry;
 
                 system_stats = await get_system_stats();
@@ -226,7 +230,23 @@
             <SystemStatsTable stats={system_stats!} />
         </div>
         <div class="flex flex-col gap-2">
-            <span class="text-xl">History</span>
+            <div class="flex flex-row gap-2">
+                <div class="text-xl flex-1">History</div>
+                <div class="flex flex-row items-center gap-2 px-3">
+                    <label
+                        for="filter_threshold"
+                        class="block text-md font-medium text-gray-700 mb-1"
+                    >
+                        Filter for Warnings
+                    </label>
+                    <input
+                        type="checkbox"
+                        id="filter_threshold"
+                        bind:checked={filter_threshold}
+                        class="px-3 py-2 border border-gray-300 rounded-md focus:outline-none focus:ring-2 focus:ring-rayhunter-blue"
+                    />
+                </div>
+            </div>
             <ManifestTable {entries} server_is_recording={!!current_entry} {manager} />
         </div>
         <DeleteAllButton />


### PR DESCRIPTION
Addresses an enhancement request from Issue https://github.com/EFForg/rayhunter/issues/400

Adds a simple filter to the UI, bound to a checkbox. Enabling it filters out events with 0 or undefined warning counts. Given how rapidly the UI polls this could be inefficient for very long lists. At that point it'd probably require a slightly more sophisticated update to how events are stored in the UI.

## Pull Request Checklist

- [x] The Rayhunter team has recently expressed interest in reviewing a PR for this. If not, this PR may be closed due our limited resources and need to prioritize how we spend them.
- [x] Added or updated any documentation as needed to support the changes in this PR.
- [x] Code has been linted and run through `cargo fmt`
- [x] If any new functionality has been added, unit tests were also added

<img width="1337" height="573" alt="image" src="https://github.com/user-attachments/assets/df347f56-7b6a-42d2-ab97-4bcae1408d19" />

<img width="402" height="618" alt="image" src="https://github.com/user-attachments/assets/bc03d00f-0345-4ff2-a22d-326052f7e190" />
