### PR TITLE
limit PR to 400 LOC

### DIFF
--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -6,6 +6,7 @@
 - [ ] Code has been linted and run through `cargo fmt`.
 - [ ] If any new functionality has been added, unit tests were also added.
 - [ ] [CONTRIBUTING.md](https://github.com/EFForg/rayhunter/blob/main/CONTRIBUTING.md) has been read.
+- [ ] Your pull request is fewer than ~400 lines of code.
 
 You must check one of:
 - [ ] No generative AI (including LLMs) tools were used to create this PR.

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -58,7 +58,7 @@ Otherwise:
   manually test them. Our test coverage isn't great, but as new features are
   added we are trying to prevent it from becoming worse.
 
-- Please keep your contirbutions to less than approximately 400 lines of code (going slightly over is fine, we aren't dogmatic about it.) This is because we are not able to give quality code review to contributions larger than that and risk introducing bugs into the system. [There was a study showing 400 LOC is the max most humans can handle.](https://smartbear.com/learn/code-review/best-practices-for-peer-code-review/)
+- Please keep your contributions to less than approximately 400 lines of code not counting tests, (going slightly over is fine, we aren't dogmatic about it.) This is because we are not able to give quality code review to contributions larger than that and risk introducing bugs into the system. [There was a study showing 400 LOC is the max most humans can handle.](https://smartbear.com/learn/code-review/best-practices-for-peer-code-review/)
 
 If you have any questions [feel free to open a discussion or chat with us on Mattermost.](https://efforg.github.io/rayhunter/support-feedback-community.html)
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -58,6 +58,8 @@ Otherwise:
   manually test them. Our test coverage isn't great, but as new features are
   added we are trying to prevent it from becoming worse.
 
+- Please keep your contirbutions to less than approximately 400 lines of code (going slightly over is fine, we aren't dogmatic about it.) This is because we are not able to give quality code review to contributions larger than that and risk introducing bugs into the system. [There was a study showing 400 LOC is the max most humans can handle.](https://smartbear.com/learn/code-review/best-practices-for-peer-code-review/)
+
 If you have any questions [feel free to open a discussion or chat with us on Mattermost.](https://efforg.github.io/rayhunter/support-feedback-community.html)
 
 ### Policy regarding AI-generated contributions:


### PR DESCRIPTION
Lately we have received a large influx of pull requests, which is great, we want #868! However, some of these pull requests are quite large which make them difficult if not impossible to actually do code review on. I'm aware that some of you like to use AI coding agents and I'm not against that if you can explain / understand all your code, and you write the documentation yourself. But AI coding agents tend to cause people to make very verbose commits of 1000 or more lines, which are just impossible to review. 

My proposal: going forward we limit pull requests to no more than 400 lines of code, if your features requires more lines than that you will have to break it up into smaller chunks. Any pull request longer than 400 lines (at our discretion, I'm not going to throw away my judgement just because a good pull request happens to be 401 lines) will be closed and the submitter asked to resubmit. Why 400? According to [this study](https://smartbear.com/learn/code-review/best-practices-for-peer-code-review/) a reviewers ability to find bad code diminishes significantly after 400 lines of code. This is consistent with my lived experience as well. I'm would like to discuss this as a community and come to a decision in about a week unless everyone instantly agrees (though anyone with open PRs over 400 LOC would have my appreciation if they would resubmit.)