### PR TITLE
installer: Fix TPLink install with --skip-sdcard

### DIFF
--- a/installer/src/tplink.rs
+++ b/installer/src/tplink.rs
@@ -104,7 +104,16 @@ async fn tplink_run_install(
     println!("Connecting via telnet to {admin_ip}");
     let addr = SocketAddr::from_str(&format!("{admin_ip}:23")).unwrap();
 
-    if !skip_sdcard {
+    if skip_sdcard {
+        sdcard_path = "/data/rayhunter-data".to_owned();
+        telnet_send_command(
+            addr,
+            &format!("mkdir -p {sdcard_path}"),
+            "exit code 0",
+            true,
+        )
+        .await?
+    } else {
         if sdcard_path.is_empty() {
             let try_paths = [
                 // TP-Link hardware less than v9.0


### PR DESCRIPTION
Correct the paths used during install to not assume an SDcard is present

## Pull Request Checklist

- [ ] The Rayhunter team has recently expressed interest in reviewing a PR for this. If not, this PR may be closed due our limited resources and need to prioritize how we spend them.
- [x] Added or updated any documentation as needed to support the changes in this PR.
- [x] Code has been linted and run through `cargo fmt`
- [x] If any new functionality has been added, unit tests were also added
