### PR TITLE
Move config form to modal

### DIFF
--- a/daemon/web/src/lib/components/ConfigForm.svelte
+++ b/daemon/web/src/lib/components/ConfigForm.svelte
@@ -1,6 +1,8 @@
 <script lang="ts">
     import { get_config, set_config, test_notification, type Config } from '../utils.svelte';
+    import Modal from './Modal.svelte';
 
+    let { shown = $bindable() }: { shown: boolean } = $props();
     let config = $state<Config | null>(null);
 
     let loading = $state(false);
@@ -10,7 +12,6 @@
     let messageType = $state<'success' | 'error' | null>(null);
     let testMessage = $state('');
     let testMessageType = $state<'success' | 'error' | null>(null);
-    let showConfig = $state(false);
 
     async function load_config() {
         try {
@@ -60,30 +61,14 @@
     }
 
     $effect(() => {
-        if (showConfig && !config) {
+        if (shown && !config) {
             load_config();
         }
     });
 </script>
 
-<div class="bg-white rounded-lg shadow-md p-6 m-4">
-    <button
-        class="w-full flex justify-between items-center text-xl font-bold mb-4 text-rayhunter-dark-blue hover:text-rayhunter-blue"
-        onclick={() => (showConfig = !showConfig)}
-    >
-        <span>Configuration</span>
-        <svg
-            class="w-6 h-6 transition-transform {showConfig ? 'rotate-180' : ''}"
-            fill="none"
-            stroke="currentColor"
-            viewBox="0 0 24 24"
-        >
-            <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M19 9l-7 7-7-7"
-            ></path>
-        </svg>
-    </button>
-
-    {#if showConfig}
+<Modal bind:shown title="Configuration">
+    <div class="p-2">
         {#if loading}
             <div class="text-center py-4">Loading config...</div>
         {:else if config}
@@ -438,5 +423,5 @@
                 Failed to load configuration. Please try reloading the page.
             </div>
         {/if}
-    {/if}
-</div>
+    </div>
+</Modal>

--- a/daemon/web/src/lib/components/LogView.svelte
+++ b/daemon/web/src/lib/components/LogView.svelte
@@ -1,34 +1,13 @@
 <script lang="ts">
     import { get_logs } from '$lib/utils.svelte';
-    import { onMount } from 'svelte';
+    import Modal from './Modal.svelte';
 
     let { shown = $bindable() }: { shown: boolean } = $props();
     let content: string | undefined = $state(undefined);
 
-    onMount(() => {
-        // Used by LogView modal
-        window.addEventListener('scroll', () => {
-            document.documentElement.style.setProperty('--scroll-y', `${window.scrollY}px`);
-        });
-    });
-
     $effect(() => {
-        if (shown) {
-            const scrollY = document.documentElement.style.getPropertyValue('--scroll-y');
-            const body = document.body;
-            body.style.position = 'fixed';
-            body.style.top = `-${scrollY}`;
-        } else {
-            const body = document.body;
-            const scrollY = body.style.top;
-            body.style.position = '';
-            body.style.top = '';
-            window.scrollTo(0, parseInt(scrollY || '0') * -1);
-        }
-
         const interval = setInterval(async () => {
             try {
-                // Don't update UI if browser tab isn't visible
                 if (content !== undefined && (document.hidden || !shown)) {
                     return;
                 }
@@ -42,33 +21,8 @@
     });
 </script>
 
-{#if shown}
-    <div
-        class="fixed left-5 right-5 top-5 bottom-5 z-50 bg-white border border-white rounded-md
-		flex flex-col p-2 drop-shadow"
-    >
-        <div class="flex h-20 justify-between items-center p-1">
-            <span class="text-2xl mb-2">Log</span>
-            <button onclick={() => (shown = false)} aria-label="close">
-                <svg
-                    xmlns="http://www.w3.org/2000/svg"
-                    aria-hidden="true"
-                    width="24"
-                    height="24"
-                    fill="currentColor"
-                    viewBox="0 0 24 24"
-                >
-                    <path
-                        fill-rule="evenodd"
-                        clip-rule="evenodd"
-                        d="M5.29289 5.29289C5.68342 4.90237 6.31658 4.90237 6.70711 5.29289L12 10.5858L17.2929 5.29289C17.6834 4.90237 18.3166 4.90237 18.7071 5.29289C19.0976 5.68342 19.0976 6.31658 18.7071 6.70711L13.4142 12L18.7071 17.2929C19.0976 17.6834 19.0976 18.3166 18.7071 18.7071C18.3166 19.0976 17.6834 19.0976 17.2929 18.7071L12 13.4142L6.70711 18.7071C6.31658 19.0976 5.68342 19.0976 5.29289 18.7071C4.90237 18.3166 4.90237 17.6834 5.29289 17.2929L10.5858 12L5.29289 6.70711C4.90237 6.31658 4.90237 5.68342 5.29289 5.29289Z"
-                        fill="#0F1729"
-                    />
-                </svg>
-            </button>
-        </div>
-        <div class="bg-gray-100 border border-gray-100 rounded-md overflow-scroll">
-            <pre class="m-2">{content}</pre>
-        </div>
+<Modal bind:shown title="Logs">
+    <div class="bg-gray-100 border border-gray-100 rounded-md overflow-scroll">
+        <pre class="m-2">{content}</pre>
     </div>
-{/if}
+</Modal>

--- a/daemon/web/src/lib/components/Modal.svelte
+++ b/daemon/web/src/lib/components/Modal.svelte
@@ -1,0 +1,62 @@
+<script lang="ts">
+    import type { Snippet } from 'svelte';
+    import { onMount } from 'svelte';
+
+    let {
+        shown = $bindable(),
+        title,
+        children,
+    }: { shown: boolean; title: string; children: Snippet } = $props();
+
+    onMount(() => {
+        window.addEventListener('scroll', () => {
+            document.documentElement.style.setProperty('--scroll-y', `${window.scrollY}px`);
+        });
+    });
+
+    $effect(() => {
+        if (shown) {
+            const scrollY = document.documentElement.style.getPropertyValue('--scroll-y');
+            const body = document.body;
+            body.style.position = 'fixed';
+            body.style.top = `-${scrollY}`;
+        } else {
+            const body = document.body;
+            const scrollY = body.style.top;
+            body.style.position = '';
+            body.style.top = '';
+            window.scrollTo(0, parseInt(scrollY || '0') * -1);
+        }
+    });
+</script>
+
+{#if shown}
+    <div
+        class="fixed left-5 right-5 top-5 bottom-5 z-50 bg-white border border-white rounded-md
+		flex flex-col p-2 drop-shadow"
+    >
+        <div class="flex justify-between items-center p-1">
+            <span class="text-2xl">{title}</span>
+            <button onclick={() => (shown = false)} aria-label="close">
+                <svg
+                    xmlns="http://www.w3.org/2000/svg"
+                    aria-hidden="true"
+                    width="24"
+                    height="24"
+                    fill="currentColor"
+                    viewBox="0 0 24 24"
+                >
+                    <path
+                        fill-rule="evenodd"
+                        clip-rule="evenodd"
+                        d="M5.29289 5.29289C5.68342 4.90237 6.31658 4.90237 6.70711 5.29289L12 10.5858L17.2929 5.29289C17.6834 4.90237 18.3166 4.90237 18.7071 5.29289C19.0976 5.68342 19.0976 6.31658 18.7071 6.70711L13.4142 12L18.7071 17.2929C19.0976 17.6834 19.0976 18.3166 18.7071 18.7071C18.3166 19.0976 17.6834 19.0976 17.2929 18.7071L12 13.4142L6.70711 18.7071C6.31658 19.0976 5.68342 19.0976 5.29289 18.7071C4.90237 18.3166 4.90237 17.6834 5.29289 17.2929L10.5858 12L5.29289 6.70711C4.90237 6.31658 4.90237 5.68342 5.29289 5.29289Z"
+                        fill="#0F1729"
+                    />
+                </svg>
+            </button>
+        </div>
+        <div class="overflow-y-auto flex-1">
+            {@render children()}
+        </div>
+    </div>
+{/if}

--- a/daemon/web/src/routes/+page.svelte
+++ b/daemon/web/src/routes/+page.svelte
@@ -21,6 +21,7 @@
     let system_stats: SystemStats | undefined = $state(undefined);
     let update_error: string | undefined = $state(undefined);
     let logview_shown: boolean = $state(false);
+    let config_shown: boolean = $state(false);
     $effect(() => {
         const interval = setInterval(async () => {
             try {
@@ -55,6 +56,7 @@
 </script>
 
 <LogView bind:shown={logview_shown} />
+<ConfigForm bind:shown={config_shown} />
 <div class="p-4 xl:px-8 bg-rayhunter-blue drop-shadow flex flex-row justify-between items-center">
     <!-- https://www.w3.org/WAI/tutorials/images/decorative/ -->
     <img src="/rayhunter_text.png" alt="" class="h-10 xl:h-12" />
@@ -100,6 +102,33 @@
                     stroke="currentColor"
                     stroke-width="1.5"
                     stroke-linecap="round"
+                />
+            </svg>
+        </button>
+        <button onclick={() => (config_shown = true)} class="flex flex-row gap-1 group">
+            <span class="hidden text-white group-hover:text-gray-400 lg:flex">Config</span>
+            <svg
+                class="w-6 h-6 text-white group-hover:text-gray-400"
+                aria-hidden="true"
+                xmlns="http://www.w3.org/2000/svg"
+                width="24"
+                height="24"
+                fill="none"
+                viewBox="0 0 24 24"
+            >
+                <path
+                    stroke="currentColor"
+                    stroke-linecap="round"
+                    stroke-linejoin="round"
+                    stroke-width="2"
+                    d="M21 13v-2a1 1 0 0 0-1-1h-.757l-.707-1.707.535-.536a1 1 0 0 0 0-1.414l-1.414-1.414a1 1 0 0 0-1.414 0l-.536.535L14 5.757V5a1 1 0 0 0-1-1h-2a1 1 0 0 0-1 1v.757L8.293 6.464l-.536-.535a1 1 0 0 0-1.414 0L4.929 7.343a1 1 0 0 0 0 1.414l.535.536L4.757 11H4a1 1 0 0 0-1 1v2a1 1 0 0 0 1 1h.757l.707 1.707-.535.536a1 1 0 0 0 0 1.414l1.414 1.414a1 1 0 0 0 1.414 0l.536-.535L10 18.243V19a1 1 0 0 0 1 1h2a1 1 0 0 0 1-1v-.757l1.707-.707.536.535a1 1 0 0 0 1.414 0l1.414-1.414a1 1 0 0 0 0-1.414l-.535-.536.707-1.707H20a1 1 0 0 0 1-1Z"
+                />
+                <path
+                    stroke="currentColor"
+                    stroke-linecap="round"
+                    stroke-linejoin="round"
+                    stroke-width="2"
+                    d="M12 15a3 3 0 1 0 0-6 3 3 0 0 0 0 6Z"
                 />
             </svg>
         </button>
@@ -273,7 +302,6 @@
             <ManifestTable {entries} server_is_recording={!!current_entry} {manager} />
         </div>
         <DeleteAllButton />
-        <ConfigForm />
     {:else}
         <div class="flex flex-col justify-center items-center">
             <!-- https://www.w3.org/WAI/tutorials/images/decorative/ -->


### PR DESCRIPTION
It's pretty annoying to have to scroll past all the old recordings to
be able to set the config. Since logs we already have figured out how to
create modals, so let's reuse that code.

<img width="799" height="350" alt="Screenshot from 2026-03-22 11-48-53" src="https://github.com/user-attachments/assets/1284b2f9-589e-4188-821e-341bfa426f77" />
<img width="634" height="181" alt="Screenshot from 2026-03-22 11-48-42" src="https://github.com/user-attachments/assets/afc7c4b2-9d8f-4cf2-9deb-76dabac14fea" />


## Pull Request Checklist

- [ ] The Rayhunter team has recently expressed interest in reviewing a PR for this.
  - If not, this PR may be closed due our limited resources and need to prioritize how we spend them.
- [ ] Added or updated any documentation as needed to support the changes in this PR.
- [ ] Code has been linted and run through `cargo fmt`.
- [ ] If any new functionality has been added, unit tests were also added.
- [x] [CONTRIBUTING.md](https://github.com/EFForg/rayhunter/blob/main/CONTRIBUTING.md) has been read.

You must check one of:
- [ ] No generative AI (including LLMs) tools were used to create this PR.
- [x] Generative AI was used to create this PR. I certify that I have read and understand the code, and *that all comments and descriptions were authored by myself* and are not the product of generative AI.
