### PR TITLE
Add notification timeout

### DIFF
--- a/daemon/src/notifications.rs
+++ b/daemon/src/notifications.rs
@@ -10,6 +10,8 @@ use thiserror::Error;
 use tokio::sync::mpsc::{self, error::TryRecvError};
 use tokio_util::task::TaskTracker;
 
+pub const DEFAULT_NOTIFICATION_TIMEOUT: u64 = 10; //seconds
+
 #[derive(Error, Debug)]
 pub enum NotificationError {
     #[error("HTTP request failed: {0}")]
@@ -56,6 +58,7 @@ struct NotificationStatus {
 
 pub struct NotificationService {
     url: Option<String>,
+    timeout: u64,
     tx: mpsc::Sender<Notification>,
     rx: mpsc::Receiver<Notification>,
 }
@@ -63,7 +66,12 @@ pub struct NotificationService {
 impl NotificationService {
     pub fn new(url: Option<String>) -> Self {
         let (tx, rx) = mpsc::channel(10);
-        Self { url, tx, rx }
+        Self {
+            url,
+            timeout: DEFAULT_NOTIFICATION_TIMEOUT,
+            tx,
+            rx,
+        }
     }
 
     pub fn new_handler(&self) -> mpsc::Sender<Notification> {
@@ -76,8 +84,14 @@ pub async fn send_notification(
     http_client: &reqwest::Client,
     url: &str,
     message: String,
+    timeout: u64,
 ) -> Result<(), NotificationError> {
-    let response = http_client.post(url).body(message).send().await?;
+    let response = http_client
+        .post(url)
+        .body(message)
+        .timeout(Duration::from_secs(timeout))
+        .send()
+        .await?;
 
     if response.status().is_success() {
         Ok(())
@@ -151,7 +165,13 @@ pub fn run_notification_worker(
                         }
                     }
 
-                    match send_notification(&http_client, &url, notification.message.clone()).await
+                    match send_notification(
+                        &http_client,
+                        &url,
+                        notification.message.clone(),
+                        notification_service.timeout,
+                    )
+                    .await
                     {
                         Ok(()) => {
                             notification.last_sent = Some(Instant::now());
@@ -230,10 +250,54 @@ mod tests {
         (received_messages, url)
     }
 
+    async fn setup_timeout_server(timeout: u64) -> String {
+        #[cfg(feature = "rustcrypto-tls")]
+        {
+            let _ = rustls_rustcrypto::provider().install_default();
+        }
+
+        let listener = TcpListener::bind("127.0.0.1:0").await.unwrap();
+        let addr = listener.local_addr().unwrap();
+        let url = format!("http://{}", addr);
+
+        tokio::spawn(async move {
+            // Accept the connection but don't respond in the timeout
+            let (_socket, _addr) = listener.accept().await.unwrap();
+            tokio::time::sleep(Duration::from_secs(timeout * 2)).await;
+        });
+
+        tokio::time::sleep(Duration::from_millis(100)).await;
+
+        url
+    }
+
     async fn cleanup_worker(sender: mpsc::Sender<Notification>, tracker: TaskTracker) {
         drop(sender);
         tracker.close();
         tracker.wait().await;
+    }
+
+    #[tokio::test]
+    async fn test_send_notification_times_out() {
+        let timeout: u64 = 2;
+        let url = setup_timeout_server(timeout).await;
+
+        let http_client = reqwest::Client::new();
+        let result = send_notification(
+            &http_client,
+            &url,
+            "test warning message".to_string(),
+            timeout,
+        )
+        .await;
+
+        match result {
+            Err(NotificationError::RequestFailed(reqwest_error)) => {
+                println!("error = {:?}", reqwest_error);
+                assert!(reqwest_error.is_timeout());
+            }
+            _ => assert!(false),
+        }
     }
 
     #[tokio::test]

--- a/daemon/src/server.rs
+++ b/daemon/src/server.rs
@@ -25,6 +25,7 @@ use crate::analysis::{AnalysisCtrlMessage, AnalysisStatus};
 use crate::config::Config;
 use crate::diag::DiagDeviceCtrlMessage;
 use crate::display::DisplayState;
+use crate::notifications::DEFAULT_NOTIFICATION_TIMEOUT;
 use crate::pcap::generate_pcap_data;
 use crate::qmdl_store::RecordingStore;
 
@@ -209,20 +210,25 @@ pub async fn test_notification(
     let http_client = reqwest::Client::new();
     let message = "Test notification from Rayhunter".to_string();
 
-    crate::notifications::send_notification(&http_client, url, message)
-        .await
-        .map(|()| {
-            (
-                StatusCode::OK,
-                "Test notification sent successfully".to_string(),
-            )
-        })
-        .map_err(|e| {
-            (
-                StatusCode::INTERNAL_SERVER_ERROR,
-                format!("Failed to send test notification: {e}"),
-            )
-        })
+    crate::notifications::send_notification(
+        &http_client,
+        url,
+        message,
+        DEFAULT_NOTIFICATION_TIMEOUT,
+    )
+    .await
+    .map(|()| {
+        (
+            StatusCode::OK,
+            "Test notification sent successfully".to_string(),
+        )
+    })
+    .map_err(|e| {
+        (
+            StatusCode::INTERNAL_SERVER_ERROR,
+            format!("Failed to send test notification: {e}"),
+        )
+    })
 }
 
 /// Response for GET /api/time


### PR DESCRIPTION
Adds a default timeout of 10 seconds for sending notifications so they don't hang indefinitely. This can happen if the server connected to is not responding or the case where there's a SIM card in the device, but it's unactivated so that DNS works but the connection doesn't.

I understand that this probably isn't high on the list of priorities, and if you decide not to bother with it, that's okay by me. I mainly wanted to use this as a way to get familiar with the codebase and the dos and don'ts of contributing so I can help out in the future.

## Pull Request Checklist

- [ ] The Rayhunter team has recently expressed interest in reviewing a PR for this.
  - If not, this PR may be closed due our limited resources and need to prioritize how we spend them.
- [ ] Added or updated any documentation as needed to support the changes in this PR.
- [x] Code has been linted and run through `cargo fmt`.
- [x] If any new functionality has been added, unit tests were also added.
- [x] [CONTRIBUTING.md](https://github.com/EFForg/rayhunter/blob/main/CONTRIBUTING.md) has been read.

You must check one of:
- [x] No generative AI (including LLMs) tools were used to create this PR.
- [ ] Generative AI was used to create this PR. I certify that I have read and understand the code, and *that all comments and descriptions were authored by myself* and are not the product of generative AI.
