### PR TITLE
Clarify which password to use on Orbic

### DIFF
--- a/doc/installing-from-release.md
+++ b/doc/installing-from-release.md
@@ -48,7 +48,7 @@ Make sure you've got one of Rayhunter's [supported devices](./supported-devices.
    ./installer tplink
    ```
 
-   * On Verizon Orbic, the password is the WiFi password.
+   * On Verizon Orbic, the password is the 2.4 GHz WiFi password.
    * On Kajeet/Smartspot devices, the default password is `$m@rt$p0tc0nf!g`
    * On Moxee-brand devices, check under the battery for the password.
    * You can reset the password by pressing the button under the back case until the unit restarts.


### PR DESCRIPTION
I only use the 5 GHz network and have customized its password. Authentication using that password via `--admin-password` failed, but the 2.4 GHz network’s password was accepted.

## Pull Request Checklist

- [ ] The Rayhunter team has recently expressed interest in reviewing a PR for this. If not, this PR may be closed due our limited resources and need to prioritize how we spend them.
- [ ] Added or updated any documentation as needed to support the changes in this PR.
- [ ] Code has been linted and run through `cargo fmt`
- [ ] If any new functionality has been added, unit tests were also added
- [x] [./CONTRIBUTING.md](../CONTRIBUTING.md) has been read
