### PR TITLE
Fix broken set_config on non-orbic devices

### DIFF
--- a/daemon/src/server.rs
+++ b/daemon/src/server.rs
@@ -155,8 +155,11 @@ pub async fn get_config(
 ))]
 pub async fn set_config(
     State(state): State<Arc<ServerState>>,
-    Json(config): Json<Config>,
+    Json(mut config): Json<Config>,
 ) -> Result<(StatusCode, String), (StatusCode, String)> {
+    // Preserve device type from current config, since the web UI doesn't include it
+    config.device = state.config.device.clone();
+
     let config_str = toml::to_string_pretty(&config).map_err(|err| {
         (
             StatusCode::INTERNAL_SERVER_ERROR,


### PR DESCRIPTION
It seems that changing any settings on TP-Link and other devices renders
rayhunter inoperable, as it resets `device = "tplink"` to the default of
"orbic" as the UI does not send the `device` field nor round-trips it.

This would cause random diag failures.

I'm not sure how this failure wasn't
much more visible. It should at the very least have broken the green
line, even if the diag device still initialized successfully.

The bug (of not round-tripping device) was there since the config UI was
introduced (d166dfc on 2025-06-03), but `device` was introduced in
22d927a (2025-07-17). But I think I'm missing something and there's some
other change that surfaced this bug only now.

The leading theory is that the UI did actually roundtrip device by
accident, it was just never reflected in the typescript types. And a
recent frontend upgrade changed the semantics.

----

## Pull Request Checklist

- [ ] The Rayhunter team has recently expressed interest in reviewing a PR for this.
  - If not, this PR may be closed due our limited resources and need to prioritize how we spend them.
- [ ] Added or updated any documentation as needed to support the changes in this PR.
- [x] Code has been linted and run through `cargo fmt`.
- [ ] If any new functionality has been added, unit tests were also added.
- [x] [CONTRIBUTING.md](https://github.com/EFForg/rayhunter/blob/main/CONTRIBUTING.md) has been read.

You must check one of:
- [ ] No generative AI (including LLMs) tools were used to create this PR.
- [x] Generative AI was used to create this PR. I certify that I have read and understand the code, and *that all comments and descriptions were authored by myself* and are not the product of generative AI. **gen-AI was used to find the real bug once it was discovered, the fix is handwritten.**