### PR TITLE
Fix dependabot config

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -11,8 +11,8 @@ updates:
       interval: "weekly"
     open-pull-requests-limit: 0
     groups:
-      applies-to: "security-updates"
-      dependency-type:
+      security:
+        applies-to: "security-updates"
         patterns:
           - "*"
 
@@ -23,8 +23,8 @@ updates:
       interval: "weekly"
     open-pull-requests-limit: 0
     groups:
-      applies-to: "security-updates"
-      dependency-type:
+      security:
+        applies-to: "security-updates"
         patterns:
           - "*"
 
@@ -35,8 +35,8 @@ updates:
       interval: "weekly"
     open-pull-requests-limit: 0
     groups:
-      applies-to: "security-updates"
-      dependency-type:
+      security:
+        applies-to: "security-updates"
         patterns:
           - "*"
 
@@ -47,7 +47,7 @@ updates:
       interval: "weekly"
     open-pull-requests-limit: 0
     groups:
-      applies-to: "security-updates"
-      dependency-type:
+      security:
+        applies-to: "security-updates"
         patterns:
           - "*"


### PR DESCRIPTION
PR #998 was supposed to filter dependabot PRs to security updates only.
But applies-to was on the wrong level of nesting.

Also renamed the group from "dependency-type" to "security", right now
we get PRs like "Bump the dependency-type group in /installer-gui with 7
updates #1010"

Search for applies-to on this page:
https://docs.github.com/en/code-security/reference/supply-chain-security/dependabot-options-reference
-- it's on the same level as patterns.

This PR was fully AI-generated, description hand-written though.
