### PR TITLE
Add mount logs to rayhunter installer

### DIFF
--- a/installer/src/tplink.rs
+++ b/installer/src/tplink.rs
@@ -379,7 +379,9 @@ fn get_rayhunter_daemon(sdcard_path: &str) -> String {
     // specific to a particular hardware revision here.
     crate::RAYHUNTER_DAEMON_INIT.replace(
         "#RAYHUNTER-PRESTART",
-        &format!("mount /dev/mmcblk0p1 {sdcard_path} || true"),
+        &format!(
+            "(mount /dev/mmcblk0p1 {sdcard_path} || true) 2>&1 | tee /tmp/rayhunter-mount.log"
+        ),
     )
 }
 


### PR DESCRIPTION
We sometimes, but rarely, get bug reports where the sdcard fails
mounting. Write a dedicated log file for the mounting action to /tmp,
separately from the rayhunter logfile that is on the sdcard itself. That
log file is probably going to be small so it can fit in /tmp.
