### PR TITLE
Make sure web UI starts and continues if diag device fails

### DIFF
--- a/daemon/src/display/generic_framebuffer.rs
+++ b/daemon/src/display/generic_framebuffer.rs
@@ -182,7 +182,7 @@ pub fn update_ui(
     }
 
     let colorblind_mode = config.colorblind_mode;
-    let mut display_style = display_style_from_state(DisplayState::Recording, colorblind_mode);
+    let mut display_style = display_style_from_state(DisplayState::Paused, colorblind_mode);
 
     task_tracker.spawn(async move {
         // this feels wrong, is there a more rusty way to do this?

--- a/daemon/src/display/tmobile.rs
+++ b/daemon/src/display/tmobile.rs
@@ -36,7 +36,7 @@ pub fn update_ui(
         invisible = true;
     }
     task_tracker.spawn(async move {
-        let mut state = DisplayState::Recording;
+        let mut state = DisplayState::Paused;
         let mut last_state = DisplayState::Paused;
 
         loop {

--- a/daemon/src/display/tplink_onebit.rs
+++ b/daemon/src/display/tplink_onebit.rs
@@ -120,7 +120,7 @@ pub fn update_ui(
     }
 
     task_tracker.spawn(async move {
-        let mut pixels = STATUS_SMILING;
+        let mut pixels = STATUS_PAUSED;
 
         loop {
             if shutdown_token.is_cancelled() {

--- a/daemon/src/display/uz801.rs
+++ b/daemon/src/display/uz801.rs
@@ -36,7 +36,7 @@ pub fn update_ui(
         invisible = true;
     }
     task_tracker.spawn(async move {
-        let mut state = DisplayState::Recording;
+        let mut state = DisplayState::Paused;
         let mut last_state = DisplayState::Paused;
         let mut last_update = std::time::Instant::now();
 

--- a/daemon/src/main.rs
+++ b/daemon/src/main.rs
@@ -39,7 +39,7 @@ use diag::{
     DiagDeviceCtrlMessage, delete_all_recordings, delete_recording, get_analysis_report,
     start_recording, stop_recording,
 };
-use log::{error, info};
+use log::{error, info, warn};
 use qmdl_store::RecordingStoreError;
 use rayhunter::Device;
 use rayhunter::diag_device::DiagDevice;
@@ -215,29 +215,8 @@ async fn run_with_config(
 
     if !config.debug_mode {
         info!("Using configuration for device: {0:?}", config.device);
-        let mut dev = DiagDevice::new(&config.device)
-            .await
-            .map_err(RayhunterError::DiagInitError)?;
-        dev.config_logs()
-            .await
-            .map_err(RayhunterError::DiagInitError)?;
 
-        info!("Starting Diag Thread");
-        run_diag_read_thread(
-            &task_tracker,
-            dev,
-            diag_rx,
-            diag_tx.clone(),
-            ui_update_tx.clone(),
-            qmdl_store_lock.clone(),
-            analysis_tx.clone(),
-            config.analyzers.clone(),
-            notification_service.new_handler(),
-            config.min_space_to_start_recording_mb,
-            config.min_space_to_continue_recording_mb,
-        );
         info!("Starting UI");
-
         let update_ui = match &config.device {
             Device::Orbic | Device::Moxee => display::orbic::update_ui,
             Device::Tplink => display::tplink::update_ui,
@@ -247,6 +226,37 @@ async fn run_with_config(
             Device::Uz801 => display::uz801::update_ui,
         };
         update_ui(&task_tracker, &config, shutdown_token.clone(), ui_update_rx);
+
+        match DiagDevice::new(&config.device).await {
+            Ok(mut dev) => match dev.config_logs().await {
+                Ok(_) => {
+                    info!("Starting Diag Thread");
+                    run_diag_read_thread(
+                        &task_tracker,
+                        dev,
+                        diag_rx,
+                        diag_tx.clone(),
+                        ui_update_tx.clone(),
+                        qmdl_store_lock.clone(),
+                        analysis_tx.clone(),
+                        config.analyzers.clone(),
+                        notification_service.new_handler(),
+                        config.min_space_to_start_recording_mb,
+                        config.min_space_to_continue_recording_mb,
+                    );
+
+                    if let Err(e) = ui_update_tx.send(display::DisplayState::Recording).await {
+                        warn!("couldn't send ui update message: {e}");
+                    }
+                }
+                Err(error) => {
+                    log::error!("Error: {}", RayhunterError::DiagInitError(error));
+                }
+            },
+            Err(error) => {
+                log::error!("Error: {}", RayhunterError::DiagInitError(error));
+            }
+        }
 
         info!("Starting Key Input service");
         key_input::run_key_input_thread(

--- a/daemon/src/main.rs
+++ b/daemon/src/main.rs
@@ -95,7 +95,6 @@ async fn run_server(
     let app = get_router().with_state(state);
 
     task_tracker.spawn(async move {
-        info!("The orca is hunting for stingrays...");
         axum::serve(listener, app)
             .with_graceful_shutdown(shutdown_token.cancelled_owned())
             .await
@@ -213,6 +212,30 @@ async fn run_with_config(
 
     let notification_service = NotificationService::new(config.ntfy_url.clone());
 
+    let analysis_status_lock = Arc::new(RwLock::new(analysis_status));
+    let wifi_status = Arc::new(RwLock::new(WifiStatus::default()));
+    wifi_station::run_wifi_client(
+        &task_tracker,
+        &config.wifi_config(),
+        shutdown_token.clone(),
+        wifi_status.clone(),
+    );
+    firewall::apply(&config).await;
+
+    let state = Arc::new(ServerState {
+        config_path: args.config_path.clone(),
+        config: config.clone(),
+        qmdl_store_lock: qmdl_store_lock.clone(),
+        diag_device_ctrl_sender: diag_tx.clone(),
+        analysis_status_lock: analysis_status_lock.clone(),
+        analysis_sender: analysis_tx.clone(),
+        daemon_restart_token: restart_token.clone(),
+        ui_update_sender: Some(ui_update_tx.clone()),
+        wifi_status,
+        wifi_scan_lock: tokio::sync::Mutex::new(()),
+    });
+    run_server(&task_tracker, state, shutdown_token.clone()).await;
+
     if !config.debug_mode {
         info!("Using configuration for device: {0:?}", config.device);
 
@@ -267,21 +290,20 @@ async fn run_with_config(
         );
     }
 
-    let analysis_status_lock = Arc::new(RwLock::new(analysis_status));
     run_analysis_thread(
         &task_tracker,
         analysis_rx,
         qmdl_store_lock.clone(),
-        analysis_status_lock.clone(),
+        analysis_status_lock,
         config.analyzers.clone(),
     );
 
     run_shutdown_thread(
         &task_tracker,
-        diag_tx.clone(),
+        diag_tx,
         shutdown_token.clone(),
         qmdl_store_lock.clone(),
-        analysis_tx.clone(),
+        analysis_tx,
     );
 
     run_battery_notification_worker(
@@ -297,29 +319,7 @@ async fn run_with_config(
         config.enabled_notifications.clone(),
     );
 
-    let wifi_status = Arc::new(RwLock::new(WifiStatus::default()));
-    wifi_station::run_wifi_client(
-        &task_tracker,
-        &config.wifi_config(),
-        shutdown_token.clone(),
-        wifi_status.clone(),
-    );
-    firewall::apply(&config).await;
-
-    let state = Arc::new(ServerState {
-        config_path: args.config_path.clone(),
-        config,
-        qmdl_store_lock: qmdl_store_lock.clone(),
-        diag_device_ctrl_sender: diag_tx,
-        analysis_status_lock,
-        analysis_sender: analysis_tx,
-        daemon_restart_token: restart_token.clone(),
-        ui_update_sender: Some(ui_update_tx),
-        wifi_status,
-        wifi_scan_lock: tokio::sync::Mutex::new(()),
-    });
-    run_server(&task_tracker, state, shutdown_token.clone()).await;
-
+    info!("The orca is hunting for stingrays...");
     task_tracker.close();
     task_tracker.wait().await;
 


### PR DESCRIPTION
## Pull Request Checklist

- [x] The Rayhunter team has recently expressed interest in reviewing a PR for this.
  - If not, this PR may be closed due our limited resources and need to prioritize how we spend them.
- [ ] Added or updated any documentation as needed to support the changes in this PR.
- [x] Code has been linted and run through `cargo fmt`.
- [ ] If any new functionality has been added, unit tests were also added.
- [x] [CONTRIBUTING.md](https://github.com/EFForg/rayhunter/blob/main/CONTRIBUTING.md) has been read.
- [x] Your pull request is fewer than ~400 lines of code.

You must check one of:
- [x] No generative AI (including LLMs) tools were used to create this PR.
- [ ] Generative AI was used to create this PR. I certify that I have read and understand the code, and *that all comments and descriptions were authored by myself* and are not the product of generative AI.

This is my attempt to address #991. I originally started by moving the UI and display code to before the diag device gets initialized, but I found in testing (which I did by setting the diag device name to something like `/dev/diag0`) that what happened was the main function exited when the device fails to initialize, so the web UI shuts down, possibly before the user has a chance to see the logs.

I added some code to log the error if the diag device can't start up, but not exit `main`. That seemed like the way to go, but I'm new to this codebase, so if that doesn't support the intended functionality, I'll take it out.