### PR TITLE
Move creation of the diag device into read thread

### DIFF
--- a/daemon/src/diag.rs
+++ b/daemon/src/diag.rs
@@ -10,6 +10,7 @@ use axum::http::header::CONTENT_TYPE;
 use axum::response::{IntoResponse, Response};
 use futures::{StreamExt, TryStreamExt, future};
 use log::{debug, error, info, warn};
+use rayhunter::Device;
 use tokio::fs::File;
 use tokio::io::{AsyncBufReadExt, BufReader};
 use tokio::sync::mpsc::{Receiver, Sender};
@@ -370,7 +371,7 @@ impl DiagTask {
 #[allow(clippy::too_many_arguments)]
 pub fn run_diag_read_thread(
     task_tracker: &TaskTracker,
-    mut dev: DiagDevice,
+    device: Device,
     mut qmdl_file_rx: Receiver<DiagDeviceCtrlMessage>,
     qmdl_file_tx: Sender<DiagDeviceCtrlMessage>,
     ui_update_sender: Sender<display::DisplayState>,
@@ -382,8 +383,21 @@ pub fn run_diag_read_thread(
     min_space_to_continue_mb: u64,
 ) {
     task_tracker.spawn(async move {
+        info!("Using configuration for device: {0:?}", device);
+        let mut dev = DiagDevice::new(&device)
+            .await?;
+        dev.config_logs()
+            .await?;
+
         let mut diag_stream = pin!(dev.as_stream().into_stream());
-        let mut diag_task = DiagTask::new(ui_update_sender, analysis_sender, analyzer_config, notification_channel, min_space_to_start_mb, min_space_to_continue_mb);
+        let mut diag_task = DiagTask::new(
+            ui_update_sender,
+            analysis_sender,
+            analyzer_config,
+            notification_channel,
+            min_space_to_start_mb,
+            min_space_to_continue_mb
+        );
         qmdl_file_tx
             .send(DiagDeviceCtrlMessage::StartRecording { response_tx: None })
             .await

--- a/daemon/src/error.rs
+++ b/daemon/src/error.rs
@@ -1,4 +1,3 @@
-use rayhunter::diag_device::DiagDeviceError;
 use thiserror::Error;
 
 use crate::qmdl_store::RecordingStoreError;
@@ -7,8 +6,6 @@ use crate::qmdl_store::RecordingStoreError;
 pub enum RayhunterError {
     #[error("Config file parsing error: {0}")]
     ConfigFileParsingError(#[from] toml::de::Error),
-    #[error("Diag intialization error: {0}")]
-    DiagInitError(DiagDeviceError),
     #[error("Tokio error: {0}")]
     TokioError(#[from] tokio::io::Error),
     #[error("QmdlStore error: {0}")]

--- a/daemon/src/main.rs
+++ b/daemon/src/main.rs
@@ -42,7 +42,6 @@ use diag::{
 use log::{error, info};
 use qmdl_store::RecordingStoreError;
 use rayhunter::Device;
-use rayhunter::diag_device::DiagDevice;
 use stats::get_log;
 use tokio::net::TcpListener;
 use tokio::select;
@@ -214,18 +213,10 @@ async fn run_with_config(
     let notification_service = NotificationService::new(config.ntfy_url.clone());
 
     if !config.debug_mode {
-        info!("Using configuration for device: {0:?}", config.device);
-        let mut dev = DiagDevice::new(&config.device)
-            .await
-            .map_err(RayhunterError::DiagInitError)?;
-        dev.config_logs()
-            .await
-            .map_err(RayhunterError::DiagInitError)?;
-
         info!("Starting Diag Thread");
         run_diag_read_thread(
             &task_tracker,
-            dev,
+            config.device.clone(),
             diag_rx,
             diag_tx.clone(),
             ui_update_tx.clone(),


### PR DESCRIPTION
Moved the creation of the DiagDevice into the diag read task thread.

This is a redo of #1004, per request from @untitaker, making the creation and initialization of the diag device async.

Side note: ran into some issues due to the advent of the WiFi tools, specifically the `wpa-supplicant`:
- It needs a `arm-linux-musleabihf-gcc` cross-compiler, which isn't available on Ubuntu. Had to build and install one using https://github.com/richfelker/musl-cross-make/. If you all think it would be useful, I can document the process in case someone else comes across the same issue.
- The `wpa-supplicant` code still wouldn't build, nor would it give me an error as to why. Digging in, I discovered that it was because the config step in the shell script was failing due to my not having `bison` and `flex` installed. It failed silently due to [this line](https://github.com/EFForg/rayhunter/blob/main/scripts/build-wpa-supplicant.sh#L43). Once I figured that out and installed the two packages, everything built.
Testing as before, everything comes up quickly enough that you can watch the device retry failures in the logs in the web UI as they're happening.

## Pull Request Checklist

- [x] The Rayhunter team has recently expressed interest in reviewing a PR for this.
  - If not, this PR may be closed due our limited resources and need to prioritize how we spend them.
- [ ] Added or updated any documentation as needed to support the changes in this PR.
- [x] Code has been linted and run through `cargo fmt`.
- [ ] If any new functionality has been added, unit tests were also added.
- [x] [CONTRIBUTING.md](https://github.com/EFForg/rayhunter/blob/main/CONTRIBUTING.md) has been read.
- [x] Your pull request is fewer than ~400 lines of code.

You must check one of:
- [x] No generative AI (including LLMs) tools were used to create this PR.
- [ ] Generative AI was used to create this PR. I certify that I have read and understand the code, and *that all comments and descriptions were authored by myself* and are not the product of generative AI.
