### PR TITLE
Upgrade num-bigint-dig

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3423,11 +3423,10 @@ dependencies = [
 
 [[package]]
 name = "num-bigint-dig"
-version = "0.8.4"
+version = "0.8.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "dc84195820f291c7697304f3cbdadd1cb7199c0efc917ff5eafd71225c136151"
+checksum = "e661dda6640fad38e827a6d4a310ff4763082116fe217f279885c97f511bb0b7"
 dependencies = [
- "byteorder",
  "lazy_static",
  "libm",
  "num-integer",


### PR DESCRIPTION
This dependency is causing warnings during compilation, vieable with `cargo report future-incompatibilities --id 1`
