### PR TITLE
Use grouped dependabot updates

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,41 @@
+version: 2
+updates:
+  # Rust dependencies
+  - package-ecosystem: "cargo"
+    directory: "/"
+    schedule:
+      interval: "weekly"
+    groups:
+      dependency-type:
+        patterns:
+          - "*"
+
+  # Python dependencies
+  - package-ecosystem: "pip"
+    directory: "/tools"
+    schedule:
+      interval: "weekly"
+    groups:
+      dependency-type:
+        patterns:
+          - "*"
+
+  # daemon/web Node.js dependencies
+  - package-ecosystem: "npm"
+    directory: "/daemon/web"
+    schedule:
+      interval: "weekly"
+    groups:
+      dependency-type:
+        patterns:
+          - "*"
+
+  # installer-gui Node.js dependencies
+  - package-ecosystem: "npm"
+    directory: "/installer-gui"
+    schedule:
+      interval: "weekly"
+    groups:
+      dependency-type:
+        patterns:
+          - "*"


### PR DESCRIPTION
When there is a CVE in some JS package, it seems to coincide with an
avalanche of security releases of random other packages.

Dependabot can actually create bulk PRs, let's try those.

**Note that this file is overriding some other org-level config that I have no visibility into. I'm not sure how those two will interact.**

----

## Pull Request Checklist

- [ ] The Rayhunter team has recently expressed interest in reviewing a PR for this.
  - If not, this PR may be closed due our limited resources and need to prioritize how we spend them.
- [ ] Added or updated any documentation as needed to support the changes in this PR.
- [ ] Code has been linted and run through `cargo fmt`.
- [ ] If any new functionality has been added, unit tests were also added.
- [x] [CONTRIBUTING.md](https://github.com/EFForg/rayhunter/blob/main/CONTRIBUTING.md) has been read.

You must check one of:
- [ ] No generative AI (including LLMs) tools were used to create this PR.
- [x] Generative AI was used to create this PR. I certify that I have read and understand the code, and *that all comments and descriptions were authored by myself* and are not the product of generative AI.

