### PR TITLE
group dependabot security updates

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -6,6 +6,7 @@ updates:
     schedule:
       interval: "weekly"
     groups:
+      applies-to: "security-updates"
       dependency-type:
         patterns:
           - "*"
@@ -16,6 +17,7 @@ updates:
     schedule:
       interval: "weekly"
     groups:
+      applies-to: "security-updates"
       dependency-type:
         patterns:
           - "*"
@@ -26,6 +28,7 @@ updates:
     schedule:
       interval: "weekly"
     groups:
+      applies-to: "security-updates"
       dependency-type:
         patterns:
           - "*"
@@ -36,6 +39,7 @@ updates:
     schedule:
       interval: "weekly"
     groups:
+      applies-to: "security-updates"
       dependency-type:
         patterns:
           - "*"

--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,3 +1,7 @@
+# open-pull-requests-limit is used to disable automated version updates
+# security updates are unaffected. see
+# * https://docs.github.com/en/code-security/how-tos/secure-your-supply-chain/secure-your-dependencies/configuring-dependabot-version-updates#disabling-dependabot-version-updates
+# * https://docs.github.com/en/code-security/reference/supply-chain-security/dependabot-options-reference#open-pull-requests-limit-
 version: 2
 updates:
   # Rust dependencies
@@ -5,6 +9,7 @@ updates:
     directory: "/"
     schedule:
       interval: "weekly"
+    open-pull-requests-limit: 0
     groups:
       applies-to: "security-updates"
       dependency-type:
@@ -16,6 +21,7 @@ updates:
     directory: "/tools"
     schedule:
       interval: "weekly"
+    open-pull-requests-limit: 0
     groups:
       applies-to: "security-updates"
       dependency-type:
@@ -27,6 +33,7 @@ updates:
     directory: "/daemon/web"
     schedule:
       interval: "weekly"
+    open-pull-requests-limit: 0
     groups:
       applies-to: "security-updates"
       dependency-type:
@@ -38,6 +45,7 @@ updates:
     directory: "/installer-gui"
     schedule:
       interval: "weekly"
+    open-pull-requests-limit: 0
     groups:
       applies-to: "security-updates"
       dependency-type:


### PR DESCRIPTION
i don't think https://github.com/EFForg/rayhunter/pull/953 did what we expected

rather than grouping security updates, i think it enabled weekly [dependabot version updates](https://docs.github.com/en/code-security/how-tos/secure-your-supply-chain/secure-your-dependencies/configuring-dependabot-version-updates) updating every dependency to the latest compatible version regardless of any security issues which results in PRs like https://github.com/EFForg/rayhunter/pull/986 and https://github.com/EFForg/rayhunter/pull/987

i personally don't think we want this. it creates a lot of regular work and churn for us and i think it even opens us up to stability and security problems as discussed [here](https://docs.zizmor.sh/audits/#dependabot-cooldown)

even if others on the project do want this, the current behavior is clearly not what was intended and think there should be more discussion before we just accept the current settings on main