### PR TITLE
Don't show scroll bars when no overflow

### DIFF
--- a/daemon/web/src/lib/components/AnalysisTable.svelte
+++ b/daemon/web/src/lib/components/AnalysisTable.svelte
@@ -33,7 +33,7 @@
     {#if report.statistics.num_warnings === 0 && report.statistics.num_informational_logs === 0}
         <p>Nothing to show!</p>
     {:else}
-        <div class="overflow-x-scroll">
+        <div class="overflow-x-auto">
             <table class="table-auto text-left">
                 <thead class="p-2">
                     <tr class="bg-gray-300">
@@ -80,7 +80,7 @@
             These are due to a limitation or bug in Rayhunter's parser, and aren't usually a
             problem.
         </p>
-        <div class="overflow-x-scroll">
+        <div class="overflow-x-auto">
             <table class="table-auto text-left">
                 <thead class="p-2">
                     <tr class="bg-gray-300">

--- a/daemon/web/src/lib/components/ManifestCard.svelte
+++ b/daemon/web/src/lib/components/ManifestCard.svelte
@@ -44,7 +44,7 @@
 </script>
 
 <div
-    class="{status_row_color} {status_border_color} drop-shadow p-4 flex flex-col gap-2 border rounded-md flex-1 overflow-x-scroll overflow-y-hidden"
+    class="{status_row_color} {status_border_color} drop-shadow p-4 flex flex-col gap-2 border rounded-md flex-1 overflow-x-auto overflow-y-hidden"
 >
     {#if current}
         <div class="flex flex-row justify-between gap-2">
@@ -81,7 +81,7 @@
                 'N/A'}</span
         >
     </div>
-    <div class="flex flex-row justify-between lg:justify-end gap-1 mt-2 overflow-x-scroll">
+    <div class="flex flex-row justify-between lg:justify-end gap-1 mt-2 overflow-x-auto">
         <DownloadLink url={entry.get_pcap_url()} text="pcap" full_button />
         <DownloadLink url={entry.get_qmdl_url()} text="qmdl" full_button />
         <DownloadLink url={entry.get_zip_url()} text="zip" full_button />


### PR DESCRIPTION
Fixes a very minor UI issue introduced in #492 where scrollbars would always be shown, at least on Chrome on Linux (Firefox and I think MacOS are better about overriding the setting and hiding them). 

Before:
<img width="930" height="280" alt="image" src="https://github.com/user-attachments/assets/bc96b442-a251-4bd2-9864-51728df7f481" />
After:
<img width="936" height="266" alt="image" src="https://github.com/user-attachments/assets/c1ea0195-36ff-4b32-8c98-ae8dba37ec97" />
