### PR TITLE
Add support for WebDAV

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -594,11 +594,11 @@ checksum = "bef38d45163c2f1dde094a7dfd33ccf595c92905c8f8f4fdc18d06fb1037718a"
 
 [[package]]
 name = "bitflags"
-version = "2.11.0"
+version = "2.9.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "843867be96c8daad0d758b57df9392b6d8d271134fce549de6ce169ff98a92af"
+checksum = "1b8e56985ec62d17e9c1001dc89c88ecd7dc08e47eba5ec7c29c7b5eeecde967"
 dependencies = [
- "serde_core",
+ "serde",
 ]
 
 [[package]]
@@ -744,7 +744,7 @@ version = "0.18.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8ca26ef0159422fb77631dc9d17b102f253b876fe1586b03b803e63a309b4ee2"
 dependencies = [
- "bitflags 2.11.0",
+ "bitflags 2.9.1",
  "cairo-sys-rs",
  "glib",
  "libc",
@@ -807,9 +807,9 @@ dependencies = [
 
 [[package]]
 name = "cc"
-version = "1.2.60"
+version = "1.2.59"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "43c5703da9466b66a946814e1adf53ea2c90f10063b86290cc9eb67ce3478a20"
+checksum = "b7a4d3ec6524d28a329fc53654bbadc9bdd7b0431f5d65f1a56ffb28a1ee5283"
 dependencies = [
  "find-msvc-tools",
  "jobserver",
@@ -1040,7 +1040,7 @@ version = "0.24.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "fa95a34622365fa5bbf40b20b75dba8dfa8c94c734aea8ac9a5ca38af14316f1"
 dependencies = [
- "bitflags 2.11.0",
+ "bitflags 2.9.1",
  "core-foundation 0.10.1",
  "core-graphics-types",
  "foreign-types",
@@ -1053,7 +1053,7 @@ version = "0.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3d44a101f213f6c4cdc1853d4b78aef6db6bdfa3468798cc1d9912f4735013eb"
 dependencies = [
- "bitflags 2.11.0",
+ "bitflags 2.9.1",
  "core-foundation 0.10.1",
  "libc",
 ]
@@ -1438,7 +1438,7 @@ version = "0.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "89a09f22a6c6069a18470eb92d2298acf25463f14256d24778e1230d789a2aec"
 dependencies = [
- "bitflags 2.11.0",
+ "bitflags 2.9.1",
  "objc2 0.6.3",
 ]
 
@@ -2173,7 +2173,7 @@ version = "0.18.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "233daaf6e83ae6a12a52055f568f9d7cf4671dabb78ff9560ab6da230ce00ee5"
 dependencies = [
- "bitflags 2.11.0",
+ "bitflags 2.9.1",
  "futures-channel",
  "futures-core",
  "futures-executor",
@@ -3018,7 +3018,7 @@ version = "0.7.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b750dcadc39a09dbadd74e118f6dd6598df77fa01df0cfcdc52c28dece74528a"
 dependencies = [
- "bitflags 2.11.0",
+ "bitflags 2.9.1",
  "serde",
  "unicode-segmentation",
 ]
@@ -3112,7 +3112,7 @@ version = "0.1.10"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "416f7e718bdb06000964960ffa43b4335ad4012ae8b99060261aa4a8088d5ccb"
 dependencies = [
- "bitflags 2.11.0",
+ "bitflags 2.9.1",
  "libc",
 ]
 
@@ -3343,7 +3343,7 @@ version = "0.9.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c3f42e7bbe13d351b6bead8286a43aac9534b82bd3cc43e47037f012ebfd62d4"
 dependencies = [
- "bitflags 2.11.0",
+ "bitflags 2.9.1",
  "jni-sys",
  "log",
  "ndk-sys",
@@ -3379,7 +3379,7 @@ version = "0.29.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "71e2746dc3a24dd78b3cfcb7be93368c6de9963d30f43a6a73998a9cf4b17b46"
 dependencies = [
- "bitflags 2.11.0",
+ "bitflags 2.9.1",
  "cfg-if",
  "cfg_aliases",
  "libc",
@@ -3391,7 +3391,7 @@ version = "0.30.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "74523f3a35e05aba87a1d978330aef40f67b0304ac79c1c00b294c9830543db6"
 dependencies = [
- "bitflags 2.11.0",
+ "bitflags 2.9.1",
  "cfg-if",
  "cfg_aliases",
  "libc",
@@ -3596,7 +3596,7 @@ version = "0.3.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d49e936b501e5c5bf01fda3a9452ff86dc3ea98ad5f283e1455153142d97518c"
 dependencies = [
- "bitflags 2.11.0",
+ "bitflags 2.9.1",
  "block2 0.6.2",
  "objc2 0.6.3",
  "objc2-core-foundation",
@@ -3609,7 +3609,7 @@ version = "0.3.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2a180dd8642fa45cdb7dd721cd4c11b1cadd4929ce112ebd8b9f5803cc79d536"
 dependencies = [
- "bitflags 2.11.0",
+ "bitflags 2.9.1",
  "dispatch2",
  "objc2 0.6.3",
 ]
@@ -3620,7 +3620,7 @@ version = "0.3.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e022c9d066895efa1345f8e33e584b9f958da2fd4cd116792e15e07e4720a807"
 dependencies = [
- "bitflags 2.11.0",
+ "bitflags 2.9.1",
  "objc2-core-foundation",
 ]
 
@@ -3645,7 +3645,7 @@ version = "0.2.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0ee638a5da3799329310ad4cfa62fbf045d5f56e3ef5ba4149e7452dcf89d5a8"
 dependencies = [
- "bitflags 2.11.0",
+ "bitflags 2.9.1",
  "block2 0.5.1",
  "libc",
  "objc2 0.5.2",
@@ -3657,7 +3657,7 @@ version = "0.3.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e3e0adef53c21f888deb4fa59fc59f7eb17404926ee8a6f59f5df0fd7f9f3272"
 dependencies = [
- "bitflags 2.11.0",
+ "bitflags 2.9.1",
  "block2 0.6.2",
  "objc2 0.6.3",
  "objc2-core-foundation",
@@ -3669,7 +3669,7 @@ version = "0.2.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "dd0cba1276f6023976a406a14ffa85e1fdd19df6b0f737b063b95f6c8c7aadd6"
 dependencies = [
- "bitflags 2.11.0",
+ "bitflags 2.9.1",
  "block2 0.5.1",
  "objc2 0.5.2",
  "objc2-foundation 0.2.2",
@@ -3681,7 +3681,7 @@ version = "0.2.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e42bee7bff906b14b167da2bac5efe6b6a07e6f7c0a21a7308d40c960242dc7a"
 dependencies = [
- "bitflags 2.11.0",
+ "bitflags 2.9.1",
  "block2 0.5.1",
  "objc2 0.5.2",
  "objc2-foundation 0.2.2",
@@ -3694,7 +3694,7 @@ version = "0.3.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d87d638e33c06f577498cbcc50491496a3ed4246998a7fbba7ccb98b1e7eab22"
 dependencies = [
- "bitflags 2.11.0",
+ "bitflags 2.9.1",
  "objc2 0.6.3",
  "objc2-core-foundation",
  "objc2-foundation 0.3.2",
@@ -3706,7 +3706,7 @@ version = "0.3.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b2e5aaab980c433cf470df9d7af96a7b46a9d892d521a2cbbb2f8a4c16751e7f"
 dependencies = [
- "bitflags 2.11.0",
+ "bitflags 2.9.1",
  "block2 0.6.2",
  "objc2 0.6.3",
  "objc2-app-kit",
@@ -4633,7 +4633,7 @@ version = "0.5.18"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ed2bf2547551a7053d6fdfafda3f938979645c44812fbfcda098faae3f1a362d"
 dependencies = [
- "bitflags 2.11.0",
+ "bitflags 2.9.1",
 ]
 
 [[package]]
@@ -4859,7 +4859,7 @@ version = "0.38.44"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "fdb5bc1ae2baa591800df16c9ca78619bf65c0488b41b96ccec5d11220d8c154"
 dependencies = [
- "bitflags 2.11.0",
+ "bitflags 2.9.1",
  "errno",
  "libc",
  "linux-raw-sys 0.4.15",
@@ -4872,7 +4872,7 @@ version = "1.0.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c71e83d6afe7ff64890ec6b71d6a69bb8a610ab78ce364b3352876bb4c801266"
 dependencies = [
- "bitflags 2.11.0",
+ "bitflags 2.9.1",
  "errno",
  "libc",
  "linux-raw-sys 0.9.4",
@@ -5552,7 +5552,7 @@ version = "0.34.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f3a753bdc39c07b192151523a3f77cd0394aa75413802c883a0f6f6a0e5ee2e7"
 dependencies = [
- "bitflags 2.11.0",
+ "bitflags 2.9.1",
  "block2 0.6.2",
  "core-foundation 0.10.1",
  "core-graphics",
@@ -6234,7 +6234,7 @@ version = "0.6.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d4e6559d53cc268e5031cd8429d05415bc4cb4aefc4aa5d6cc35fbf5b924a1f8"
 dependencies = [
- "bitflags 2.11.0",
+ "bitflags 2.9.1",
  "bytes",
  "futures-util",
  "http",
@@ -7337,7 +7337,7 @@ version = "0.39.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6f42320e61fe2cfd34354ecb597f86f413484a798ba44a8ca1165c58d42da6c1"
 dependencies = [
- "bitflags 2.11.0",
+ "bitflags 2.9.1",
 ]
 
 [[package]]

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -594,11 +594,11 @@ checksum = "bef38d45163c2f1dde094a7dfd33ccf595c92905c8f8f4fdc18d06fb1037718a"
 
 [[package]]
 name = "bitflags"
-version = "2.9.1"
+version = "2.11.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1b8e56985ec62d17e9c1001dc89c88ecd7dc08e47eba5ec7c29c7b5eeecde967"
+checksum = "843867be96c8daad0d758b57df9392b6d8d271134fce549de6ce169ff98a92af"
 dependencies = [
- "serde",
+ "serde_core",
 ]
 
 [[package]]
@@ -744,7 +744,7 @@ version = "0.18.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8ca26ef0159422fb77631dc9d17b102f253b876fe1586b03b803e63a309b4ee2"
 dependencies = [
- "bitflags 2.9.1",
+ "bitflags 2.11.0",
  "cairo-sys-rs",
  "glib",
  "libc",
@@ -807,9 +807,9 @@ dependencies = [
 
 [[package]]
 name = "cc"
-version = "1.2.59"
+version = "1.2.60"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b7a4d3ec6524d28a329fc53654bbadc9bdd7b0431f5d65f1a56ffb28a1ee5283"
+checksum = "43c5703da9466b66a946814e1adf53ea2c90f10063b86290cc9eb67ce3478a20"
 dependencies = [
  "find-msvc-tools",
  "jobserver",
@@ -1040,7 +1040,7 @@ version = "0.24.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "fa95a34622365fa5bbf40b20b75dba8dfa8c94c734aea8ac9a5ca38af14316f1"
 dependencies = [
- "bitflags 2.9.1",
+ "bitflags 2.11.0",
  "core-foundation 0.10.1",
  "core-graphics-types",
  "foreign-types",
@@ -1053,7 +1053,7 @@ version = "0.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3d44a101f213f6c4cdc1853d4b78aef6db6bdfa3468798cc1d9912f4735013eb"
 dependencies = [
- "bitflags 2.9.1",
+ "bitflags 2.11.0",
  "core-foundation 0.10.1",
  "libc",
 ]
@@ -1438,7 +1438,7 @@ version = "0.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "89a09f22a6c6069a18470eb92d2298acf25463f14256d24778e1230d789a2aec"
 dependencies = [
- "bitflags 2.9.1",
+ "bitflags 2.11.0",
  "objc2 0.6.3",
 ]
 
@@ -2173,7 +2173,7 @@ version = "0.18.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "233daaf6e83ae6a12a52055f568f9d7cf4671dabb78ff9560ab6da230ce00ee5"
 dependencies = [
- "bitflags 2.9.1",
+ "bitflags 2.11.0",
  "futures-channel",
  "futures-core",
  "futures-executor",
@@ -3018,7 +3018,7 @@ version = "0.7.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b750dcadc39a09dbadd74e118f6dd6598df77fa01df0cfcdc52c28dece74528a"
 dependencies = [
- "bitflags 2.9.1",
+ "bitflags 2.11.0",
  "serde",
  "unicode-segmentation",
 ]
@@ -3112,7 +3112,7 @@ version = "0.1.10"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "416f7e718bdb06000964960ffa43b4335ad4012ae8b99060261aa4a8088d5ccb"
 dependencies = [
- "bitflags 2.9.1",
+ "bitflags 2.11.0",
  "libc",
 ]
 
@@ -3343,7 +3343,7 @@ version = "0.9.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c3f42e7bbe13d351b6bead8286a43aac9534b82bd3cc43e47037f012ebfd62d4"
 dependencies = [
- "bitflags 2.9.1",
+ "bitflags 2.11.0",
  "jni-sys",
  "log",
  "ndk-sys",
@@ -3379,7 +3379,7 @@ version = "0.29.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "71e2746dc3a24dd78b3cfcb7be93368c6de9963d30f43a6a73998a9cf4b17b46"
 dependencies = [
- "bitflags 2.9.1",
+ "bitflags 2.11.0",
  "cfg-if",
  "cfg_aliases",
  "libc",
@@ -3391,7 +3391,7 @@ version = "0.30.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "74523f3a35e05aba87a1d978330aef40f67b0304ac79c1c00b294c9830543db6"
 dependencies = [
- "bitflags 2.9.1",
+ "bitflags 2.11.0",
  "cfg-if",
  "cfg_aliases",
  "libc",
@@ -3596,7 +3596,7 @@ version = "0.3.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d49e936b501e5c5bf01fda3a9452ff86dc3ea98ad5f283e1455153142d97518c"
 dependencies = [
- "bitflags 2.9.1",
+ "bitflags 2.11.0",
  "block2 0.6.2",
  "objc2 0.6.3",
  "objc2-core-foundation",
@@ -3609,7 +3609,7 @@ version = "0.3.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2a180dd8642fa45cdb7dd721cd4c11b1cadd4929ce112ebd8b9f5803cc79d536"
 dependencies = [
- "bitflags 2.9.1",
+ "bitflags 2.11.0",
  "dispatch2",
  "objc2 0.6.3",
 ]
@@ -3620,7 +3620,7 @@ version = "0.3.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e022c9d066895efa1345f8e33e584b9f958da2fd4cd116792e15e07e4720a807"
 dependencies = [
- "bitflags 2.9.1",
+ "bitflags 2.11.0",
  "objc2-core-foundation",
 ]
 
@@ -3645,7 +3645,7 @@ version = "0.2.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0ee638a5da3799329310ad4cfa62fbf045d5f56e3ef5ba4149e7452dcf89d5a8"
 dependencies = [
- "bitflags 2.9.1",
+ "bitflags 2.11.0",
  "block2 0.5.1",
  "libc",
  "objc2 0.5.2",
@@ -3657,7 +3657,7 @@ version = "0.3.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e3e0adef53c21f888deb4fa59fc59f7eb17404926ee8a6f59f5df0fd7f9f3272"
 dependencies = [
- "bitflags 2.9.1",
+ "bitflags 2.11.0",
  "block2 0.6.2",
  "objc2 0.6.3",
  "objc2-core-foundation",
@@ -3669,7 +3669,7 @@ version = "0.2.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "dd0cba1276f6023976a406a14ffa85e1fdd19df6b0f737b063b95f6c8c7aadd6"
 dependencies = [
- "bitflags 2.9.1",
+ "bitflags 2.11.0",
  "block2 0.5.1",
  "objc2 0.5.2",
  "objc2-foundation 0.2.2",
@@ -3681,7 +3681,7 @@ version = "0.2.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e42bee7bff906b14b167da2bac5efe6b6a07e6f7c0a21a7308d40c960242dc7a"
 dependencies = [
- "bitflags 2.9.1",
+ "bitflags 2.11.0",
  "block2 0.5.1",
  "objc2 0.5.2",
  "objc2-foundation 0.2.2",
@@ -3694,7 +3694,7 @@ version = "0.3.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d87d638e33c06f577498cbcc50491496a3ed4246998a7fbba7ccb98b1e7eab22"
 dependencies = [
- "bitflags 2.9.1",
+ "bitflags 2.11.0",
  "objc2 0.6.3",
  "objc2-core-foundation",
  "objc2-foundation 0.3.2",
@@ -3706,7 +3706,7 @@ version = "0.3.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b2e5aaab980c433cf470df9d7af96a7b46a9d892d521a2cbbb2f8a4c16751e7f"
 dependencies = [
- "bitflags 2.9.1",
+ "bitflags 2.11.0",
  "block2 0.6.2",
  "objc2 0.6.3",
  "objc2-app-kit",
@@ -4633,7 +4633,7 @@ version = "0.5.18"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ed2bf2547551a7053d6fdfafda3f938979645c44812fbfcda098faae3f1a362d"
 dependencies = [
- "bitflags 2.9.1",
+ "bitflags 2.11.0",
 ]
 
 [[package]]
@@ -4705,6 +4705,7 @@ dependencies = [
  "base64 0.22.1",
  "bytes",
  "futures-core",
+ "futures-util",
  "http",
  "http-body",
  "http-body-util",
@@ -4723,12 +4724,14 @@ dependencies = [
  "sync_wrapper",
  "tokio",
  "tokio-rustls",
+ "tokio-util",
  "tower",
  "tower-http",
  "tower-service",
  "url",
  "wasm-bindgen",
  "wasm-bindgen-futures",
+ "wasm-streams 0.4.2",
  "web-sys",
  "webpki-roots",
 ]
@@ -4763,7 +4766,7 @@ dependencies = [
  "url",
  "wasm-bindgen",
  "wasm-bindgen-futures",
- "wasm-streams",
+ "wasm-streams 0.5.0",
  "web-sys",
 ]
 
@@ -4856,7 +4859,7 @@ version = "0.38.44"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "fdb5bc1ae2baa591800df16c9ca78619bf65c0488b41b96ccec5d11220d8c154"
 dependencies = [
- "bitflags 2.9.1",
+ "bitflags 2.11.0",
  "errno",
  "libc",
  "linux-raw-sys 0.4.15",
@@ -4869,7 +4872,7 @@ version = "1.0.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c71e83d6afe7ff64890ec6b71d6a69bb8a610ab78ce364b3352876bb4c801266"
 dependencies = [
- "bitflags 2.9.1",
+ "bitflags 2.11.0",
  "errno",
  "libc",
  "linux-raw-sys 0.9.4",
@@ -5549,7 +5552,7 @@ version = "0.34.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f3a753bdc39c07b192151523a3f77cd0394aa75413802c883a0f6f6a0e5ee2e7"
 dependencies = [
- "bitflags 2.9.1",
+ "bitflags 2.11.0",
  "block2 0.6.2",
  "core-foundation 0.10.1",
  "core-graphics",
@@ -6231,7 +6234,7 @@ version = "0.6.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d4e6559d53cc268e5031cd8429d05415bc4cb4aefc4aa5d6cc35fbf5b924a1f8"
 dependencies = [
- "bitflags 2.9.1",
+ "bitflags 2.11.0",
  "bytes",
  "futures-util",
  "http",
@@ -6625,6 +6628,19 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5fd04d9e306f1907bd13c6361b5c6bfc7b3b3c095ed3f8a9246390f8dbdee129"
 dependencies = [
  "unicode-ident",
+]
+
+[[package]]
+name = "wasm-streams"
+version = "0.4.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "15053d8d85c7eccdbefef60f06769760a563c7f0a9d6902a13d35c7800b0ad65"
+dependencies = [
+ "futures-util",
+ "js-sys",
+ "wasm-bindgen",
+ "wasm-bindgen-futures",
+ "web-sys",
 ]
 
 [[package]]
@@ -7321,7 +7337,7 @@ version = "0.39.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6f42320e61fe2cfd34354ecb597f86f413484a798ba44a8ca1165c58d42da6c1"
 dependencies = [
- "bitflags 2.9.1",
+ "bitflags 2.11.0",
 ]
 
 [[package]]

--- a/daemon/Cargo.toml
+++ b/daemon/Cargo.toml
@@ -15,8 +15,14 @@ required-features = ["apidocs"]
 
 [features]
 default = ["rustcrypto-tls"]
-rustcrypto-tls = ["reqwest/rustls-tls-webpki-roots-no-provider", "dep:rustls-rustcrypto"]
-pq-tls = ["reqwest/rustls-tls-webpki-roots-no-provider", "dep:rustls-post-quantum"]
+rustcrypto-tls = [
+    "reqwest/rustls-tls-webpki-roots-no-provider",
+    "dep:rustls-rustcrypto",
+]
+pq-tls = [
+    "reqwest/rustls-tls-webpki-roots-no-provider",
+    "dep:rustls-post-quantum",
+]
 apidocs = ["dep:utoipa", "wifi-station/utoipa"]
 
 [dependencies]
@@ -24,8 +30,17 @@ rayhunter = { path = "../lib" }
 wifi-station = { git = "https://github.com/BeigeBox/wifi-station", rev = "e8ec5b4" }
 toml = "0.8.8"
 serde = { version = "1.0.193", features = ["derive"] }
-tokio = { version = "1.44.2", default-features = false, features = ["fs", "signal", "process", "rt"] }
-axum = { version = "0.8", default-features = false, features = ["http1", "tokio", "json"] }
+tokio = { version = "1.44.2", default-features = false, features = [
+    "fs",
+    "signal",
+    "process",
+    "rt",
+] }
+axum = { version = "0.8", default-features = false, features = [
+    "http1",
+    "tokio",
+    "json",
+] }
 thiserror = "1.0.52"
 libc = "0.2.150"
 log = "0.4.20"
@@ -33,14 +48,21 @@ tokio-util = { version = "0.7.10", features = ["rt", "io", "compat"] }
 futures-macro = "0.3.30"
 include_dir = "0.7.3"
 chrono = { version = "0.4.31", features = ["serde"] }
-tokio-stream = { version = "0.1.14", default-features = false, features = ["io-util"] }
+tokio-stream = { version = "0.1.14", default-features = false, features = [
+    "io-util",
+] }
 futures = { version = "0.3.30", default-features = false }
 serde_json = "1.0.114"
-image = { version =  "0.25.1", default-features = false, features = ["png", "gif"] }
+image = { version = "0.25.1", default-features = false, features = [
+    "png",
+    "gif",
+] }
 tempfile = "3.10.2"
 async_zip = { version = "0.0.17", features = ["tokio"] }
 anyhow = "1.0.98"
-reqwest = { version = "0.12.20", default-features = false }
+reqwest = { version = "0.12.20", default-features = false, features = [
+    "stream",
+] }
 rustls-rustcrypto = { version = "0.0.2-alpha", optional = true }
 rustls-post-quantum = { version = "0.2.4", optional = true }
 async-trait = "0.1.88"

--- a/daemon/Cargo.toml
+++ b/daemon/Cargo.toml
@@ -15,14 +15,8 @@ required-features = ["apidocs"]
 
 [features]
 default = ["rustcrypto-tls"]
-rustcrypto-tls = [
-    "reqwest/rustls-tls-webpki-roots-no-provider",
-    "dep:rustls-rustcrypto",
-]
-pq-tls = [
-    "reqwest/rustls-tls-webpki-roots-no-provider",
-    "dep:rustls-post-quantum",
-]
+rustcrypto-tls = ["reqwest/rustls-tls-webpki-roots-no-provider", "dep:rustls-rustcrypto"]
+pq-tls = ["reqwest/rustls-tls-webpki-roots-no-provider", "dep:rustls-post-quantum"]
 apidocs = ["dep:utoipa", "wifi-station/utoipa"]
 
 [dependencies]
@@ -30,17 +24,8 @@ rayhunter = { path = "../lib" }
 wifi-station = { git = "https://github.com/BeigeBox/wifi-station", rev = "e8ec5b4" }
 toml = "0.8.8"
 serde = { version = "1.0.193", features = ["derive"] }
-tokio = { version = "1.44.2", default-features = false, features = [
-    "fs",
-    "signal",
-    "process",
-    "rt",
-] }
-axum = { version = "0.8", default-features = false, features = [
-    "http1",
-    "tokio",
-    "json",
-] }
+tokio = { version = "1.44.2", default-features = false, features = ["fs", "signal", "process", "rt"] }
+axum = { version = "0.8", default-features = false, features = ["http1", "tokio", "json"] }
 thiserror = "1.0.52"
 libc = "0.2.150"
 log = "0.4.20"
@@ -48,21 +33,14 @@ tokio-util = { version = "0.7.10", features = ["rt", "io", "compat"] }
 futures-macro = "0.3.30"
 include_dir = "0.7.3"
 chrono = { version = "0.4.31", features = ["serde"] }
-tokio-stream = { version = "0.1.14", default-features = false, features = [
-    "io-util",
-] }
+tokio-stream = { version = "0.1.14", default-features = false, features = ["io-util"] }
 futures = { version = "0.3.30", default-features = false }
 serde_json = "1.0.114"
-image = { version = "0.25.1", default-features = false, features = [
-    "png",
-    "gif",
-] }
+image = { version =  "0.25.1", default-features = false, features = ["png", "gif"] }
 tempfile = "3.10.2"
 async_zip = { version = "0.0.17", features = ["tokio"] }
 anyhow = "1.0.98"
-reqwest = { version = "0.12.20", default-features = false, features = [
-    "stream",
-] }
+reqwest = { version = "0.12.20", default-features = false, features = ["stream"] }
 rustls-rustcrypto = { version = "0.0.2-alpha", optional = true }
 rustls-post-quantum = { version = "0.2.4", optional = true }
 async-trait = "0.1.88"

--- a/daemon/src/config.rs
+++ b/daemon/src/config.rs
@@ -67,6 +67,8 @@ pub struct WebdavConfig {
     pub username: Option<String>,
     /// Optional password for HTTP Basic auth
     pub password: Option<String>,
+    /// Timeout (in seconds) for each upload request
+    pub upload_timeout_secs: u64,
     /// How often (in seconds) the worker scans for entries to upload
     pub poll_interval_secs: u64,
     /// Minimum age (in seconds) an entry must have before it becomes eligible for upload
@@ -82,6 +84,7 @@ impl Default for WebdavConfig {
             remote_path: "/".to_string(),
             username: None,
             password: None,
+            upload_timeout_secs: 300,
             poll_interval_secs: 3600,
             min_age_secs: 86400,
             delete_on_upload: false,

--- a/daemon/src/config.rs
+++ b/daemon/src/config.rs
@@ -50,6 +50,43 @@ pub struct Config {
     pub firewall_restrict_outbound: bool,
     /// Vector containing additional wifi client firewall ports to open
     pub firewall_allowed_ports: Option<Vec<u16>>,
+    /// Optional WebDAV upload configuration. When unset, no upload worker runs.
+    pub webdav: Option<WebdavConfig>,
+}
+
+/// Configuration for uploading finished QMDL recordings to a WebDAV server.
+#[derive(Debug, Clone, Deserialize, Serialize)]
+#[serde(default)]
+#[cfg_attr(feature = "apidocs", derive(utoipa::ToSchema))]
+pub struct WebdavConfig {
+    /// WebDAV server base URL, e.g. "https://dav.example.com"
+    pub host: String,
+    /// Remote directory to upload files under
+    pub remote_path: String,
+    /// Optional username for HTTP Basic auth
+    pub username: Option<String>,
+    /// Optional password for HTTP Basic auth
+    pub password: Option<String>,
+    /// How often (in seconds) the worker scans for entries to upload
+    pub poll_interval_secs: u64,
+    /// Minimum age (in seconds) an entry must have before it becomes eligible for upload
+    pub min_age_secs: i64,
+    /// Delete the file locally after a successful upload
+    pub delete_on_upload: bool,
+}
+
+impl Default for WebdavConfig {
+    fn default() -> Self {
+        WebdavConfig {
+            host: String::new(),
+            remote_path: "/".to_string(),
+            username: None,
+            password: None,
+            poll_interval_secs: 3600,
+            min_age_secs: 86400,
+            delete_on_upload: false,
+        }
+    }
 }
 
 impl Default for Config {
@@ -74,6 +111,7 @@ impl Default for Config {
             dns_servers: None,
             firewall_restrict_outbound: true,
             firewall_allowed_ports: None,
+            webdav: None,
         }
     }
 }

--- a/daemon/src/config.rs
+++ b/daemon/src/config.rs
@@ -59,10 +59,8 @@ pub struct Config {
 #[serde(default)]
 #[cfg_attr(feature = "apidocs", derive(utoipa::ToSchema))]
 pub struct WebdavConfig {
-    /// WebDAV server base URL, e.g. "https://dav.example.com"
-    pub host: String,
-    /// Remote directory to upload files under
-    pub remote_path: String,
+    /// WebDAV server base URL, e.g. "https://example.com/remote.php/files/untitaker/my-subfolder/"
+    pub url: String,
     /// Optional username for HTTP Basic auth
     pub username: Option<String>,
     /// Optional password for HTTP Basic auth
@@ -80,8 +78,7 @@ pub struct WebdavConfig {
 impl Default for WebdavConfig {
     fn default() -> Self {
         WebdavConfig {
-            host: String::new(),
-            remote_path: "/".to_string(),
+            url: String::new(),
             username: None,
             password: None,
             upload_timeout_secs: 300,

--- a/daemon/src/lib.rs
+++ b/daemon/src/lib.rs
@@ -12,6 +12,7 @@ pub mod pcap;
 pub mod qmdl_store;
 pub mod server;
 pub mod stats;
+pub mod webdav;
 
 #[cfg(feature = "apidocs")]
 use utoipa::OpenApi;

--- a/daemon/src/main.rs
+++ b/daemon/src/main.rs
@@ -12,6 +12,8 @@ mod pcap;
 mod qmdl_store;
 mod server;
 mod stats;
+mod webdav;
+
 use std::net::SocketAddr;
 use std::sync::Arc;
 
@@ -27,6 +29,7 @@ use crate::server::{
     scan_wifi, serve_static, set_config, set_time_offset, test_notification,
 };
 use crate::stats::{get_qmdl_manifest, get_system_stats};
+use crate::webdav::run_webdav_upload_worker;
 use wifi_station::WifiStatus;
 
 use analysis::{
@@ -295,6 +298,15 @@ async fn run_with_config(
         wifi_status.clone(),
     );
     firewall::apply(&config).await;
+
+    if let Some(webdav_config) = config.webdav.clone() {
+        run_webdav_upload_worker(
+            &task_tracker,
+            shutdown_token.clone(),
+            qmdl_store_lock.clone(),
+            webdav_config.into(),
+        );
+    }
 
     let state = Arc::new(ServerState {
         config_path: args.config_path.clone(),

--- a/daemon/src/qmdl_store.rs
+++ b/daemon/src/qmdl_store.rs
@@ -347,7 +347,8 @@ impl RecordingStore {
         Ok(())
     }
 
-    pub fn get_unuploaded_entries_with_age(&self, min_age: TimeDelta) -> Vec<String> {
+    pub fn get_next_unuploaded_entry(&self, min_age: TimeDelta) -> Option<String> {
+        let now = rayhunter::clock::get_adjusted_now();
         self.manifest
             .entries
             .iter()
@@ -355,12 +356,12 @@ impl RecordingStore {
                 if self.is_current_entry(&entry.name) || entry.upload_time.is_some() {
                     return None;
                 }
-                (rayhunter::clock::get_adjusted_now()
-                    - entry.last_message_time.unwrap_or(entry.start_time)
-                    > min_age)
-                    .then_some(entry.name.clone())
+                let age = now - entry.last_message_time.unwrap_or(entry.start_time);
+
+                (age > min_age).then_some((&entry.name, age))
             })
-            .collect()
+            .max_by_key(|(_, age)| *age)
+            .map(|(name, _)| name.clone())
     }
 
     // Finds an entry by filename
@@ -612,7 +613,7 @@ mod tests {
     }
 
     #[tokio::test]
-    async fn test_get_unuploaded_entries_with_age() {
+    async fn test_get_next_unuploaded_entry() {
         let dir = make_temp_dir();
         let mut store = RecordingStore::create(dir.path()).await.unwrap();
 
@@ -632,10 +633,27 @@ mod tests {
         store.manifest.entries[2].start_time = Local::now() - TimeDelta::seconds(10);
         store.manifest.entries[2].last_message_time = Some(Local::now() - TimeDelta::seconds(1));
 
-        let eligible = store.get_unuploaded_entries_with_age(TimeDelta::seconds(3));
-        assert_eq!(eligible, vec!["entry-0".to_string(), "entry-1".to_string()]);
+        assert_eq!(
+            store.get_next_unuploaded_entry(TimeDelta::seconds(3600)),
+            None,
+        );
 
-        let none_eligible = store.get_unuploaded_entries_with_age(TimeDelta::seconds(3600));
-        assert!(none_eligible.is_empty());
+        assert_eq!(
+            store.get_next_unuploaded_entry(TimeDelta::seconds(3)),
+            Some("entry-0".to_owned())
+        );
+        store
+            .mark_entry_as_uploaded("entry-0", Local::now())
+            .await
+            .unwrap();
+        assert_eq!(
+            store.get_next_unuploaded_entry(TimeDelta::seconds(3)),
+            Some("entry-1".to_owned())
+        );
+        store
+            .mark_entry_as_uploaded("entry-1", Local::now())
+            .await
+            .unwrap();
+        assert_eq!(store.get_next_unuploaded_entry(TimeDelta::seconds(3)), None);
     }
 }

--- a/daemon/src/qmdl_store.rs
+++ b/daemon/src/qmdl_store.rs
@@ -2,7 +2,7 @@ use std::io::{self, ErrorKind};
 use std::os::unix::fs::MetadataExt;
 use std::path::{Path, PathBuf};
 
-use chrono::{DateTime, Local};
+use chrono::{DateTime, Local, TimeDelta};
 use log::{info, warn};
 use rayhunter::util::RuntimeMetadata;
 use serde::{Deserialize, Serialize};
@@ -67,6 +67,9 @@ pub struct ManifestEntry {
     pub arch: Option<String>,
     #[serde(default)]
     pub stop_reason: Option<String>,
+    /// When the manifest was uploaded to a WebDAV server
+    #[cfg_attr(feature = "apidocs", schema(value_type = String))]
+    pub upload_time: Option<DateTime<Local>>,
 }
 
 impl ManifestEntry {
@@ -82,6 +85,7 @@ impl ManifestEntry {
             system_os: Some(metadata.system_os),
             arch: Some(metadata.arch),
             stop_reason: None,
+            upload_time: None,
         }
     }
 
@@ -212,6 +216,7 @@ impl RecordingStore {
                 system_os: None,
                 arch: None,
                 stop_reason: None,
+                upload_time: None,
             });
         }
 
@@ -342,6 +347,20 @@ impl RecordingStore {
         Ok(())
     }
 
+    pub fn get_unuploaded_entries_with_age(&self, min_age: TimeDelta) -> Vec<String> {
+        self.manifest
+            .entries
+            .iter()
+            .filter_map(|entry| {
+                if self.is_current_entry(&entry.name) || entry.upload_time.is_some() {
+                    return None;
+                }
+                (rayhunter::clock::get_adjusted_now() - entry.last_message_time? > min_age)
+                    .then_some(entry.name.clone())
+            })
+            .collect()
+    }
+
     // Finds an entry by filename
     pub fn entry_for_name(&self, name: &str) -> Option<(usize, &ManifestEntry)> {
         let entry_index = self
@@ -365,6 +384,22 @@ impl RecordingStore {
             self.manifest.entries[idx].stop_reason = Some(reason);
             self.write_manifest().await?;
         }
+        Ok(())
+    }
+
+    pub async fn mark_entry_as_uploaded(
+        &mut self,
+        name: &str,
+        upload_time: DateTime<Local>,
+    ) -> Result<(), RecordingStoreError> {
+        let entry_index = self
+            .manifest
+            .entries
+            .iter()
+            .position(|entry| entry.name == name)
+            .ok_or(RecordingStoreError::NoSuchEntryError)?;
+        self.manifest.entries[entry_index].upload_time = Some(upload_time);
+        self.write_manifest().await?;
         Ok(())
     }
 
@@ -543,5 +578,66 @@ mod tests {
         // recording.
         store.delete_all_entries().await.unwrap();
         assert!(store.current_entry.is_none());
+    }
+
+    #[tokio::test]
+    async fn test_mark_entry_as_uploaded_sets_time_and_persists() {
+        let dir = make_temp_dir();
+        let mut store = RecordingStore::create(dir.path()).await.unwrap();
+        let _ = store.new_entry().await.unwrap();
+        let name = store.manifest.entries[0].name.clone();
+        store.close_current_entry().await.unwrap();
+
+        let upload_time = Local::now();
+        store
+            .mark_entry_as_uploaded(&name, upload_time)
+            .await
+            .unwrap();
+        assert_eq!(store.manifest.entries[0].upload_time, Some(upload_time));
+
+        let reloaded = RecordingStore::load(dir.path()).await.unwrap();
+        assert_eq!(reloaded.manifest.entries[0].upload_time, Some(upload_time));
+    }
+
+    #[tokio::test]
+    async fn test_mark_entry_as_uploaded_missing_entry() {
+        let dir = make_temp_dir();
+        let mut store = RecordingStore::create(dir.path()).await.unwrap();
+        assert!(matches!(
+            store.mark_entry_as_uploaded("nope", Local::now()).await,
+            Err(RecordingStoreError::NoSuchEntryError)
+        ));
+    }
+
+    #[tokio::test]
+    async fn test_get_unuploaded_entries_with_age() {
+        let dir = make_temp_dir();
+        let mut store = RecordingStore::create(dir.path()).await.unwrap();
+
+        // Create four entries (the fourth stays current). new_entry names entries by
+        // integer-second timestamp, so rapid consecutive calls collide; rename explicitly
+        // so each entry has a distinct name.
+        for _ in 0..4 {
+            let _ = store.new_entry().await.unwrap();
+        }
+        for (i, entry) in store.manifest.entries.iter_mut().enumerate() {
+            entry.name = format!("entry-{}", i);
+        }
+
+        // Entry 0: closed, last_message_time = None → excluded by `?`.
+        // Entry 1: closed, last_message_time = Some(_), upload_time = Some(_) → excluded.
+        store.manifest.entries[1].last_message_time = Some(Local::now());
+        store.manifest.entries[1].upload_time = Some(Local::now());
+        // Entry 2: closed, last_message_time = Some(_), upload_time = None → eligible.
+        store.manifest.entries[2].last_message_time = Some(Local::now());
+        // Entry 3: still the current entry → excluded.
+        store.manifest.entries[3].last_message_time = Some(Local::now());
+
+        let eligible = store.get_unuploaded_entries_with_age(TimeDelta::seconds(-1));
+        assert_eq!(eligible, vec!["entry-2".to_string()]);
+
+        // Entry 2's last_message_time is freshly set, so a 1-hour min_age excludes it.
+        let none_eligible = store.get_unuploaded_entries_with_age(TimeDelta::seconds(3600));
+        assert!(none_eligible.is_empty());
     }
 }

--- a/daemon/src/qmdl_store.rs
+++ b/daemon/src/qmdl_store.rs
@@ -355,7 +355,9 @@ impl RecordingStore {
                 if self.is_current_entry(&entry.name) || entry.upload_time.is_some() {
                     return None;
                 }
-                (rayhunter::clock::get_adjusted_now() - entry.last_message_time? > min_age)
+                (rayhunter::clock::get_adjusted_now()
+                    - entry.last_message_time.unwrap_or(entry.start_time)
+                    > min_age)
                     .then_some(entry.name.clone())
             })
             .collect()
@@ -614,29 +616,25 @@ mod tests {
         let dir = make_temp_dir();
         let mut store = RecordingStore::create(dir.path()).await.unwrap();
 
-        // Create four entries (the fourth stays current). new_entry names entries by
-        // integer-second timestamp, so rapid consecutive calls collide; rename explicitly
-        // so each entry has a distinct name.
-        for _ in 0..4 {
+        for _ in 0..3 {
             let _ = store.new_entry().await.unwrap();
         }
-        for (i, entry) in store.manifest.entries.iter_mut().enumerate() {
-            entry.name = format!("entry-{}", i);
-        }
 
-        // Entry 0: closed, last_message_time = None → excluded by `?`.
-        // Entry 1: closed, last_message_time = Some(_), upload_time = Some(_) → excluded.
-        store.manifest.entries[1].last_message_time = Some(Local::now());
-        store.manifest.entries[1].upload_time = Some(Local::now());
-        // Entry 2: closed, last_message_time = Some(_), upload_time = None → eligible.
-        store.manifest.entries[2].last_message_time = Some(Local::now());
-        // Entry 3: still the current entry → excluded.
-        store.manifest.entries[3].last_message_time = Some(Local::now());
+        store.manifest.entries[0].name = "entry-0".to_owned();
+        store.manifest.entries[0].start_time = Local::now() - TimeDelta::seconds(10);
+        store.manifest.entries[0].last_message_time = None;
 
-        let eligible = store.get_unuploaded_entries_with_age(TimeDelta::seconds(-1));
-        assert_eq!(eligible, vec!["entry-2".to_string()]);
+        store.manifest.entries[1].name = "entry-1".to_owned();
+        store.manifest.entries[1].start_time = Local::now() - TimeDelta::seconds(10);
+        store.manifest.entries[1].last_message_time = Some(Local::now() - TimeDelta::seconds(5));
 
-        // Entry 2's last_message_time is freshly set, so a 1-hour min_age excludes it.
+        store.manifest.entries[2].name = "entry-2".to_owned();
+        store.manifest.entries[2].start_time = Local::now() - TimeDelta::seconds(10);
+        store.manifest.entries[2].last_message_time = Some(Local::now() - TimeDelta::seconds(1));
+
+        let eligible = store.get_unuploaded_entries_with_age(TimeDelta::seconds(3));
+        assert_eq!(eligible, vec!["entry-0".to_string(), "entry-1".to_string()]);
+
         let none_eligible = store.get_unuploaded_entries_with_age(TimeDelta::seconds(3600));
         assert!(none_eligible.is_empty());
     }

--- a/daemon/src/webdav.rs
+++ b/daemon/src/webdav.rs
@@ -17,8 +17,7 @@ use crate::qmdl_store::RecordingStore;
 pub struct WebdavUploadWorkerConfig {
     poll_interval: Duration,
     min_age: TimeDelta,
-    remote_path: String,
-    host: String,
+    url: String,
     username: Option<String>,
     password: Option<String>,
     timeout: Duration,
@@ -30,8 +29,7 @@ impl From<WebdavConfig> for WebdavUploadWorkerConfig {
         WebdavUploadWorkerConfig {
             poll_interval: Duration::from_secs(value.poll_interval_secs),
             min_age: TimeDelta::seconds(value.min_age_secs),
-            remote_path: value.remote_path,
-            host: value.host,
+            url: value.url,
             username: value.username,
             password: value.password,
             timeout: Duration::from_secs(value.upload_timeout_secs),
@@ -66,30 +64,24 @@ impl Display for FileKind {
 #[derive(Debug, Clone)]
 struct WebDavClient {
     client: Client,
-    base_url: String,
+    url: String,
     username: Option<String>,
     password: Option<String>,
 }
 
 impl WebDavClient {
     fn new(
-        host: String,
+        mut url: String,
         username: Option<String>,
         password: Option<String>,
         timeout: Duration,
-        root_dir: String,
     ) -> Result<Self, reqwest::Error> {
-        let host = host.trim_end_matches('/');
-        let root = root_dir.trim_matches('/');
-        let base_url = if root.is_empty() {
-            format!("{}/", host)
-        } else {
-            format!("{}/{}/", host, root)
-        };
-
+        if !url.ends_with('/') {
+            url.push('/');
+        }
         Ok(Self {
             client: reqwest::Client::builder().timeout(timeout).build()?,
-            base_url,
+            url,
             username,
             password,
         })
@@ -101,7 +93,7 @@ impl WebDavClient {
         let stream = ReaderStream::new(file);
         let body = Body::wrap_stream(stream);
 
-        let target = format!("{}{}", self.base_url, name);
+        let target = format!("{}{}", self.url, name);
 
         let client = self
             .client
@@ -189,11 +181,10 @@ pub fn run_webdav_upload_worker(
         interval.set_missed_tick_behavior(time::MissedTickBehavior::Skip);
 
         let webdav_client = match WebDavClient::new(
-            config.host,
+            config.url,
             config.username,
             config.password,
             config.timeout,
-            config.remote_path,
         ) {
             Ok(client) => client,
             Err(err) => {
@@ -304,7 +295,7 @@ mod tests {
 
         let listener = TcpListener::bind("127.0.0.1:0").await.unwrap();
         let addr = listener.local_addr().unwrap();
-        let url = format!("http://{}", addr);
+        let url = format!("http://{}/dav", addr);
 
         tokio::spawn(async move {
             axum::serve(listener, app).await.unwrap();
@@ -352,8 +343,7 @@ mod tests {
         let config = WebdavUploadWorkerConfig {
             poll_interval: Duration::from_millis(50),
             min_age: TimeDelta::seconds(-1),
-            remote_path: "dav".to_string(),
-            host: url,
+            url,
             username: Some("user".to_string()),
             password: Some("password".to_string()),
             timeout: Duration::from_secs(1),
@@ -408,8 +398,7 @@ mod tests {
         let config = WebdavUploadWorkerConfig {
             poll_interval: Duration::from_millis(50),
             min_age: TimeDelta::seconds(-1),
-            remote_path: "dav".to_string(),
-            host: url,
+            url,
             username: None,
             password: None,
             timeout: Duration::from_secs(1),
@@ -439,8 +428,7 @@ mod tests {
         let config = WebdavUploadWorkerConfig {
             poll_interval: Duration::from_millis(50),
             min_age: TimeDelta::seconds(3600),
-            remote_path: "dav".to_string(),
-            host: url,
+            url,
             username: None,
             password: None,
             timeout: Duration::from_secs(1),

--- a/daemon/src/webdav.rs
+++ b/daemon/src/webdav.rs
@@ -206,7 +206,7 @@ pub fn run_webdav_upload_worker(
                             break;
                         }
 
-                        let (Some(_), Some(_)) = join!(
+                        let (Some(()), Some(())) = join!(
                             try_upload_entry(
                                 webdav_client.clone(),
                                 qmdl_store_lock.clone(),

--- a/daemon/src/webdav.rs
+++ b/daemon/src/webdav.rs
@@ -17,10 +17,10 @@ use crate::qmdl_store::RecordingStore;
 pub struct WebdavUploadWorkerConfig {
     poll_interval: Duration,
     min_age: TimeDelta,
-    remote_path: Arc<String>,
-    host: Arc<String>,
-    username: Option<Arc<String>>,
-    password: Option<Arc<String>>,
+    remote_path: String,
+    host: String,
+    username: Option<String>,
+    password: Option<String>,
     delete_on_upload: bool,
 }
 
@@ -29,10 +29,10 @@ impl From<WebdavConfig> for WebdavUploadWorkerConfig {
         WebdavUploadWorkerConfig {
             poll_interval: Duration::from_secs(value.poll_interval_secs),
             min_age: TimeDelta::seconds(value.min_age_secs),
-            remote_path: Arc::new(value.remote_path),
-            host: Arc::new(value.host),
-            username: value.username.map(Arc::new),
-            password: value.password.map(Arc::new),
+            remote_path: value.remote_path,
+            host: value.host,
+            username: value.username,
+            password: value.password,
             delete_on_upload: value.delete_on_upload,
         }
     }
@@ -64,17 +64,17 @@ impl Display for FileKind {
 #[derive(Debug, Clone)]
 struct WebDavClient {
     client: Client,
-    base_url: Arc<String>,
-    username: Option<Arc<String>>,
-    password: Option<Arc<String>>,
+    base_url: String,
+    username: Option<String>,
+    password: Option<String>,
 }
 
 impl WebDavClient {
     fn new(
-        host: Arc<String>,
-        username: Option<Arc<String>>,
-        password: Option<Arc<String>>,
-        root_dir: Arc<String>,
+        host: String,
+        username: Option<String>,
+        password: Option<String>,
+        root_dir: String,
     ) -> Self {
         let host = host.trim_end_matches('/');
         let root = root_dir.trim_matches('/');
@@ -86,13 +86,13 @@ impl WebDavClient {
 
         Self {
             client: reqwest::Client::new(),
-            base_url: Arc::new(base_url),
+            base_url,
             username,
             password,
         }
     }
 
-    async fn try_upload_file(&self, file: File, name: Arc<String>) -> anyhow::Result<Response> {
+    async fn try_upload_file(&self, file: File, name: &str) -> anyhow::Result<Response> {
         let file_size = file.metadata().await?.len();
 
         let stream = ReaderStream::new(file);
@@ -106,7 +106,7 @@ impl WebDavClient {
             .header(CONTENT_TYPE, "application/octet-stream")
             .header(CONTENT_LENGTH, file_size);
 
-        let client = match (self.username.clone(), self.password.clone()) {
+        let client = match (&self.username, &self.password) {
             (Some(username), Some(password)) => client.basic_auth(username, Some(password)),
             (Some(username), None) => client.basic_auth(username, None::<&str>),
             (None, None) => client,
@@ -147,7 +147,7 @@ async fn try_upload_entry(
         return None;
     };
 
-    let file_name = Arc::new(format!("{}{}", entry_name, file_kind.as_extension()));
+    let file_name = format!("{}{}", entry_name, file_kind.as_extension());
 
     let res = select! {
         _ = shutdown_token.cancelled() => {
@@ -157,7 +157,7 @@ async fn try_upload_entry(
             );
             return None;
         },
-        res = client.try_upload_file(file, file_name) => res,
+        res = client.try_upload_file(file, &file_name) => res,
     };
 
     match res {
@@ -342,10 +342,10 @@ mod tests {
         let config = WebdavUploadWorkerConfig {
             poll_interval: Duration::from_millis(50),
             min_age: TimeDelta::seconds(-1),
-            remote_path: Arc::new("dav".to_string()),
-            host: Arc::new(url),
-            username: Some(Arc::new("user".to_string())),
-            password: Some(Arc::new("password".to_string())),
+            remote_path: "dav".to_string(),
+            host: url,
+            username: Some("user".to_string()),
+            password: Some("password".to_string()),
             delete_on_upload: false,
         };
 
@@ -397,8 +397,8 @@ mod tests {
         let config = WebdavUploadWorkerConfig {
             poll_interval: Duration::from_millis(50),
             min_age: TimeDelta::seconds(-1),
-            remote_path: Arc::new("dav".to_string()),
-            host: Arc::new(url),
+            remote_path: "dav".to_string(),
+            host: url,
             username: None,
             password: None,
             delete_on_upload: true,
@@ -427,8 +427,8 @@ mod tests {
         let config = WebdavUploadWorkerConfig {
             poll_interval: Duration::from_millis(50),
             min_age: TimeDelta::seconds(3600),
-            remote_path: Arc::new("dav".to_string()),
-            host: Arc::new(url),
+            remote_path: "dav".to_string(),
+            host: url,
             username: None,
             password: None,
             delete_on_upload: false,

--- a/daemon/src/webdav.rs
+++ b/daemon/src/webdav.rs
@@ -21,6 +21,7 @@ pub struct WebdavUploadWorkerConfig {
     host: String,
     username: Option<String>,
     password: Option<String>,
+    timeout: Duration,
     delete_on_upload: bool,
 }
 
@@ -33,6 +34,7 @@ impl From<WebdavConfig> for WebdavUploadWorkerConfig {
             host: value.host,
             username: value.username,
             password: value.password,
+            timeout: Duration::from_secs(value.upload_timeout_secs),
             delete_on_upload: value.delete_on_upload,
         }
     }
@@ -74,8 +76,9 @@ impl WebDavClient {
         host: String,
         username: Option<String>,
         password: Option<String>,
+        timeout: Duration,
         root_dir: String,
-    ) -> Self {
+    ) -> Result<Self, reqwest::Error> {
         let host = host.trim_end_matches('/');
         let root = root_dir.trim_matches('/');
         let base_url = if root.is_empty() {
@@ -84,12 +87,12 @@ impl WebDavClient {
             format!("{}/{}/", host, root)
         };
 
-        Self {
-            client: reqwest::Client::new(),
+        Ok(Self {
+            client: reqwest::Client::builder().timeout(timeout).build()?,
             base_url,
             username,
             password,
-        }
+        })
     }
 
     async fn try_upload_file(&self, file: File, name: &str) -> anyhow::Result<Response> {
@@ -185,12 +188,19 @@ pub fn run_webdav_upload_worker(
         let mut interval = time::interval(config.poll_interval);
         interval.set_missed_tick_behavior(time::MissedTickBehavior::Skip);
 
-        let webdav_client = WebDavClient::new(
+        let webdav_client = match WebDavClient::new(
             config.host,
             config.username,
             config.password,
+            config.timeout,
             config.remote_path,
-        );
+        ) {
+            Ok(client) => client,
+            Err(err) => {
+                warn!("Unable to create WebDAV client: {:?}", err);
+                return;
+            }
+        };
 
         loop {
             select! {
@@ -346,6 +356,7 @@ mod tests {
             host: url,
             username: Some("user".to_string()),
             password: Some("password".to_string()),
+            timeout: Duration::from_secs(1),
             delete_on_upload: false,
         };
 
@@ -401,6 +412,7 @@ mod tests {
             host: url,
             username: None,
             password: None,
+            timeout: Duration::from_secs(1),
             delete_on_upload: true,
         };
 
@@ -431,6 +443,7 @@ mod tests {
             host: url,
             username: None,
             password: None,
+            timeout: Duration::from_secs(1),
             delete_on_upload: false,
         };
 

--- a/daemon/src/webdav.rs
+++ b/daemon/src/webdav.rs
@@ -197,47 +197,44 @@ pub fn run_webdav_upload_worker(
             select! {
                 _ = shutdown_token.cancelled() => break,
                 _ = interval.tick() => {
-                    let entries = qmdl_store_lock
-                        .read()
-                        .await
-                        .get_unuploaded_entries_with_age(config.min_age);
-
-                    for entry_name in entries {
-                        if shutdown_token.is_cancelled() {
-                            break;
-                        }
+                    loop {
+                        let Some(unuploaded_entry) = qmdl_store_lock
+                            .read()
+                            .await
+                            .get_next_unuploaded_entry(config.min_age) else {
+                                break;
+                            };
 
                         let (Some(()), Some(())) = join!(
                             try_upload_entry(
                                 webdav_client.clone(),
                                 qmdl_store_lock.clone(),
-                                entry_name.clone(),
+                                unuploaded_entry.clone(),
                                 FileKind::Qmdl,
                                 shutdown_token.clone(),
                             ),
                             try_upload_entry(
                                 webdav_client.clone(),
                                 qmdl_store_lock.clone(),
-                                entry_name.clone(),
+                                unuploaded_entry.clone(),
                                 FileKind::Analysis,
                                 shutdown_token.clone()
                             ),
                         ) else {
-                            continue;
+                            break;
                         };
 
                         if config.delete_on_upload {
-                            match qmdl_store_lock.write().await.delete_entry(&entry_name).await {
-                                Ok(_) => info!("Successfully deleted entry: {} after upload to WebDAV", entry_name),
-                                Err(err) => warn!("Unable to delete entry: {} after upload to WebDAV: {}", entry_name, err),
+                            match qmdl_store_lock.write().await.delete_entry(&unuploaded_entry).await {
+                                Ok(_) => info!("Successfully deleted entry: {} after upload to WebDAV", unuploaded_entry),
+                                Err(err) => warn!("Unable to delete entry: {} after upload to WebDAV: {}", unuploaded_entry, err),
                             }
                         } else {
-                            match qmdl_store_lock.write().await.mark_entry_as_uploaded(&entry_name, rayhunter::clock::get_adjusted_now()).await {
-                                Ok(_) => info!("Successfully marked entry: {} as uploaded", entry_name),
-                                Err(err) => warn!("Unable to mark entry: {} as uploaded: {}", entry_name, err),
+                            match qmdl_store_lock.write().await.mark_entry_as_uploaded(&unuploaded_entry, rayhunter::clock::get_adjusted_now()).await {
+                                Ok(_) => info!("Successfully marked entry: {} as uploaded", unuploaded_entry),
+                                Err(err) => warn!("Unable to mark entry: {} as uploaded: {}", unuploaded_entry, err),
                             }
                         }
-
                     }
                 }
             }

--- a/daemon/src/webdav.rs
+++ b/daemon/src/webdav.rs
@@ -1,0 +1,448 @@
+use std::fmt::Display;
+use std::{sync::Arc, time::Duration};
+
+use chrono::TimeDelta;
+use log::{info, warn};
+use reqwest::header::{CONTENT_LENGTH, CONTENT_TYPE};
+use reqwest::{Body, Client, Response};
+use tokio::fs::File;
+use tokio::join;
+use tokio::{select, sync::RwLock, time};
+use tokio_util::io::ReaderStream;
+use tokio_util::{sync::CancellationToken, task::TaskTracker};
+
+use crate::config::WebdavConfig;
+use crate::qmdl_store::RecordingStore;
+
+pub struct WebdavUploadWorkerConfig {
+    poll_interval: Duration,
+    min_age: TimeDelta,
+    remote_path: Arc<String>,
+    host: Arc<String>,
+    username: Option<Arc<String>>,
+    password: Option<Arc<String>>,
+    delete_on_upload: bool,
+}
+
+impl From<WebdavConfig> for WebdavUploadWorkerConfig {
+    fn from(value: WebdavConfig) -> Self {
+        WebdavUploadWorkerConfig {
+            poll_interval: Duration::from_secs(value.poll_interval_secs),
+            min_age: TimeDelta::seconds(value.min_age_secs),
+            remote_path: Arc::new(value.remote_path),
+            host: Arc::new(value.host),
+            username: value.username.map(Arc::new),
+            password: value.password.map(Arc::new),
+            delete_on_upload: value.delete_on_upload,
+        }
+    }
+}
+
+enum FileKind {
+    Analysis,
+    Qmdl,
+}
+
+impl FileKind {
+    fn as_extension(&self) -> &'static str {
+        match self {
+            FileKind::Analysis => ".ndjson",
+            FileKind::Qmdl => ".qmdl",
+        }
+    }
+}
+
+impl Display for FileKind {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        match self {
+            FileKind::Analysis => write!(f, "analysis"),
+            FileKind::Qmdl => write!(f, "QMDL"),
+        }
+    }
+}
+
+#[derive(Debug, Clone)]
+struct WebDavClient {
+    client: Client,
+    base_url: Arc<String>,
+    username: Option<Arc<String>>,
+    password: Option<Arc<String>>,
+}
+
+impl WebDavClient {
+    fn new(
+        host: Arc<String>,
+        username: Option<Arc<String>>,
+        password: Option<Arc<String>>,
+        root_dir: Arc<String>,
+    ) -> Self {
+        let host = host.trim_end_matches('/');
+        let root = root_dir.trim_matches('/');
+        let base_url = if root.is_empty() {
+            format!("{}/", host)
+        } else {
+            format!("{}/{}/", host, root)
+        };
+
+        Self {
+            client: reqwest::Client::new(),
+            base_url: Arc::new(base_url),
+            username,
+            password,
+        }
+    }
+
+    async fn try_upload_file(&self, file: File, name: Arc<String>) -> anyhow::Result<Response> {
+        let file_size = file.metadata().await?.len();
+
+        let stream = ReaderStream::new(file);
+        let body = Body::wrap_stream(stream);
+
+        let target = format!("{}{}", self.base_url, name);
+
+        let client = self
+            .client
+            .put(&target)
+            .header(CONTENT_TYPE, "application/octet-stream")
+            .header(CONTENT_LENGTH, file_size);
+
+        let client = match (self.username.clone(), self.password.clone()) {
+            (Some(username), Some(password)) => client.basic_auth(username, Some(password)),
+            (Some(username), None) => client.basic_auth(username, None::<&str>),
+            (None, None) => client,
+            (None, Some(_)) => {
+                warn!(
+                    "Got WebDAV auth setting with no username but with a password, skipping authentication"
+                );
+                client
+            }
+        };
+
+        let resp = client.body(body).send().await?.error_for_status();
+        Ok(resp?)
+    }
+}
+
+async fn try_upload_entry(
+    client: WebDavClient,
+    store: Arc<RwLock<RecordingStore>>,
+    entry_name: String,
+    file_kind: FileKind,
+    shutdown_token: CancellationToken,
+) -> Option<()> {
+    let read_lock = store.read().await;
+    let entry_idx = read_lock.entry_for_name(&entry_name)?.0;
+    let file = match file_kind {
+        FileKind::Analysis => read_lock.open_entry_analysis(entry_idx).await,
+        FileKind::Qmdl => read_lock.open_entry_qmdl(entry_idx).await,
+    };
+    drop(read_lock);
+
+    let Ok(file) = file.map_err(|err| {
+        warn!(
+            "Unable to open entry: {} {} file: {:?}",
+            entry_name, file_kind, err
+        )
+    }) else {
+        return None;
+    };
+
+    let file_name = Arc::new(format!("{}{}", entry_name, file_kind.as_extension()));
+
+    let res = select! {
+        _ = shutdown_token.cancelled() => {
+            warn!(
+                "Cancelling upload for entry {} {} file: received shutdown signal",
+                entry_name, file_kind
+            );
+            return None;
+        },
+        res = client.try_upload_file(file, file_name) => res,
+    };
+
+    match res {
+        Ok(_) => {
+            info!("Uploaded {} file for entry {}", file_kind, entry_name);
+            Some(())
+        }
+        Err(err) => {
+            warn!(
+                "Failed to upload {} file for entry {}: {:?}",
+                file_kind, entry_name, err
+            );
+            None
+        }
+    }
+}
+
+pub fn run_webdav_upload_worker(
+    task_tracker: &TaskTracker,
+    shutdown_token: CancellationToken,
+    qmdl_store_lock: Arc<RwLock<RecordingStore>>,
+    config: WebdavUploadWorkerConfig,
+) {
+    task_tracker.spawn(async move {
+        let mut interval = time::interval(config.poll_interval);
+        interval.set_missed_tick_behavior(time::MissedTickBehavior::Skip);
+
+        let webdav_client = WebDavClient::new(
+            config.host,
+            config.username,
+            config.password,
+            config.remote_path,
+        );
+
+        loop {
+            select! {
+                _ = shutdown_token.cancelled() => break,
+                _ = interval.tick() => {
+                    let entries = qmdl_store_lock
+                        .read()
+                        .await
+                        .get_unuploaded_entries_with_age(config.min_age);
+
+                    for entry_name in entries {
+                        if shutdown_token.is_cancelled() {
+                            break;
+                        }
+
+                        let (Some(_), Some(_)) = join!(
+                            try_upload_entry(
+                                webdav_client.clone(),
+                                qmdl_store_lock.clone(),
+                                entry_name.clone(),
+                                FileKind::Qmdl,
+                                shutdown_token.clone(),
+                            ),
+                            try_upload_entry(
+                                webdav_client.clone(),
+                                qmdl_store_lock.clone(),
+                                entry_name.clone(),
+                                FileKind::Analysis,
+                                shutdown_token.clone()
+                            ),
+                        ) else {
+                            continue;
+                        };
+
+                        if config.delete_on_upload {
+                            match qmdl_store_lock.write().await.delete_entry(&entry_name).await {
+                                Ok(_) => info!("Successfully deleted entry: {} after upload to WebDAV", entry_name),
+                                Err(err) => warn!("Unable to delete entry: {} after upload to WebDAV: {}", entry_name, err),
+                            }
+                        } else {
+                            match qmdl_store_lock.write().await.mark_entry_as_uploaded(&entry_name, rayhunter::clock::get_adjusted_now()).await {
+                                Ok(_) => info!("Successfully marked entry: {} as uploaded", entry_name),
+                                Err(err) => warn!("Unable to mark entry: {} as uploaded: {}", entry_name, err),
+                            }
+                        }
+
+                    }
+                }
+            }
+        }
+    });
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use axum::{
+        Router,
+        body::Bytes,
+        extract::{Path as AxumPath, State},
+        http::{HeaderMap, StatusCode},
+        routing::put,
+    };
+    use tempfile::Builder;
+    use tokio::io::AsyncWriteExt;
+    use tokio::net::TcpListener;
+    use tokio::sync::Mutex;
+
+    #[derive(Clone, Debug)]
+    struct RecordedPut {
+        path: String,
+        auth: Option<String>,
+        body: Vec<u8>,
+    }
+
+    async fn capture_put(
+        State(state): State<Arc<Mutex<Vec<RecordedPut>>>>,
+        AxumPath(path): AxumPath<String>,
+        headers: HeaderMap,
+        body: Bytes,
+    ) -> StatusCode {
+        let auth = headers
+            .get("authorization")
+            .and_then(|v| v.to_str().ok())
+            .map(String::from);
+        state.lock().await.push(RecordedPut {
+            path,
+            auth,
+            body: body.to_vec(),
+        });
+        StatusCode::CREATED
+    }
+
+    async fn setup_webdav_server() -> (Arc<Mutex<Vec<RecordedPut>>>, String) {
+        crate::crypto_provider::install_default();
+
+        let state = Arc::new(Mutex::new(Vec::new()));
+        let app = Router::new()
+            .route("/{*path}", put(capture_put))
+            .with_state(state.clone());
+
+        let listener = TcpListener::bind("127.0.0.1:0").await.unwrap();
+        let addr = listener.local_addr().unwrap();
+        let url = format!("http://{}", addr);
+
+        tokio::spawn(async move {
+            axum::serve(listener, app).await.unwrap();
+        });
+
+        tokio::time::sleep(Duration::from_millis(100)).await;
+
+        (state, url)
+    }
+
+    async fn cleanup_worker(shutdown: CancellationToken, tracker: TaskTracker) {
+        shutdown.cancel();
+        tracker.close();
+        tracker.wait().await;
+    }
+
+    async fn make_store_with_closed_entry(
+        dir: &std::path::Path,
+    ) -> (Arc<RwLock<RecordingStore>>, String) {
+        let mut store = RecordingStore::create(dir).await.unwrap();
+        let (mut qmdl_file, mut analysis_file) = store.new_entry().await.unwrap();
+        qmdl_file.write_all(b"fake qmdl payload").await.unwrap();
+        qmdl_file.flush().await.unwrap();
+        analysis_file
+            .write_all(b"fake ndjson payload")
+            .await
+            .unwrap();
+        analysis_file.flush().await.unwrap();
+        let entry_index = store.current_entry.unwrap();
+        let name = store.manifest.entries[entry_index].name.clone();
+        store.update_entry_qmdl_size(entry_index, 17).await.unwrap();
+        store.close_current_entry().await.unwrap();
+        (Arc::new(RwLock::new(store)), name)
+    }
+
+    #[tokio::test]
+    async fn test_webdav_upload_worker_uploads_entry() {
+        let (captured, url) = setup_webdav_server().await;
+
+        let dir = Builder::new().prefix("webdav_test").tempdir().unwrap();
+        let (store, entry_name) = make_store_with_closed_entry(dir.path()).await;
+
+        let shutdown = CancellationToken::new();
+        let tracker = TaskTracker::new();
+        let config = WebdavUploadWorkerConfig {
+            poll_interval: Duration::from_millis(50),
+            min_age: TimeDelta::seconds(-1),
+            remote_path: Arc::new("dav".to_string()),
+            host: Arc::new(url),
+            username: Some(Arc::new("user".to_string())),
+            password: Some(Arc::new("password".to_string())),
+            delete_on_upload: false,
+        };
+
+        run_webdav_upload_worker(&tracker, shutdown.clone(), store.clone(), config);
+
+        tokio::time::sleep(Duration::from_millis(500)).await;
+        cleanup_worker(shutdown, tracker).await;
+
+        let recorded = captured.lock().await;
+        assert_eq!(recorded.len(), 2);
+        let paths: Vec<&str> = recorded.iter().map(|r| r.path.as_str()).collect();
+        let qmdl_path = format!("dav/{}.qmdl", entry_name);
+        let ndjson_path = format!("dav/{}.ndjson", entry_name);
+        assert!(paths.contains(&qmdl_path.as_str()));
+        assert!(paths.contains(&ndjson_path.as_str()));
+        for put in recorded.iter() {
+            assert_eq!(put.auth.as_deref(), Some("Basic dXNlcjpwYXNzd29yZA=="));
+        }
+        let qmdl_body = recorded
+            .iter()
+            .find(|r| r.path == qmdl_path)
+            .unwrap()
+            .body
+            .clone();
+        let ndjson_body = recorded
+            .iter()
+            .find(|r| r.path == ndjson_path)
+            .unwrap()
+            .body
+            .clone();
+        drop(recorded);
+        assert_eq!(qmdl_body, b"fake qmdl payload");
+        assert_eq!(ndjson_body, b"fake ndjson payload");
+
+        let store_read = store.read().await;
+        let (_, entry) = store_read.entry_for_name(&entry_name).unwrap();
+        assert!(entry.upload_time.is_some());
+    }
+
+    #[tokio::test]
+    async fn test_webdav_upload_worker_deletes_when_configured() {
+        let (captured, url) = setup_webdav_server().await;
+
+        let dir = Builder::new().prefix("webdav_test").tempdir().unwrap();
+        let (store, entry_name) = make_store_with_closed_entry(dir.path()).await;
+
+        let shutdown = CancellationToken::new();
+        let tracker = TaskTracker::new();
+        let config = WebdavUploadWorkerConfig {
+            poll_interval: Duration::from_millis(50),
+            min_age: TimeDelta::seconds(-1),
+            remote_path: Arc::new("dav".to_string()),
+            host: Arc::new(url),
+            username: None,
+            password: None,
+            delete_on_upload: true,
+        };
+
+        run_webdav_upload_worker(&tracker, shutdown.clone(), store.clone(), config);
+
+        tokio::time::sleep(Duration::from_millis(500)).await;
+        cleanup_worker(shutdown, tracker).await;
+
+        assert_eq!(captured.lock().await.len(), 2);
+
+        let store_read = store.read().await;
+        assert!(store_read.entry_for_name(&entry_name).is_none());
+    }
+
+    #[tokio::test]
+    async fn test_webdav_upload_worker_respects_min_age() {
+        let (captured, url) = setup_webdav_server().await;
+
+        let dir = Builder::new().prefix("webdav_test").tempdir().unwrap();
+        let (store, entry_name) = make_store_with_closed_entry(dir.path()).await;
+
+        let shutdown = CancellationToken::new();
+        let tracker = TaskTracker::new();
+        let config = WebdavUploadWorkerConfig {
+            poll_interval: Duration::from_millis(50),
+            min_age: TimeDelta::seconds(3600),
+            remote_path: Arc::new("dav".to_string()),
+            host: Arc::new(url),
+            username: None,
+            password: None,
+            delete_on_upload: false,
+        };
+
+        run_webdav_upload_worker(&tracker, shutdown.clone(), store.clone(), config);
+
+        tokio::time::sleep(Duration::from_millis(500)).await;
+        cleanup_worker(shutdown, tracker).await;
+
+        assert!(captured.lock().await.is_empty());
+
+        let store_read = store.read().await;
+        let (_, entry) = store_read.entry_for_name(&entry_name).unwrap();
+        assert!(entry.upload_time.is_none());
+    }
+}

--- a/dist/config.toml.in
+++ b/dist/config.toml.in
@@ -55,6 +55,29 @@ firewall_restrict_outbound = true
 # Example: allow HTTP (80) and SSH (22).
 # firewall_allowed_ports = [80, 22]
 
+# WebDAV Upload
+# If a [webdav] section is present, finished recordings (both the raw .qmdl file
+# and its .ndjson analysis output) are uploaded in the background to a WebDAV
+# server once they've been closed for at least min_age_secs. After a successful
+# upload the entry is either marked as uploaded in the manifest, or deleted
+# locally if delete_on_upload = true. With no [webdav] section, no upload
+# worker runs.
+#
+# [webdav]
+# host = "https://dav.example.com"
+# remote_path = "/rayhunter"
+# # HTTP Basic auth. Both fields are optional; a password without a username is
+# # rejected and the request is sent unauthenticated.
+# username = "user"
+# password = "pass"
+# # How often the worker scans for eligible entries (default 3600).
+# poll_interval_secs = 3600
+# # Minimum age in seconds before an entry becomes eligible for upload
+# # (default 86400 = 1 day).
+# min_age_secs = 86400
+# # Delete the entry locally after a successful upload (default false).
+# delete_on_upload = false
+
 # Analyzer Configuration
 # Enable/disable specific IMSI catcher detection heuristics
 # See https://github.com/EFForg/rayhunter/blob/main/doc/heuristics.md for details

--- a/dist/config.toml.in
+++ b/dist/config.toml.in
@@ -70,6 +70,8 @@ firewall_restrict_outbound = true
 # # rejected and the request is sent unauthenticated.
 # username = "user"
 # password = "pass"
+# # Timeout in seconds for each upload request (default 300).
+# upload_timeout_secs = 300
 # # How often the worker scans for eligible entries (default 3600).
 # poll_interval_secs = 3600
 # # Minimum age in seconds before an entry becomes eligible for upload

--- a/doc/configuration.md
+++ b/doc/configuration.md
@@ -63,8 +63,7 @@ WebDAV upload is currently configurable only by editing `config.toml` — there 
 
 | Key | Required | Default | Description |
 | --- | --- | --- | --- |
-| `host` | yes | — | WebDAV server base URL, e.g. `https://dav.example.com` |
-| `remote_path` | no | `"/"` | Remote directory to upload files into |
+| `url` | yes | — | WebDAV server base URL, e.g. `https://example.com/remote.php/files/user/rayhunter/` |
 | `username` | no | — | HTTP Basic auth username |
 | `password` | no | — | HTTP Basic auth password |
 | `upload_timeout_secs` | no | `300` | Timeout (seconds) for each upload request |
@@ -76,8 +75,7 @@ Example:
 
 ```toml
 [webdav]
-host = "https://dav.example.com"
-remote_path = "/rayhunter"
+url = "https://dav.example.com/rayhunter/"
 username = "user"
 password = "pass"
 upload_timeout_secs = 300

--- a/doc/configuration.md
+++ b/doc/configuration.md
@@ -67,6 +67,7 @@ WebDAV upload is currently configurable only by editing `config.toml` — there 
 | `remote_path` | no | `"/"` | Remote directory to upload files into |
 | `username` | no | — | HTTP Basic auth username |
 | `password` | no | — | HTTP Basic auth password |
+| `upload_timeout_secs` | no | `300` | Timeout (seconds) for each upload request |
 | `poll_interval_secs` | no | `3600` | How often (seconds) the worker scans for eligible entries |
 | `min_age_secs` | no | `86400` | Minimum age (seconds) an entry must have before it becomes eligible for upload |
 | `delete_on_upload` | no | `false` | Delete the entry locally after a successful upload |
@@ -79,6 +80,7 @@ host = "https://dav.example.com"
 remote_path = "/rayhunter"
 username = "user"
 password = "pass"
+upload_timeout_secs = 300
 poll_interval_secs = 3600
 min_age_secs = 86400
 delete_on_upload = false

--- a/doc/configuration.md
+++ b/doc/configuration.md
@@ -55,4 +55,39 @@ You can also configure WiFi during installation:
 
 - **Restrict outbound traffic** limits what the device can send over the network. When enabled, only DNS, DHCP, and HTTPS traffic is allowed; everything else is blocked. This is enabled by default and prevents the device from phoning home to the carrier over cellular. If you need to allow additional ports (for example, port 80 for HTTP or port 22 for SSH), add them to the **Additional allowed ports** list.
 
+## WebDAV Upload
+
+Rayhunter can automatically upload finished recordings to a WebDAV server. When a `[webdav]` section is present in `config.toml`, a background worker periodically scans the recording store and uploads any closed entry that is older than `min_age_secs`. Each eligible entry uploads two files: the raw `.qmdl` capture and its `.ndjson` analysis output. After a successful upload the entry is either marked as uploaded in the manifest (and skipped on subsequent polls), or deleted locally if `delete_on_upload = true`. With no `[webdav]` section, no upload worker runs.
+
+WebDAV upload is currently configurable only by editing `config.toml` — there is no web UI control for it yet.
+
+| Key | Required | Default | Description |
+| --- | --- | --- | --- |
+| `host` | yes | — | WebDAV server base URL, e.g. `https://dav.example.com` |
+| `remote_path` | no | `"/"` | Remote directory to upload files into |
+| `username` | no | — | HTTP Basic auth username |
+| `password` | no | — | HTTP Basic auth password |
+| `poll_interval_secs` | no | `3600` | How often (seconds) the worker scans for eligible entries |
+| `min_age_secs` | no | `86400` | Minimum age (seconds) an entry must have before it becomes eligible for upload |
+| `delete_on_upload` | no | `false` | Delete the entry locally after a successful upload |
+
+Example:
+
+```toml
+[webdav]
+host = "https://dav.example.com"
+remote_path = "/rayhunter"
+username = "user"
+password = "pass"
+poll_interval_secs = 3600
+min_age_secs = 86400
+delete_on_upload = false
+```
+
+A few notes on behavior:
+
+- **Auth:** HTTP Basic. Supplying a `password` without a `username` is rejected — the request is sent unauthenticated and a warning is logged.
+- **Retries and overwrites:** each entry's two files (`.qmdl` and `.ndjson`) must both upload successfully before the entry is marked as uploaded in the manifest. If one upload fails, the entry stays unmarked and both files are retried on the next poll — the one that previously succeeded will be overwritten on the server. Once an entry is marked as uploaded, Rayhunter will not upload it again.
+- **Currently-recording entry:** the active recording is never uploaded; only closed entries are eligible.
+
 If you prefer editing `config.toml` file, you need to obtain a shell on your [Orbic](./orbic.md#obtaining-a-shell) or [TP-Link](./tplink-m7350.md#obtaining-a-shell) device and edit the file manually. You can view the [default configuration file on GitHub](https://github.com/EFForg/rayhunter/blob/main/dist/config.toml.in).


### PR DESCRIPTION
## Pull Request Checklist

- [x] The Rayhunter team has recently expressed interest in reviewing a PR for this.
  - If not, this PR may be closed due our limited resources and need to prioritize how we spend them.
- [x] Added or updated any documentation as needed to support the changes in this PR.
- [x] Code has been linted and run through `cargo fmt`.
- [x] If any new functionality has been added, unit tests were also added.
- [x] [CONTRIBUTING.md](https://github.com/EFForg/rayhunter/blob/main/CONTRIBUTING.md) has been read.

You must check one of:
- [ ] No generative AI (including LLMs) tools were used to create this PR.
- [x] Generative AI was used to create this PR. I certify that I have read and understand the code, and *that all comments and descriptions were authored by myself* and are not the product of generative AI.

## Changes

Allow the user to configure a WebDAV server to the daemon. The daemon will periodically poll `RecordingStore` for unuploaded entries older than a specific duration (user's choice). If any were found, it will upload them to the WebDAV server, after the upload is successful, it will either mark the file as uploaded or delete them.

- Update the relevant config files.
- Add some machinery to `RecordingStore`:
    - Retrieve a vector of entries that has not been uploaded but is over a certain age
    - Mark an entry as uploaded
- Add a `run_webdav_upload_worker` similar to `run_battery_notification_worker`, that periodically polls `RecordingStore` for entries older than a specific age. Uploads them to a WebDAV server, and either mark them as uploaded or delete them based on config.

## Local testing

Started a webdav server locally at 8080.

Appended the config file with

```toml
[webdav]
host = "http://MacBook-Pro.local:8080/"
remote_path = "/"
username = "user"
password = "password"
# Short intervals for testing — in production the defaults (3600 / 86400) are saner.
poll_interval_secs = 30
min_age_secs = 10
delete_on_upload = false
```

Restarted and connected to the device

Verified that the files are available in the webdav server. And enteries are mark as `uploaded` with the new `uploaded_time` field.

```toml
[[entries]]
name = "1775353069"
start_time = "2026-04-04T21:37:49.050216717-04:00"
last_message_time = "2026-04-04T21:53:23.569852963-04:00"
qmdl_size_bytes = 6646
rayhunter_version = "0.10.2"
system_os = "Linux 3.18.48"
arch = "armv7l"
upload_time = "2026-04-21T00:48:00.528118061-04:00"
...
```