### PR TITLE
check: add flag help documentation

### DIFF
--- a/check/src/main.rs
+++ b/check/src/main.rs
@@ -16,19 +16,19 @@ use walkdir::WalkDir;
 #[derive(Parser, Debug)]
 #[command(version, about)]
 struct Args {
-    #[arg(short = 'p', long)]
+    #[arg(short = 'p', long, help = "A file or directory of packet captures")]
     path: PathBuf,
 
-    #[arg(short = 'P', long)]
+    #[arg(short = 'P', long, help = "Convert qmdl files to pcap before analysis")]
     pcapify: bool,
 
-    #[arg(long)]
+    #[arg(long, help = "Show why some packets were skipped during analysis")]
     show_skipped: bool,
 
-    #[arg(short, long)]
+    #[arg(short, long, help = "Only print warnings/errors to stdout")]
     quiet: bool,
 
-    #[arg(short, long)]
+    #[arg(short, long, help = "Show debug messages")]
     debug: bool,
 }
 


### PR DESCRIPTION
## Pull Request Checklist

- [x] The Rayhunter team has recently expressed interest in reviewing a PR for this. If not, this PR may be closed due our limited resources and need to prioritize how we spend them.
  - _Response: not directly but supports a subsequent PR._
- [x] Added or updated any documentation as needed to support the changes in this PR.
- [x] Code has been linted and run through `cargo fmt`
- [x] If any new functionality has been added, unit tests were also added
- [x] [./CONTRIBUTING.md](../CONTRIBUTING.md) has been read

## Problem

The rayhunter check `-p|--path` flag accepts both a path as well as a directory of captures, but this isn't immediately apparent. A subsequent pull request building on this didn't account for this functionality; others may not realize that this multi-file feature is available.

More broadly, the check command flags aren't documented so the behavior of some flags aren't immediately obvious.

## Solution

Document check command help flags.
