### PR TITLE
web: target older mobile browsers

### DIFF
--- a/daemon/web/vite.config.ts
+++ b/daemon/web/vite.config.ts
@@ -28,6 +28,10 @@ export default defineConfig({
     },
     plugins: [sveltekit()],
     build: {
+        // Keep the generated bundle compatible with older mobile browsers.
+        // The default Vite target follows a modern baseline that can be too new
+        // for older iOS Safari releases reported in issue #903.
+        target: ['es2018', 'safari12'],
         // Force everything into one HTML file. SvelteKit will still generate
         // a lot of JS files but they are deadweight and will not be included
         // in the rust binary.


### PR DESCRIPTION
## Summary\n- lower the web bundle target to ES2018/Safari 12 in Vite\n- keep the generated UI compatible with older mobile browsers, including older iOS Safari\n- leave the existing build pipeline intact instead of introducing a heavier legacy plugin\n\n## Validation\n- cd daemon/web && npm test\n- cd daemon/web && npx vite build\n\nCloses #903