### PR TITLE
Fix telnet_send_command_with_output returning the input

### DIFF
--- a/installer/src/util.rs
+++ b/installer/src/util.rs
@@ -147,7 +147,10 @@ pub async fn telnet_send_file(
             drop(stream);
         }
 
-        handle.await??
+        handle
+            .await
+            .context("background nc writer failed")?
+            .context("background nc writer failed")?
     };
 
     let checksum = md5::compute(payload);


### PR DESCRIPTION
telnet_send_command_with_output returns output with the original command
contained. This leads to higher-level bugs. Fix #894

Also, change telnet_send_command_with_output to not return any "exit
code" related output. This is now only part of telnet_send_command,
which means this output does not leak into users of the DeviceConnection
trait (Which uses telnet_send_command_with_output)

`telnet_send_command` is not a great API because users expect the
`exit code 0` string to be part of output, but it's too widely used to
change it now.