### PR TITLE
add devicetype for moxee add quick destination size check

### DIFF
--- a/daemon/src/main.rs
+++ b/daemon/src/main.rs
@@ -241,6 +241,7 @@ async fn run_with_config(
 
         let update_ui = match &config.device {
             Device::Orbic => display::orbic::update_ui,
+            Device::Moxee => display::orbic::update_ui,
             Device::Tplink => display::tplink::update_ui,
             Device::Tmobile => display::tmobile::update_ui,
             Device::Wingtech => display::wingtech::update_ui,

--- a/installer/src/lib.rs
+++ b/installer/src/lib.rs
@@ -282,7 +282,7 @@ async fn run(args: Args) -> Result<(), Error> {
             .context("Failed to install rayhunter on the Pinephone's Quectel modem")?,
         #[cfg(not(target_os = "android"))]
         Command::OrbicUsb(args) => orbic::install(args.reset_config).await.context("\nFailed to install rayhunter on the Orbic RC400L (USB installer)")?,
-        Command::Orbic(args) => orbic_network::install(args.admin_ip, args.admin_username, args.admin_password, args.reset_config, args.data_dir).await.context("\nFailed to install rayhunter on the Orbic RC400L")?,
+        Command::Orbic(args) => orbic_network::install(args.admin_ip, args.admin_username, args.admin_password, args.reset_config, args.data_dir, "orbic").await.context("\nFailed to install rayhunter on the Orbic RC400L")?,
         Command::Moxee(args) => moxee::install(args).await.context("\nFailed to install rayhunter on the Moxee Hotspot")?,
         Command::Wingtech(args) => wingtech::install(args).await.context("\nFailed to install rayhunter on the Wingtech CT2MHS01")?,
         Command::Util(subcommand) => {

--- a/installer/src/moxee.rs
+++ b/installer/src/moxee.rs
@@ -10,6 +10,7 @@ pub async fn install(args: MoxeeArgs) -> Result<()> {
         args.admin_password,
         args.reset_config,
         data_dir,
+        "moxee",
     )
     .await
 }

--- a/lib/src/lib.rs
+++ b/lib/src/lib.rs
@@ -38,4 +38,5 @@ pub enum Device {
     Wingtech,
     Pinephone,
     Uz801,
+    Moxee,
 }


### PR DESCRIPTION
Add a device type indicating moxee (critical need for other development work I'm doing). Check that the binary we're pushing isn't going to be too big for the destination (prevents bricking devices by pushing dev builds with exceed release sizes - almost bricked my Moxee myself).

## Pull Request Checklist

- [X] The Rayhunter team has recently expressed interest in reviewing a PR for this.
  - If not, this PR may be closed due our limited resources and need to prioritize how we spend them.
- [X] Added or updated any documentation as needed to support the changes in this PR.
- [X] Code has been linted and run through `cargo fmt`.
- [X] If any new functionality has been added, unit tests were also added.
- [X] [CONTRIBUTING.md](https://github.com/EFForg/rayhunter/blob/main/CONTRIBUTING.md) has been read.
