### PR TITLE
Add PTY-enabled shell support for Orbic devices

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2749,6 +2749,7 @@ dependencies = [
  "futures",
  "hyper",
  "hyper-util",
+ "libc",
  "md5 0.7.0",
  "md5crypt",
  "nusb",

--- a/installer/Cargo.toml
+++ b/installer/Cargo.toml
@@ -35,6 +35,7 @@ futures = "0.3"
 
 [target.'cfg(unix)'.dependencies]
 termios = "0.3"
+libc = "0.2"
 
 [target.'cfg(all(target_os = "linux", not(target_os = "android")))'.dependencies.adb_client]
 git = "https://github.com/EFForg/adb_client.git"

--- a/installer/src/lib.rs
+++ b/installer/src/lib.rs
@@ -97,6 +97,11 @@ struct OrbicNetworkArgs {
     /// Admin password for authentication.
     #[arg(long)]
     admin_password: Option<String>,
+
+    /// Use legacy mode without raw terminal (shows typed characters locally).
+    /// Default mode uses raw terminal for better special key handling.
+    #[arg(long)]
+    no_pty: bool,
 }
 
 #[derive(Parser, Debug)]
@@ -281,7 +286,7 @@ async fn run(args: Args) -> Result<(), Error> {
             #[cfg(not(target_os = "android"))]
             UtilSubCommand::PinephoneStopAdb => pinephone::stop_adb().await.context("\nFailed to stop adb on the PinePhone's modem")?,
             UtilSubCommand::OrbicStartTelnet(args) => orbic_network::start_telnet(&args.admin_ip, &args.admin_username, args.admin_password.as_deref()).await.context("\nFailed to start telnet on the Orbic RC400L")?,
-            UtilSubCommand::OrbicShell(args) => orbic_network::shell(&args.admin_ip, &args.admin_username, args.admin_password.as_deref()).await.context("\nFailed to open shell on Orbic RC400L")?,
+            UtilSubCommand::OrbicShell(args) => orbic_network::shell(&args.admin_ip, &args.admin_username, args.admin_password.as_deref(), !args.no_pty).await.context("\nFailed to open shell on Orbic RC400L")?,
         }
         }
     }


### PR DESCRIPTION
## Pull Request Checklist

- [  ] The Rayhunter team has recently expressed interest in reviewing a PR for this.                                      
        ⚠️ No explicit desire found, but this is a potential quality of life improvement for end users

- [x] Added or updated any documentation as needed to support the changes in this PR.                                     
        CLI --help already documents --no-pty flag; orbic.md already documents orbic-shell command.                         
                                                                                                                            
  - [x] Code has been linted and run through `cargo fmt`                                                                    
                                                                                                                            
  - [ ] If any new functionality has been added, unit tests were also added                                                 
        ⚠️ No unit tests - this is hardware-dependent shell functionality.                                                  
                                                                                                                            
  - [x] [./CONTRIBUTING.md](../CONTRIBUTING.md) has been read                                                               
                                                                                                                            
  PR Description                                                                                                            
                                                                                                                            
  ## Summary                                                                                                                
  Adds PTY-enabled shell support for Orbic devices via `orbic-shell` command, providing proper terminal functionality       
  (visible prompt, line editing, Ctrl+C).                                                                                   
                                                                                                                            
  ## Changes                                                                                                                
  - PTY shell using BusyBox `script` for terminal allocation                                                                
  - FIFO-based bidirectional I/O with `exec 3<>/tmp/f` trick to prevent deadlock                                            
  - Early TTY detection to fail gracefully in non-interactive contexts                                                      
  - `--no-pty` flag for legacy mode (scripted access)                                                                       
  - Added `libc` dependency for `isatty()` check                                                                            
                                                                                                                            
  ## Test plan                                                                                                              
  - [x] `tty` returns `/dev/pts/0` (proper PTY allocation)                                                                  
  - [x] Shell prompt visible, commands execute correctly                                                                    
  - [x] `--no-pty` legacy mode works                                                                                        
  - [x] Tested on Orbic RC400L                                    