### PR TITLE
Bump tower to 0.5.3

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -6321,9 +6321,9 @@ checksum = "ea68304e134ecd095ac6c3574494fc62b909f416c4fca77e440530221e549d3d"
 
 [[package]]
 name = "tower"
-version = "0.5.2"
+version = "0.5.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d039ad9159c98b70ecfd540b2573b97f7f52c3e8d9f8ad57a24b916a536975f9"
+checksum = "ebe5ef63511595f1344e2d5cfa636d973292adc0eec1f0ad45fae9f0851ab1d4"
 dependencies = [
  "futures-core",
  "futures-util",

--- a/installer/Cargo.toml
+++ b/installer/Cargo.toml
@@ -28,7 +28,7 @@ nusb = "0.1.13"
 reqwest = { version = "0.12.15", features = ["json"], default-features = false }
 serde = { version = "1.0.219", features = ["derive"] }
 sha2 = "0.10.8"
-tokio = { version = "1.44.2", features = ["io-util", "macros", "rt"], default-features = false }
+tokio = { version = "1.44.2", features = ["io-util", "io-std", "macros", "rt"], default-features = false }
 tokio-retry2 = "0.5.7"
 tokio-stream = "0.1.17"
 futures = "0.3"


### PR DESCRIPTION
There are no important changes in the new tower version. The only reason
i'm bumping it is because it exposes our mis-configuration of tokio: We
depend on API surface enabled by `io-std`, but don't enable that
feature. Tower 0.5.2 pulls in that feature though, and our code works
anyway. Tower 0.5.3 no longer requires this feature and our code stops
compiling.

I ran into this issue while using the installer as a library, where tower
is pinned to a different version.