### PR TITLE
update installer-gui version to 0.8.0

### DIFF
--- a/installer-gui/src-tauri/Cargo.toml
+++ b/installer-gui/src-tauri/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "installer-gui"
-version = "0.7.1"
+version = "0.8.0"
 edition = "2024"
 
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html


### PR DESCRIPTION
we released 0.8.0 between when https://github.com/EFForg/rayhunter/pull/687 was opened and it was merged. this just updates cargo.toml to be in step with the other packages in the repo