### PR TITLE
Use Vec::with_capacity

### DIFF
--- a/daemon/src/display/generic_framebuffer.rs
+++ b/daemon/src/display/generic_framebuffer.rs
@@ -102,7 +102,7 @@ pub trait GenericFramebuffer: Send + 'static {
             resized_img = img;
         }
         let img_rgba8 = resized_img.as_rgba8().unwrap();
-        let mut buf = Vec::new();
+        let mut buf = Vec::with_capacity((height * width).try_into().unwrap());
         for y in 0..height {
             for x in 0..width {
                 let px = img_rgba8.get_pixel(x, y);
@@ -145,7 +145,7 @@ pub trait GenericFramebuffer: Send + 'static {
 
     async fn draw_patterned_line(&mut self, color: Color, height: u32, pattern: LinePattern) {
         let width = self.dimensions().width;
-        let mut buffer = Vec::new();
+        let mut buffer = Vec::with_capacity((height * width).try_into().unwrap());
 
         for _row in 0..height {
             for col in 0..width {

--- a/daemon/src/display/orbic.rs
+++ b/daemon/src/display/orbic.rs
@@ -23,7 +23,7 @@ impl GenericFramebuffer for Framebuffer {
     }
 
     async fn write_buffer(&mut self, buffer: Vec<(u8, u8, u8)>) {
-        let mut raw_buffer = Vec::new();
+        let mut raw_buffer = Vec::with_capacity(buffer.len() * 2);
         for (r, g, b) in buffer {
             let mut rgb565: u16 = (r as u16 & 0b11111000) << 8;
             rgb565 |= (g as u16 & 0b11111100) << 3;

--- a/daemon/src/display/tplink_framebuffer.rs
+++ b/daemon/src/display/tplink_framebuffer.rs
@@ -50,7 +50,7 @@ impl GenericFramebuffer for Framebuffer {
             rop: 0,
         };
 
-        let mut raw_buffer = Vec::new();
+        let mut raw_buffer = Vec::with_capacity(buffer.len() * 2);
         for (r, g, b) in buffer {
             let mut rgb565: u16 = (r as u16 & 0b11111000) << 8;
             rgb565 |= (g as u16 & 0b11111100) << 3;

--- a/daemon/src/display/wingtech.rs
+++ b/daemon/src/display/wingtech.rs
@@ -28,7 +28,7 @@ impl GenericFramebuffer for Framebuffer {
     }
 
     async fn write_buffer(&mut self, buffer: Vec<(u8, u8, u8)>) {
-        let mut raw_buffer = Vec::new();
+        let mut raw_buffer = Vec::with_capacity(buffer.len() * 2);
         for (r, g, b) in buffer {
             let mut rgb565: u16 = (r as u16 & 0b11111000) << 8;
             rgb565 |= (g as u16 & 0b11111100) << 3;


### PR DESCRIPTION
Noticed while poking around `Vec::new` calls immediately followed by filling the `Vec`. `Vec::with_capacity` can be used to avoid reallocating. Tested on kajeet hardware as that's all I have, but I can't imagine this causing issues on other hardware.

## Pull Request Checklist

- [ ] The Rayhunter team has recently expressed interest in reviewing a PR for this.
  - If not, this PR may be closed due our limited resources and need to prioritize how we spend them.
- [ ] Added or updated any documentation as needed to support the changes in this PR.
- [x] Code has been linted and run through `cargo fmt`.
- [ ] If any new functionality has been added, unit tests were also added.
- [x] [CONTRIBUTING.md](https://github.com/EFForg/rayhunter/blob/main/CONTRIBUTING.md) has been read.