### PR TITLE
Do not overwrite configs by default

### DIFF
--- a/installer/src/connection.rs
+++ b/installer/src/connection.rs
@@ -1,0 +1,68 @@
+use std::future::Future;
+use std::net::SocketAddr;
+
+use anyhow::Result;
+
+use crate::output::println;
+
+/// Abstraction for device communication (telnet or ADB)
+pub trait DeviceConnection {
+    /// Run a shell command and return its output
+    fn run_command(&mut self, command: &str) -> impl Future<Output = Result<String>> + Send;
+
+    /// Write a file to the device
+    fn write_file(&mut self, path: &str, content: &[u8])
+    -> impl Future<Output = Result<()>> + Send;
+}
+
+/// Check if a file exists using a DeviceConnection
+pub async fn file_exists<C: DeviceConnection>(conn: &mut C, path: &str) -> bool {
+    conn.run_command(&format!("test -f {path} && echo exists || echo missing"))
+        .await
+        .map(|output| output.contains("exists"))
+        .unwrap_or(false)
+}
+
+/// Shared config installation logic
+pub async fn install_config<C: DeviceConnection>(
+    conn: &mut C,
+    config_path: &str,
+    device_type: &str,
+    reset_config: bool,
+) -> Result<()> {
+    if reset_config || !file_exists(conn, config_path).await {
+        let config = crate::CONFIG_TOML.replace(
+            r#"#device = "orbic""#,
+            &format!(r#"device = "{device_type}""#),
+        );
+        conn.write_file(config_path, config.as_bytes()).await?;
+    } else {
+        println!("Config file already exists, skipping (use --reset-config to overwrite)");
+    }
+    Ok(())
+}
+
+/// Telnet-based connection wrapper
+pub struct TelnetConnection {
+    pub addr: SocketAddr,
+    pub wait_for_prompt: bool,
+}
+
+impl TelnetConnection {
+    pub fn new(addr: SocketAddr, wait_for_prompt: bool) -> Self {
+        Self {
+            addr,
+            wait_for_prompt,
+        }
+    }
+}
+
+impl DeviceConnection for TelnetConnection {
+    async fn run_command(&mut self, command: &str) -> Result<String> {
+        crate::util::telnet_send_command_with_output(self.addr, command, self.wait_for_prompt).await
+    }
+
+    async fn write_file(&mut self, path: &str, content: &[u8]) -> Result<()> {
+        crate::util::telnet_send_file(self.addr, path, content, self.wait_for_prompt).await
+    }
+}

--- a/installer/src/lib.rs
+++ b/installer/src/lib.rs
@@ -5,6 +5,7 @@ use env_logger::Env;
 #[cfg(not(target_os = "android"))]
 use anyhow::bail;
 
+mod connection;
 #[cfg(not(target_os = "android"))]
 mod orbic;
 mod orbic_auth;
@@ -79,10 +80,18 @@ struct InstallTpLink {
     /// your custom path may conflict with the builtin storage functionality.
     #[arg(long, default_value = "")]
     sdcard_path: String,
+
+    /// Overwrite config.toml even if it already exists on the device.
+    #[arg(long)]
+    reset_config: bool,
 }
 
 #[derive(Parser, Debug)]
-struct InstallOrbic {}
+struct InstallOrbic {
+    /// Overwrite config.toml even if it already exists on the device.
+    #[arg(long)]
+    reset_config: bool,
+}
 
 #[derive(Parser, Debug)]
 struct OrbicNetworkArgs {
@@ -97,6 +106,10 @@ struct OrbicNetworkArgs {
     /// Admin password for authentication.
     #[arg(long)]
     admin_password: Option<String>,
+
+    /// Overwrite config.toml even if it already exists on the device.
+    #[arg(long)]
+    reset_config: bool,
 }
 
 #[derive(Parser, Debug)]
@@ -231,8 +244,8 @@ async fn run(args: Args) -> Result<(), Error> {
         Command::Pinephone(_) => pinephone::install().await
             .context("Failed to install rayhunter on the Pinephone's Quectel modem")?,
         #[cfg(not(target_os = "android"))]
-        Command::OrbicUsb(_) => orbic::install().await.context("\nFailed to install rayhunter on the Orbic RC400L (USB installer)")?,
-        Command::Orbic(args) => orbic_network::install(args.admin_ip, args.admin_username, args.admin_password).await.context("\nFailed to install rayhunter on the Orbic RC400L")?,
+        Command::OrbicUsb(args) => orbic::install(args.reset_config).await.context("\nFailed to install rayhunter on the Orbic RC400L (USB installer)")?,
+        Command::Orbic(args) => orbic_network::install(args.admin_ip, args.admin_username, args.admin_password, args.reset_config).await.context("\nFailed to install rayhunter on the Orbic RC400L")?,
         Command::Wingtech(args) => wingtech::install(args).await.context("\nFailed to install rayhunter on the Wingtech CT2MHS01")?,
         Command::Util(subcommand) => {
             match subcommand.command {


### PR DESCRIPTION
On tplink and orbic, do not overwrite config files by default. There is
a new flag `installer orbic --reset-config` that one can use to restore
the old behavior. This fixes #778, a long-standing issue existent since
0.3.0.

The businesslogic for config file overrides is shared to some degree.
The Install trait from pinephone.rs has been moved out and renamed to
DeviceConnection for that purpose, so that `install_config` can be
shared across installers, which in turn can delegate to the trait for
running commands and copying files. This also works towards #542.

However, the pinephone and other installers have not been adapted to
support --reset-config out of fear of regressions. A future refactor by
somebody with ability to test on pinephone should probably also consider
using the same DeviceConnection impl as orbic, if possible.
