### PR TITLE
suggest using a different usb connection when troubleshooting

### DIFF
--- a/doc/installing-from-release.md
+++ b/doc/installing-from-release.md
@@ -44,6 +44,8 @@ Make sure you've got one of Rayhunter's [supported devices](./supported-devices.
 
 ## Troubleshooting
 
+* If you are having trouble installing Rayhunter and you're connecting to your device over USB, try using a different USB cable to connect the device to your computer. If you are using a USB hub, try using a different one or directly connecting the device to a USB port on your computer. A faulty USB connection can cause the Rayhunter installer to fail.
+
 * You can test your device by enabling the test heuristic. This will be very noisy and fire an alert every time you see a new tower. Be sure to turn it off when you are done testing.  
 
 * On MacOS if you encounter an error that says "No Orbic device found," it may because you have the "Allow accessories to connect" security setting set to "Ask for approval." You may need to temporarily change it to "Always" for the script to run. Make sure to change it back to a more secure setting when you're done.


### PR DESCRIPTION
the first time i tried to install rayhunter, i did it through a usb hub and the installer failed. i then connected the hotspot directly to my computer without the hub and it worked just fine

i brought this up in a meeting at EFF about rayhunter where it was suggested we mention this as a troubleshooting step in case it helps someone else. not all usb devices are created equal and these few sentences could potentially save users from some otherwise painful debugging