### PR TITLE
orbic-network: Disable connection pooling

### DIFF
--- a/installer/src/orbic_network.rs
+++ b/installer/src/orbic_network.rs
@@ -22,7 +22,10 @@ struct ExploitResponse {
 }
 
 async fn login_and_exploit(admin_ip: &str, username: &str, password: &str) -> Result<()> {
-    let client: Client = Client::new();
+    // Disable connection pooling. The Orbic's web server does not properly support
+    // HTTP/1.1 keep-alive, so reusing connections causes "connection closed before
+    // message completed" errors.
+    let client: Client = Client::builder().pool_max_idle_per_host(0).build()?;
 
     // Step 1: Get login info (priKey and session cookie)
     let login_info_response = client


### PR DESCRIPTION
Every once in a while, I get the error posted in #901:

    Caused by:
        0: Failed to send login request
        1: error sending request
        2: client error (SendRequest)
        3: connection closed before message completed

Either "failed to send login request" or "failed to start telnet" -- in either case there's a
request happening before it, and it's always "connection closed before
message completed".

This is on firmware version `ORB400L_V1.1.5_BVZRT`, stock orbic.

Disabling connection pooling seems to reduce the amount of flakiness.

Here is what I used to test this fix:

    while echo | cargo run -p installer util orbic-shell --admin-password 96df5476 ; do true; done

Usually it would stop <100 iterations, now it can do 800+ iterations.

