### PR TITLE
Add UPX-compressed daemon variant for storage-constrained (Moxxe)

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -322,7 +322,7 @@ jobs:
           targets: armv7-unknown-linux-musleabihf
       - uses: Swatinem/rust-cache@v2
       - name: Install ARM cross-compilation toolchain
-        run: sudo apt-get update && sudo apt-get install -y gcc-arm-linux-gnueabihf
+        run: sudo apt-get update && sudo apt-get install -y gcc-arm-linux-gnueabihf upx-ucl
       - name: Build rayhunter-daemon (armv7)
         run: |
           pushd daemon/web
@@ -338,10 +338,20 @@ jobs:
           #
           # https://github.com/rust-lang/cargo/issues/4463
           CC_armv7_unknown_linux_musleabihf=arm-linux-gnueabihf-gcc cargo build-daemon-firmware
+      - name: Create UPX-compressed daemon for storage-constrained devices
+        run: |
+          cp target/armv7-unknown-linux-musleabihf/firmware/rayhunter-daemon \
+             target/armv7-unknown-linux-musleabihf/firmware/rayhunter-daemon-compressed
+          upx --best target/armv7-unknown-linux-musleabihf/firmware/rayhunter-daemon-compressed
       - uses: actions/upload-artifact@v4
         with:
           name: rayhunter-daemon
           path: target/armv7-unknown-linux-musleabihf/firmware/rayhunter-daemon
+          if-no-files-found: error
+      - uses: actions/upload-artifact@v4
+        with:
+          name: rayhunter-daemon-compressed
+          path: target/armv7-unknown-linux-musleabihf/firmware/rayhunter-daemon-compressed
           if-no-files-found: error
 
   build_rust_installer:
@@ -540,6 +550,19 @@ jobs:
       - build_rootshell
       - build_rayhunter
       - build_rust_installer
+    env:
+      # Note included in release ZIP for users choosing between daemon variants
+      DAEMON_README: |
+        This release includes two builds of rayhunter-daemon:
+
+        rayhunter-daemon/
+          The standard build. Use this unless you are running out of storage.
+
+        rayhunter-daemon-compressed/
+          A UPX-compressed build for devices with extreme storage constraints
+          (such as the Moxee, which has less than 8MB of usable space). The
+          tradeoff is slower startup time, since the binary must decompress
+          itself into memory before it can run.
     runs-on: ubuntu-latest
     strategy:
       matrix:
@@ -556,7 +579,7 @@ jobs:
           persist-credentials: false
       - uses: actions/download-artifact@v4
       - name: Fix executable permissions on binaries
-        run: chmod +x installer-*/installer rayhunter-check-*/rayhunter-check rayhunter-daemon/rayhunter-daemon
+        run: chmod +x installer-*/installer rayhunter-check-*/rayhunter-check rayhunter-daemon/rayhunter-daemon rayhunter-daemon-compressed/rayhunter-daemon-compressed
       - name: Get Rayhunter version
         id: get_version
         run: echo "VERSION=$(grep '^version' daemon/Cargo.toml | head -n 1 | cut -d'"' -f2)" >> $GITHUB_ENV
@@ -571,6 +594,11 @@ jobs:
           else
             mv installer-$platform/installer "$dest"/installer
           fi
+          # Include both standard and compressed daemon builds
+          mkdir -p "$dest/rayhunter-daemon-compressed"
+          cp rayhunter-daemon-compressed/rayhunter-daemon-compressed \
+             "$dest/rayhunter-daemon-compressed/rayhunter-daemon"
+          echo "$DAEMON_README" > "$dest/DAEMON-VARIANTS.txt"
           cp -r rayhunter-check-* rayhunter-daemon dist/scripts "$dest"/
           zip -r "$dest.zip" "$dest"
           sha256sum "$dest.zip" > "$dest.zip.sha256"


### PR DESCRIPTION
I added UPX compression to the workflow so it generates 2 artifacts. The first is the normal rayhunter-daemon and the other is rayhunter-daemon-compressed.

_You're probably asking, why did she do that?_ 

The Moxee's /data partition is 9.3MB total with roughly 7.5MB usable. The standard rayhunter-daemon firmware binary is 4.89MB, leaving about 2.6MB for config, logs, and recordings. That's barely enough to be useful.

The UPX-compressed build added to CI brings the binary down to 2.25MB, a 54% reduction. On a Moxee that leaves around 5.25MB free, roughly double what you get with the standard build.

The compressed binary is a self-extracting executable. It decompresses itself into memory on startup, so there's a small delay before the daemon is running. At runtime it behaves identically to the standard build.

One caveat: UPX has a history of compatibility issues with older ARM kernels (the Moxee runs 3.18). I did make sure to use  `--best` without `--lzma` since LZMA specifically causes segfaults on armv7. The build passes CI (ran it on my fork) and produces a valid ARM ELF, but it needs to be tested on actual Moxee hardware before we ship it as a recommendation.

**someone with a moxxe** When this PR runs through the checks, it should create 2 artifacts. rayhunter-daemon and rayhunter-daemon-compressed. If you could grab the compressed artifact and try installing that on a moxxe that would be wonderful. I'm still waiting for mine to arrive. I'm leaving this in draft since the CI still builds, but this isn't ready to be merged.

## Pull Request Checklist

- [X] The Rayhunter team has recently expressed interest in reviewing a PR for this.
  - If not, this PR may be closed due our limited resources and need to prioritize how we spend them.
- [X] Added or updated any documentation as needed to support the changes in this PR.
- [X] Code has been linted and run through `cargo fmt`.
- [X] If any new functionality has been added, unit tests were also added.
- [X] [CONTRIBUTING.md](https://github.com/EFForg/rayhunter/blob/main/CONTRIBUTING.md) has been read.
