### PR TITLE
lld test

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -105,6 +105,8 @@ jobs:
     steps:
     - uses: actions/checkout@v4
     - uses: dtolnay/rust-toolchain@1.89.0
+      with:
+        components: rustfmt, clippy
     - uses: Swatinem/rust-cache@v2
     - name: Check formatting
       run: cargo fmt --all --check


### PR DESCRIPTION
- use older toolchain
- CI: Fix missing components in rust setup

checking if this triggers windows defender, see #624 