### PR TITLE
Filter out asn1_codecs warnings in rayhunter-daemon

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -936,16 +936,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5b63caa9aa9397e2d9480a9b13673856c78d8ac123288526c37d7839f2a86990"
 
 [[package]]
-name = "colored"
-version = "2.2.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "117725a109d387c937a1533ce01b450cbde6b88abceea8473c4d7a85853cda3c"
-dependencies = [
- "lazy_static",
- "windows-sys 0.59.0",
-]
-
-[[package]]
 name = "combine"
 version = "4.6.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3519,15 +3509,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "num_threads"
-version = "0.1.7"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5c7398b9c8b70908f6371f47ed36737907c87c52af34c268fed0bf0ceb92ead9"
-dependencies = [
- "libc",
-]
-
-[[package]]
 name = "nusb"
 version = "0.1.14"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -4696,6 +4677,7 @@ dependencies = [
  "chrono",
  "crc",
  "deku 0.20.2",
+ "env_logger 0.11.8",
  "futures",
  "libc",
  "log",
@@ -4719,7 +4701,6 @@ dependencies = [
  "log",
  "pcap-file-tokio",
  "rayhunter",
- "simple_logger",
  "tokio",
  "walkdir",
 ]
@@ -4733,7 +4714,6 @@ dependencies = [
  "async_zip",
  "axum",
  "chrono",
- "env_logger 0.11.8",
  "futures",
  "futures-macro",
  "image",
@@ -5435,18 +5415,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "simple_logger"
-version = "5.0.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e8c5dfa5e08767553704aa0ffd9d9794d527103c736aba9854773851fd7497eb"
-dependencies = [
- "colored",
- "log",
- "time",
- "windows-sys 0.48.0",
-]
-
-[[package]]
 name = "siphasher"
 version = "0.3.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -6095,9 +6063,7 @@ checksum = "8a7619e19bc266e0f9c5e6686659d394bc57973859340060a69221e57dbc0c40"
 dependencies = [
  "deranged",
  "itoa",
- "libc",
  "num-conv",
- "num_threads",
  "powerfmt",
  "serde",
  "time-core",

--- a/check/Cargo.toml
+++ b/check/Cargo.toml
@@ -10,5 +10,4 @@ log = "0.4.20"
 tokio = { version = "1.44.2", default-features = false, features = ["fs", "signal", "process", "rt-multi-thread"] }
 pcap-file-tokio = "0.1.0"
 clap = { version = "4.5.2", features = ["derive"] }
-simple_logger = "5.0.0"
 walkdir = "2.5.0"

--- a/check/src/main.rs
+++ b/check/src/main.rs
@@ -177,14 +177,7 @@ async fn main() {
     } else {
         log::LevelFilter::Info
     };
-    simple_logger::SimpleLogger::new()
-        .with_colors(true)
-        .without_timestamps()
-        .with_level(level)
-        //Filter out a stupid massive amount of uneccesary warnings from hampi about undecoded extensions
-        .with_module_level("asn1_codecs", log::LevelFilter::Error)
-        .init()
-        .unwrap();
+    rayhunter::init_logging(level);
 
     let harness = Harness::new_with_config(&AnalyzerConfig::default());
     info!("Analyzers:");

--- a/daemon/Cargo.toml
+++ b/daemon/Cargo.toml
@@ -18,7 +18,6 @@ axum = { version = "0.8", default-features = false, features = ["http1", "tokio"
 thiserror = "1.0.52"
 libc = "0.2.150"
 log = "0.4.20"
-env_logger = { version = "0.11", default-features = false }
 tokio-util = { version = "0.7.10", features = ["rt", "io", "compat"] }
 futures-macro = "0.3.30"
 include_dir = "0.7.3"

--- a/daemon/src/main.rs
+++ b/daemon/src/main.rs
@@ -170,7 +170,7 @@ fn run_shutdown_thread(
 
 #[tokio::main(flavor = "current_thread")]
 async fn main() -> Result<(), RayhunterError> {
-    env_logger::init();
+    rayhunter::init_logging(log::LevelFilter::Info);
 
     #[cfg(feature = "rustcrypto-tls")]
     {

--- a/daemon/web/src/lib/components/AnalysisTable.svelte
+++ b/daemon/web/src/lib/components/AnalysisTable.svelte
@@ -78,7 +78,8 @@
         <p class="text-lg underline">Unparsed Messages</p>
         <p>
             These are due to a limitation or bug in Rayhunter's parser, and aren't usually a
-            problem.
+            problem. We'll not accept bug reports about them unless something else is going wrong
+            (such as false-positives or definite false-negatives)
         </p>
         <div class="overflow-x-auto">
             <table class="table-auto text-left">

--- a/lib/Cargo.toml
+++ b/lib/Cargo.toml
@@ -16,6 +16,7 @@ crc = "3.0.1"
 deku = { version = "0.20.0", features = ["logging"] }
 libc = "0.2.150"
 log = "0.4.20"
+env_logger = { version = "0.11", default-features = false }
 nix = { version = "0.29.0", features = ["feature"] }
 pcap-file-tokio = "0.1.0"
 pycrate-rs = { git = "https://github.com/EFForg/pycrate-rs" }

--- a/lib/src/lib.rs
+++ b/lib/src/lib.rs
@@ -1,5 +1,16 @@
 use serde::{Deserialize, Serialize};
 
+/// Initialize logging with the given default level, suppressing noisy warnings
+/// from hampi about undecoded ASN1 extensions. Respects `RUST_LOG` overrides.
+pub fn init_logging(default_level: log::LevelFilter) {
+    env_logger::Builder::new()
+        .filter_level(default_level)
+        //Filter out a stupid massive amount of uneccessary warnings from hampi about undecoded extensions
+        .filter_module("asn1_codecs", log::LevelFilter::Error)
+        .parse_default_env()
+        .init();
+}
+
 pub mod analysis;
 pub mod diag;
 pub mod gsmtap;


### PR DESCRIPTION
...and make a small UI change so that folks won't get concerned about parsing errors.

Right now all the "undecoded extensions" noise goes into
rayhunter-daemon.log, and users get concerned about it when browsing
that through the UI.
