### PR TITLE
Fix Message parser crashes found by fuzzing

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2730,7 +2730,7 @@ dependencies = [
 
 [[package]]
 name = "installer-gui"
-version = "0.7.1"
+version = "0.8.0"
 dependencies = [
  "anyhow",
  "installer",


### PR DESCRIPTION
These payloads would previous cause panic on underflow.

The fuzzing setup lives in
https://github.com/untitaker/rayhunter/tree/fuzz-wip -- I can eventually
upstream it though right now it runs very inefficiently.
