### PR TITLE
Use /proc/net/route instead of ip route command

### DIFF
--- a/daemon/src/stats.rs
+++ b/daemon/src/stats.rs
@@ -181,11 +181,8 @@ pub struct RouteStatus {
 }
 
 pub async fn get_route_status() -> Json<RouteStatus> {
-    let mut cmd = Command::new("busybox");
-    cmd.args(["ip", "route"]);
-
-    let has_default_route = match get_cmd_output(cmd).await {
-        Ok(output) => output.lines().any(|line| line.starts_with("default ")),
+    let has_default_route = match check_default_route().await {
+        Ok(result) => result,
         Err(err) => {
             log::warn!("Failed to check default route: {err}");
             // More likely than not, this is a portability issue. The logic hasn't been fully
@@ -195,4 +192,15 @@ pub async fn get_route_status() -> Json<RouteStatus> {
     };
 
     Json(RouteStatus { has_default_route })
+}
+
+// Checks for an IPv4 default route by reading /proc/net/route
+// instead of shelling out to `ip route`, which may not be available on all devices.
+async fn check_default_route() -> std::io::Result<bool> {
+    let contents = tokio::fs::read_to_string("/proc/net/route").await?;
+    Ok(contents.lines().skip(1).any(|line| {
+        line.split_whitespace()
+            .nth(1)
+            .is_some_and(|dest| dest == "00000000")
+    }))
 }


### PR DESCRIPTION
Fix #811, allegedly /proc/net/route is almost always available, and no
additional dependency is needed at all.
