### PR TITLE
Make WiFi tools optional on the orbic installer too

### DIFF
--- a/installer/src/connection.rs
+++ b/installer/src/connection.rs
@@ -47,20 +47,27 @@ pub async fn install_config<C: DeviceConnection>(
 ///
 /// Skips any binary that is already present on the device (e.g. provided by firmware),
 /// since those may be newer or better-integrated than the bundled versions.
-pub async fn install_wifi_tools<C: DeviceConnection>(
-    conn: &mut C,
-    wpa_supplicant: &[u8],
-    wpa_cli: &[u8],
-    iw: &[u8],
-) -> Result<()> {
+///
+/// In debug builds the wpa-supplicant binaries may not be bundled (build.rs sets the
+/// env vars to empty in that case); when so, this is a no-op so devs don't have to
+/// build wpa-supplicant just to install on Orbic.
+pub async fn install_wifi_tools<C: DeviceConnection>(conn: &mut C) -> Result<()> {
+    if env!("FILE_WPA_SUPPLICANT").is_empty() {
+        println!("wifi tools were not built into this installer, skipping");
+        return Ok(());
+    }
     let tools: &[(&str, &str, &[u8])] = &[
         (
             "wpa_supplicant",
             "/data/rayhunter/bin/wpa_supplicant",
-            wpa_supplicant,
+            crate::get_file!("FILE_WPA_SUPPLICANT"),
         ),
-        ("wpa_cli", "/data/rayhunter/bin/wpa_cli", wpa_cli),
-        ("iw", "/data/rayhunter/bin/iw", iw),
+        (
+            "wpa_cli",
+            "/data/rayhunter/bin/wpa_cli",
+            crate::get_file!("FILE_WPA_CLI"),
+        ),
+        ("iw", "/data/rayhunter/bin/iw", crate::get_file!("FILE_IW")),
     ];
     for &(name, dest, payload) in tools {
         if device_has_binary(conn, name).await {

--- a/installer/src/orbic.rs
+++ b/installer/src/orbic.rs
@@ -170,13 +170,7 @@ async fn setup_rayhunter(mut adb_device: ADBUSBDevice, reset_config: bool) -> Re
             device: &mut adb_device,
         };
         install_config(&mut conn, "orbic", reset_config).await?;
-        install_wifi_tools(
-            &mut conn,
-            crate::get_file!("FILE_WPA_SUPPLICANT"),
-            crate::get_file!("FILE_WPA_CLI"),
-            crate::get_file!("FILE_IW"),
-        )
-        .await?;
+        install_wifi_tools(&mut conn).await?;
     }
 
     install_file(

--- a/installer/src/orbic_network.rs
+++ b/installer/src/orbic_network.rs
@@ -248,13 +248,7 @@ async fn setup_rayhunter(admin_ip: &str, reset_config: bool, data_dir: &str) -> 
     )
     .await?;
 
-    install_wifi_tools(
-        &mut conn,
-        crate::get_file!("FILE_WPA_SUPPLICANT"),
-        crate::get_file!("FILE_WPA_CLI"),
-        crate::get_file!("FILE_IW"),
-    )
-    .await?;
+    install_wifi_tools(&mut conn).await?;
 
     install_config(&mut conn, "orbic", reset_config).await?;
 


### PR DESCRIPTION
This is a followup to https://github.com/EFForg/rayhunter/pull/995

That PR only made building wpa-supplicant optional for developers who
effectively test their changes on tplink. Anybody who uses orbic in dev
still had to have a crosscompiler
(https://github.com/EFForg/rayhunter/pull/1007#issuecomment-4323039496)

This PR now actually makes WiFi tools optional within the orbic
installer too. That step is just skipped entirely if wpa supplicant
wasn't built.
