### PR TITLE
Better support for firmware-devel profile

### DIFF
--- a/.cargo/config.toml
+++ b/.cargo/config.toml
@@ -5,6 +5,10 @@ build-daemon-firmware = "build -p rayhunter-daemon --bin rayhunter-daemon --targ
 # Build the daemon with "firmware-devel" profile and "rustcrypto" backend.
 # Works with just the Rust toolchain, and is medium-slow to build. Binaries are slightly larger.
 build-daemon-firmware-devel = "build -p rayhunter-daemon --bin rayhunter-daemon --target armv7-unknown-linux-musleabihf --profile firmware-devel"
+# Build rootshell for firmware
+build-rootshell-firmware = "build -p rootshell --bin rootshell --target armv7-unknown-linux-musleabihf --profile firmware"
+# Build rootshell for development
+build-rootshell-firmware-devel = "build -p rootshell --bin rootshell --target armv7-unknown-linux-musleabihf --profile firmware-devel"
 
 [target.aarch64-apple-darwin]
 linker = "rust-lld"

--- a/doc/installing-from-source.md
+++ b/doc/installing-from-source.md
@@ -47,12 +47,11 @@ cargo build-daemon-firmware-devel
 # CC_armv7_unknown_linux_musleabihf=arm-linux-gnueabihf-gcc cargo build-daemon-firmware
 
 # Build rootshell
-cargo build -p rootshell --bin rootshell --target armv7-unknown-linux-musleabihf --profile firmware
+cargo build-rootshell-firmware-devel
 
 # Replace 'orbic' with your device type if different.
 # A list of possible values can be found with 'cargo run --bin installer help'.
-# Use FILE_RAYHUNTER_DAEMON to specify the daemon binary path when using development builds:
-FILE_RAYHUNTER_DAEMON=$PWD/target/armv7-unknown-linux-musleabihf/firmware-devel/rayhunter-daemon cargo run -p installer --bin installer orbic
+FIRMWARE_PROFILE=firmware-devel cargo run -p installer --bin installer orbic
 ```
 
 ### If you're on Windows or can't run the install scripts

--- a/installer-gui/README.md
+++ b/installer-gui/README.md
@@ -14,12 +14,13 @@ You'll need to install [Tauri's dependencies](https://tauri.app/start/prerequisi
 
 The GUI installer pulls in the CLI installer as a library. Like with the CLI installer, the firmware binary needs to be present and can be overridden with the same envvars. See `../installer/build.rs` for options.
 
-For example, to build the firmware in development mode and then provide the path explicitly:
+For example, to build the firmware in development mode:
 
 ```bash
 cargo build-daemon-firmware-devel
+cargo build-rootshell-firmware-devel
 
-(cd installer-gui && FILE_RAYHUNTER_DAEMON=$PWD/../target/armv7-unknown-linux-musleabihf/firmware-devel/rayhunter-daemon npm run tauri android build)
+(cd installer-gui && FIRMWARE_PROFILE=firmware-devel npm run tauri android build)
 ```
 
 ## Building

--- a/installer/build.rs
+++ b/installer/build.rs
@@ -1,18 +1,19 @@
-use core::str;
 use std::path::Path;
 use std::process::exit;
 
 fn main() {
     println!("cargo::rerun-if-env-changed=NO_FIRMWARE_BIN");
-    let include_dir = Path::new(concat!(
-        env!("CARGO_MANIFEST_DIR"),
-        "/../target/armv7-unknown-linux-musleabihf/firmware/"
-    ));
-    set_binary_var(include_dir, "FILE_ROOTSHELL", "rootshell");
-    set_binary_var(include_dir, "FILE_RAYHUNTER_DAEMON", "rayhunter-daemon");
+    println!("cargo::rerun-if-env-changed=FIRMWARE_PROFILE");
+    let profile = std::env::var("FIRMWARE_PROFILE").unwrap_or_else(|_| "firmware".to_string());
+    let include_dir = Path::new(env!("CARGO_MANIFEST_DIR"))
+        .join("../target/armv7-unknown-linux-musleabihf")
+        .join(&profile);
+    set_binary_var(&include_dir, "FILE_ROOTSHELL", "rootshell");
+    set_binary_var(&include_dir, "FILE_RAYHUNTER_DAEMON", "rayhunter-daemon");
 }
 
 fn set_binary_var(include_dir: &Path, var: &str, file: &str) {
+    println!("cargo::rerun-if-env-changed={var}");
     if std::env::var_os("NO_FIRMWARE_BIN").is_some() {
         let out_dir = std::env::var("OUT_DIR").unwrap();
         std::fs::create_dir_all(&out_dir).unwrap();
@@ -23,6 +24,7 @@ fn set_binary_var(include_dir: &Path, var: &str, file: &str) {
     }
     if std::env::var_os(var).is_none() {
         let binary = include_dir.join(file);
+        println!("cargo::rerun-if-changed={}", binary.display());
         if !binary.exists() {
             println!(
                 "cargo::error=Firmware binary {file} not present at {}",
@@ -31,6 +33,5 @@ fn set_binary_var(include_dir: &Path, var: &str, file: &str) {
             exit(0);
         }
         println!("cargo::rustc-env={var}={}", binary.display());
-        println!("cargo::rerun-if-changed={}", binary.display());
     }
 }


### PR DESCRIPTION
Currently you have to override a bunch of paths to use firmware-devel
when building the installer. This changes that, and adds a new
FIRMWARE_PROFILE envvar that can be used to fix both rootshell and
rayhunter-daemon paths at the same time.

There is now also a new cargo command for building rootshell, similar to
how building the daemon firmware works.

I'm not sure what to do with make.sh. I have personally never used it.
