### PR TITLE
Upgrade rustls-webpki to fix CVE

### DIFF
--- a/.cargo/audit.toml
+++ b/.cargo/audit.toml
@@ -8,4 +8,8 @@ ignore = [
     # user-input. we could get rid of this warning by disabling the image
     # dependency in adb-client.
     "RUSTSEC-2024-0436",
+    # rustls-webpki 0.102.8 CRL Distribution Point flaw (via rustls-rustcrypto).
+    # Only affects dev builds, production firmware uses ring-tls.
+    # TODO: Remove once rustls-rustcrypto releases a version newer than 0.0.2-alpha.
+    "RUSTSEC-2026-0049",
 ]

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4990,7 +4990,7 @@ dependencies = [
  "once_cell",
  "ring",
  "rustls-pki-types",
- "rustls-webpki 0.103.3",
+ "rustls-webpki 0.103.10",
  "subtle",
  "zeroize",
 ]
@@ -5048,9 +5048,9 @@ dependencies = [
 
 [[package]]
 name = "rustls-webpki"
-version = "0.103.3"
+version = "0.103.10"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e4a72fe2bcf7a6ac6fd7d0b9e5cb68aeb7d4c0a0271730218b3e92d43b4eb435"
+checksum = "df33b2b81ac578cabaf06b89b0631153a3f416b0a886e8a7a1707fb51abbd1ef"
 dependencies = [
  "ring",
  "rustls-pki-types",


### PR DESCRIPTION
We have two versions of rustls-webpki in our deptree:

- One used in the ring backend (0.103), which we're upgrading here
- One used in the rustcrypto backend (0.102), which we can't upgrade and
  therefore have to ignore the CVE anyway.

The ring backend is the one we actually use in release builds.
rustcrypto is only used during development builds to make compilation
simpler.

## Pull Request Checklist

- [ ] The Rayhunter team has recently expressed interest in reviewing a PR for this.
  - If not, this PR may be closed due our limited resources and need to prioritize how we spend them.
- [ ] Added or updated any documentation as needed to support the changes in this PR.
- [ ] Code has been linted and run through `cargo fmt`.
- [ ] If any new functionality has been added, unit tests were also added.
- [x] [CONTRIBUTING.md](https://github.com/EFForg/rayhunter/blob/main/CONTRIBUTING.md) has been read.

You must check one of:
- [ ] No generative AI (including LLMs) tools were used to create this PR.
- [x] Generative AI was used to create this PR. I certify that I have read and understand the code, and *that all comments and descriptions were authored by myself* and are not the product of generative AI.
