### PR TITLE
run `zizmor --fix=all .`

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -31,13 +31,14 @@ jobs:
       - uses: actions/checkout@v4
         with:
           fetch-depth: 0
+          persist-credentials: false
       - name: detect file changes
         id: files_changed
         run: |
           lcommit=${{ github.event.pull_request.base.sha || 'origin/main' }}
 
           # If we are on main, or if these workflow files are being changed, run everything
-          if [ ${{ github.ref }} = 'refs/heads/main' ] || git diff --name-only $lcommit..HEAD | grep -qe ^.github/workflows/ -e ^.cargo
+          if [ ${GITHUB_REF} = 'refs/heads/main' ] || git diff --name-only $lcommit..HEAD | grep -qe ^.github/workflows/ -e ^.cargo
           then
             echo "building everything"
             echo code_count=forced >> "$GITHUB_OUTPUT"
@@ -66,6 +67,8 @@ jobs:
       contents: read
     steps:
       - uses: actions/checkout@v4
+        with:
+          persist-credentials: false
       - name: Install mdBook
         run: |
           cargo install mdbook --no-default-features --features search --vers "^0.4" --locked
@@ -83,6 +86,8 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
+        with:
+          persist-credentials: false
       - name: Install mdBook
         run: |
           cargo install mdbook --no-default-features --features search --vers "^0.4" --locked
@@ -107,6 +112,8 @@ jobs:
       contents: read
     steps:
     - uses: actions/checkout@v4
+      with:
+        persist-credentials: false
     - uses: dtolnay/rust-toolchain@stable
       with:
         components: rustfmt, clippy
@@ -141,6 +148,8 @@ jobs:
       contents: read
     steps:
     - uses: actions/checkout@v4
+      with:
+        persist-credentials: false
     - uses: dtolnay/rust-toolchain@stable
       with:
         components: clippy
@@ -164,6 +173,8 @@ jobs:
         working-directory: daemon/web
     steps:
       - uses: actions/checkout@v4
+        with:
+          persist-credentials: false
       - run: npm install
       - run: npm run lint
       - run: npm run check
@@ -180,6 +191,8 @@ jobs:
         working-directory: installer-gui
     steps:
       - uses: actions/checkout@v4
+        with:
+          persist-credentials: false
       - run: npm install
       - run: npm run lint
       - run: npm run check
@@ -192,6 +205,8 @@ jobs:
       contents: read
     steps:
       - uses: actions/checkout@v4
+        with:
+          persist-credentials: false
       - uses: Swatinem/rust-cache@v2
       - name: cargo check
         shell: bash
@@ -236,6 +251,8 @@ jobs:
     runs-on: ${{ matrix.platform.os }}
     steps:
       - uses: actions/checkout@v4
+        with:
+          persist-credentials: false
       - uses: dtolnay/rust-toolchain@stable
         with:
           targets: ${{ matrix.platform.target }}
@@ -258,6 +275,8 @@ jobs:
       contents: read
     steps:
       - uses: actions/checkout@v4
+        with:
+          persist-credentials: false
       - uses: dtolnay/rust-toolchain@stable
         with:
           targets: armv7-unknown-linux-musleabihf
@@ -284,6 +303,8 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
+        with:
+          persist-credentials: false
       - uses: dtolnay/rust-toolchain@stable
         with:
           targets: armv7-unknown-linux-musleabihf
@@ -345,6 +366,8 @@ jobs:
     runs-on: ${{ matrix.platform.os }}
     steps:
       - uses: actions/checkout@v4
+        with:
+          persist-credentials: false
       - uses: actions/download-artifact@v4
       - uses: dtolnay/rust-toolchain@stable
         with:
@@ -382,6 +405,8 @@ jobs:
     runs-on: ${{ matrix.platform.os }}
     steps:
       - uses: actions/checkout@v4
+        with:
+          persist-credentials: false
       - uses: actions/download-artifact@v4
       - uses: dtolnay/rust-toolchain@stable
         with:
@@ -432,6 +457,8 @@ jobs:
     runs-on: macos-latest
     steps:
       - uses: actions/checkout@v4
+        with:
+          persist-credentials: false
       - uses: actions/download-artifact@v4
       - uses: dtolnay/rust-toolchain@stable
         with:
@@ -468,6 +495,8 @@ jobs:
     runs-on: windows-latest
     steps:
       - uses: actions/checkout@v4
+        with:
+          persist-credentials: false
       - uses: actions/download-artifact@v4
       - uses: dtolnay/rust-toolchain@stable
         with:
@@ -511,6 +540,8 @@ jobs:
           - windows-x86_64
     steps:
       - uses: actions/checkout@v4
+        with:
+          persist-credentials: false
       - uses: actions/download-artifact@v4
       - name: Fix executable permissions on binaries
         run: chmod +x installer-*/installer rayhunter-check-*/rayhunter-check rayhunter-daemon/rayhunter-daemon
@@ -520,7 +551,7 @@ jobs:
       - name: Setup versioned release directory
         run: |
           platform="${{ matrix.platform }}"
-          dest="rayhunter-v${{ env.VERSION }}-${{ matrix.platform }}"
+          dest="rayhunter-v${VERSION}-${{ matrix.platform }}"
           mkdir "$dest"
           # Handle installer with proper extension for Windows
           if [ "$platform" = "windows-x86_64" ]; then

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -14,6 +14,8 @@ jobs:
       contents: read
     steps:
       - uses: actions/checkout@v4
+        with:
+          persist-credentials: false
       - name: Ensure all Cargo.toml files have the same version defined.
         run: |
           defined_versions=$(find lib check daemon installer installer-gui rootshell telcom-parser -name Cargo.toml -exec grep ^version {} \; | sort -u | wc -l)
@@ -41,6 +43,8 @@ jobs:
       contents: write
     steps:
       - uses: actions/checkout@v4
+        with:
+          persist-credentials: false
       - uses: actions/download-artifact@v4
       - name: Create release
         run: |


### PR DESCRIPTION
as part of certbot development at EFF we recently started playing with [zizmor](https://github.com/zizmorcore/zizmor) to find potential security problems in our github actions setup

after we did that, someone happened to run zizmor against the rayhunter repo and it found a few things which i am fixing here. i don't think any of them are a big deal, but i think not persisting git credentials when we don't need them and using normal bash variable expansion rather than the github actions template expansions that have resulted in shell injection attacks is a mild improvement

you can see github actions running successfully on my fork with these changes at https://github.com/bmw/rayhunter/actions/runs/19590757556