### PR TITLE
fix: fix typo in connection error message

### DIFF
--- a/daemon/web/src/routes/+page.svelte
+++ b/daemon/web/src/routes/+page.svelte
@@ -197,7 +197,7 @@
             </span>
             <span
                 >This webpage is not currently receiving updates from your Rayhunter device. This
-                could be do loss of connection or some issue with your device.</span
+                could be due to loss of connection or some issue with your device.</span
             >
             {#if update_error}
                 <details>


### PR DESCRIPTION
Fix typo in connection error message: 'do loss' → 'due to loss'.

Fixes #864