### PR TITLE
Show tracking area code for test heuristic in UI

### DIFF
--- a/lib/src/analysis/test_analyzer.rs
+++ b/lib/src/analysis/test_analyzer.rs
@@ -39,6 +39,12 @@ impl Analyzer for TestAnalyzer {
                 .0
                 .as_bitslice()
                 .load_be::<u32>();
+            let tac = sib1
+                .cell_access_related_info
+                .tracking_area_code
+                .0
+                .as_bitslice()
+                .load_be::<u32>();
             let plmn = &sib1.cell_access_related_info.plmn_identity_list.0;
             let mcc_string: String;
 
@@ -62,8 +68,8 @@ impl Analyzer for TestAnalyzer {
             return Some(Event {
                 event_type: EventType::Low,
                 message: format!(
-                    "SIB1 received CID: {}, PLMN: {}-{}",
-                    cid, mcc_string, mnc_string
+                    "SIB1 received CID: {}, TAC: {}, PLMN: {}-{}",
+                    cid, tac, mcc_string, mnc_string
                 ),
             });
         }


### PR DESCRIPTION
Hey,
thanks for the project, it was really easy to join (even as a non-rust guy)!

I added a small change. The test heuristic now also shows the tracking area code:

```
1/6/80, 1:00:06 AM GMT+1	Test Analyzer v1	SIB1 received CID: xxxxx, TAC: xxxxx, PLMN: 262-03 (packet 5)	Low
```

This makes it easier to find the base station on opencellid.org. 