### PR TITLE
Fix roaming falsepos

### DIFF
--- a/lib/src/analysis/imsi_requested.rs
+++ b/lib/src/analysis/imsi_requested.rs
@@ -7,13 +7,13 @@ use super::analyzer::{Analyzer, Event, EventType};
 use super::information_element::{InformationElement, LteInformationElement};
 use log::debug;
 
-use telcom_parser::lte_rrc::{
-    DL_DCCH_MessageType, DL_DCCH_MessageType_c1, UL_CCCH_MessageType, UL_CCCH_MessageType_c1,
-};
-use telcom_parser::lte_rrc::{BCCH_DL_SCH_MessageType, BCCH_DL_SCH_MessageType_c1};
-use telcom_parser::lte_rrc::{PLMN_Identity, PLMN_IdentityList, MCC_MNC_Digit};
-use pycrate_rs::nas::generated::emm::emm_attach_request::TAI;
 use pycrate_rs::nas::generated::emm::emm_attach_reject::EMMCauseEMMCause as AttachRejectEMMCause;
+use pycrate_rs::nas::generated::emm::emm_attach_request::TAI;
+use telcom_parser::lte_rrc::{BCCH_DL_SCH_MessageType, BCCH_DL_SCH_MessageType_c1};
+use telcom_parser::lte_rrc::{
+    /* DL_DCCH_MessageType, DL_DCCH_MessageType_c1,*/ UL_CCCH_MessageType, UL_CCCH_MessageType_c1,
+};
+use telcom_parser::lte_rrc::{MCC_MNC_Digit, PLMN_Identity, PLMN_IdentityList};
 
 const TIMEOUT_THRESHHOLD: usize = 50;
 
@@ -46,8 +46,8 @@ impl ImsiRequestedAnalyzer {
             state: State::Unattached,
             timeout_counter: 0,
             flag: None,
-            // You will likely wonder why this isn't an Option<PLMN{mcc: u32, mnc: u32}> 
-            // The answer is that I like strings. 
+            // You will likely wonder why this isn't an Option<PLMN{mcc: u32, mnc: u32}>
+            // The answer is that I like strings.
             likely_enb_plmn: "Unknown".to_string(),
             likely_ue_plmn: "Unknown".to_string(),
         }
@@ -85,14 +85,18 @@ impl ImsiRequestedAnalyzer {
                 if self.likely_enb_plmn == self.likely_ue_plmn {
                     self.flag = Some(Event {
                         event_type: EventType::High,
-                        message: format!("Disconnected after Identity Request without Auth Accept on home network!"),
+                        message: format!(
+                            "Disconnected after Identity Request without Auth Accept on home network!"
+                        ),
                     });
                 } else {
                     self.flag = Some(Event {
                         event_type: EventType::Low,
-                        message: format!("Disconnected after Identity Request without Auth Accept, but this could be a false positive roaming issue - Tower PLMN: {}, UE PLMN: {}", self.likely_enb_plmn, self.likely_ue_plmn),
+                        message: format!(
+                            "Disconnected after Identity Request without Auth Accept, but this could be a false positive roaming issue - Tower PLMN: {}, UE PLMN: {}",
+                            self.likely_enb_plmn, self.likely_ue_plmn
+                        ),
                     });
-
                 }
             }
 
@@ -113,33 +117,41 @@ impl ImsiRequestedAnalyzer {
 
     // Sometimes an ENB can have multiple PLMNS
     fn format_plmn_list(&mut self, plmn_list: &PLMN_IdentityList) -> String {
-        plmn_list.0.iter()
+        plmn_list
+            .0
+            .iter()
             .map(|info| self.plmn_identity_to_str(&info.plmn_identity))
             .collect::<Vec<_>>()
             .join(", ")
     }
 
     // PLMN is represented in two very different ways in the LTE spec so we need
-    // two very different functions to decode them. I hate this. 
+    // two very different functions to decode them. I hate this.
     fn plmn_identity_to_str(&mut self, plmn: &PLMN_Identity) -> String {
-        let mcc_digits: String = plmn.mcc
+        let mcc_digits: String = plmn
+            .mcc
             .as_ref()
-            .map(|mcc| mcc.0.iter()
-                .filter_map(|d| match d {
-                    MCC_MNC_Digit(n) => Some(n.to_string()),
-                })
-                .collect::<Vec<_>>()
-                .join(""))
+            .map(|mcc| {
+                mcc.0
+                    .iter()
+                    .filter_map(|d| match d {
+                        MCC_MNC_Digit(n) => Some(n.to_string()),
+                    })
+                    .collect::<Vec<_>>()
+                    .join("")
+            })
             .unwrap_or_default();
-        
-        let mnc_digits: String = plmn.mnc
-            .0.iter()
+
+        let mnc_digits: String = plmn
+            .mnc
+            .0
+            .iter()
             .filter_map(|d| match d {
                 MCC_MNC_Digit(n) => Some(n.to_string()),
             })
             .collect::<Vec<_>>()
             .join("");
-        
+
         format!("{}-{}", mcc_digits, mnc_digits)
     }
 
@@ -158,7 +170,10 @@ impl ImsiRequestedAnalyzer {
         let mnc_str = if mnc_digit3 == 0xF {
             format!("{:02}", mnc_digit1 * 10 + mnc_digit2)
         } else {
-            format!("{:03}", mnc_digit1 as u32 * 100 + mnc_digit2 as u32 * 10 + mnc_digit3 as u32)
+            format!(
+                "{:03}",
+                mnc_digit1 as u32 * 100 + mnc_digit2 as u32 * 10 + mnc_digit3 as u32
+            )
         };
 
         format!("{}-{}", mcc_str, mnc_str)
@@ -166,12 +181,9 @@ impl ImsiRequestedAnalyzer {
 
     fn extract_plmn(&mut self, old_tai: &Option<TAI>) -> String {
         match old_tai {
-            Some(t) => {
-                self.plmn_vec_to_str(&t.plmn)
-            },
-            None => "Unknown".to_string()
+            Some(t) => self.plmn_vec_to_str(&t.plmn),
+            None => "Unknown".to_string(),
         }
-
     }
 }
 
@@ -195,19 +207,18 @@ impl Analyzer for ImsiRequestedAnalyzer {
         ie: &InformationElement,
         packet_num: usize,
     ) -> Option<Event> {
-        // Set the enodeb plmn to the last sib1 we got, we should improve this once we have PCI data, this 
-        // is a naive approach. 
+        // Set the enodeb plmn to the last sib1 we got, we should improve this once we have PCI data, this
+        // is a naive approach.
         if let InformationElement::LTE(lte_ie) = ie
             && let LteInformationElement::BcchDlSch(sch_msg) = &**lte_ie
             && let BCCH_DL_SCH_MessageType::C1(c1) = &sch_msg.message
-            && let BCCH_DL_SCH_MessageType_c1::SystemInformationBlockType1(sib1) = c1 {
-                
-                let plmn = &sib1.cell_access_related_info.plmn_identity_list;
-                self.likely_enb_plmn = self.format_plmn_list(plmn);
-                
-                return None;
-        }
+            && let BCCH_DL_SCH_MessageType_c1::SystemInformationBlockType1(sib1) = c1
+        {
+            let plmn = &sib1.cell_access_related_info.plmn_identity_list;
+            self.likely_enb_plmn = self.format_plmn_list(plmn);
 
+            return None;
+        }
 
         if let InformationElement::LTE(inner) = ie {
             match &**inner {
@@ -236,7 +247,9 @@ impl Analyzer for ImsiRequestedAnalyzer {
                     }
                     NASMessage::EMMMessage(EMMMessage::EMMAttachReject(reject)) => {
                         self.transition(State::Disconnect, packet_num);
-                        if reject.emm_cause.inner == AttachRejectEMMCause::EPSServicesAndNonEPSServicesNotAllowed {
+                        if reject.emm_cause.inner
+                            == AttachRejectEMMCause::EPSServicesAndNonEPSServicesNotAllowed
+                        {
                             self.flag = Some(Event {
                                 event_type: EventType::Low,
                                 message: "Identity requested without authentication but its likely a false positive unless your SIM card has an active plan".to_string(),
@@ -257,7 +270,7 @@ impl Analyzer for ImsiRequestedAnalyzer {
                 },
 
                 // This causes two messages in the event of a false positive when we should always get an attach reject anyway so
-                // I'm commentingit out until I figure out a smarter way to deal with it. 
+                // I'm commentingit out until I figure out a smarter way to deal with it.
                 /*
                 LteInformationElement::DlDcch(rrc_payload) => {
                     if let DL_DCCH_MessageType::C1(DL_DCCH_MessageType_c1::RrcConnectionRelease(

--- a/lib/src/analysis/imsi_requested.rs
+++ b/lib/src/analysis/imsi_requested.rs
@@ -10,6 +10,10 @@ use log::debug;
 use telcom_parser::lte_rrc::{
     DL_DCCH_MessageType, DL_DCCH_MessageType_c1, UL_CCCH_MessageType, UL_CCCH_MessageType_c1,
 };
+use telcom_parser::lte_rrc::{BCCH_DL_SCH_MessageType, BCCH_DL_SCH_MessageType_c1};
+use telcom_parser::lte_rrc::{PLMN_Identity, PLMN_IdentityList, MCC_MNC_Digit};
+use pycrate_rs::nas::generated::emm::emm_attach_request::TAI;
+use pycrate_rs::nas::generated::emm::emm_attach_reject::EMMCauseEMMCause as AttachRejectEMMCause;
 
 const TIMEOUT_THRESHHOLD: usize = 50;
 
@@ -26,6 +30,8 @@ pub struct ImsiRequestedAnalyzer {
     state: State,
     timeout_counter: usize,
     flag: Option<Event>,
+    likely_enb_plmn: String,
+    likely_ue_plmn: String,
 }
 
 impl Default for ImsiRequestedAnalyzer {
@@ -40,6 +46,10 @@ impl ImsiRequestedAnalyzer {
             state: State::Unattached,
             timeout_counter: 0,
             flag: None,
+            // You will likely wonder why this isn't an Option<PLMN{mcc: u32, mnc: u32}> 
+            // The answer is that I like strings. 
+            likely_enb_plmn: "Unknown".to_string(),
+            likely_ue_plmn: "Unknown".to_string(),
         }
     }
 
@@ -72,10 +82,18 @@ impl ImsiRequestedAnalyzer {
 
             // IMSI to Disconnect without AuthAccept
             (State::IdentityRequest, State::Disconnect) => {
-                self.flag = Some(Event {
-                    event_type: EventType::High,
-                    message: "Disconnected after Identity Request without Auth Accept".to_string(),
-                });
+                if self.likely_enb_plmn == self.likely_ue_plmn {
+                    self.flag = Some(Event {
+                        event_type: EventType::High,
+                        message: format!("Disconnected after Identity Request without Auth Accept on home network!"),
+                    });
+                } else {
+                    self.flag = Some(Event {
+                        event_type: EventType::Low,
+                        message: format!("Disconnected after Identity Request without Auth Accept, but this could be a false positive roaming issue - Tower PLMN: {}, UE PLMN: {}", self.likely_enb_plmn, self.likely_ue_plmn),
+                    });
+
+                }
             }
 
             (_, State::IdentityRequest) => {
@@ -92,6 +110,69 @@ impl ImsiRequestedAnalyzer {
         }
         self.state = next_state;
     }
+
+    // Sometimes an ENB can have multiple PLMNS
+    fn format_plmn_list(&mut self, plmn_list: &PLMN_IdentityList) -> String {
+        plmn_list.0.iter()
+            .map(|info| self.plmn_identity_to_str(&info.plmn_identity))
+            .collect::<Vec<_>>()
+            .join(", ")
+    }
+
+    // PLMN is represented in two very different ways in the LTE spec so we need
+    // two very different functions to decode them. I hate this. 
+    fn plmn_identity_to_str(&mut self, plmn: &PLMN_Identity) -> String {
+        let mcc_digits: String = plmn.mcc
+            .as_ref()
+            .map(|mcc| mcc.0.iter()
+                .filter_map(|d| match d {
+                    MCC_MNC_Digit(n) => Some(n.to_string()),
+                })
+                .collect::<Vec<_>>()
+                .join(""))
+            .unwrap_or_default();
+        
+        let mnc_digits: String = plmn.mnc
+            .0.iter()
+            .filter_map(|d| match d {
+                MCC_MNC_Digit(n) => Some(n.to_string()),
+            })
+            .collect::<Vec<_>>()
+            .join("");
+        
+        format!("{}-{}", mcc_digits, mnc_digits)
+    }
+
+    fn plmn_vec_to_str(&mut self, bytes: &Vec<u8>) -> String {
+        let mcc_digit1 = bytes[0] & 0x0F;
+        let mcc_digit2 = (bytes[0] >> 4) & 0x0F;
+        let mcc_digit3 = bytes[1] & 0x0F;
+
+        let mnc_digit1 = bytes[2] & 0x0F;
+        let mnc_digit2 = (bytes[2] >> 4) & 0x0F;
+        let mnc_digit3 = (bytes[1] >> 4) & 0x0F;
+
+        let mcc = mcc_digit1 as u32 * 100 + mcc_digit2 as u32 * 10 + mcc_digit3 as u32;
+
+        let mcc_str = format!("{:03}", mcc);
+        let mnc_str = if mnc_digit3 == 0xF {
+            format!("{:02}", mnc_digit1 * 10 + mnc_digit2)
+        } else {
+            format!("{:03}", mnc_digit1 as u32 * 100 + mnc_digit2 as u32 * 10 + mnc_digit3 as u32)
+        };
+
+        format!("{}-{}", mcc_str, mnc_str)
+    }
+
+    fn extract_plmn(&mut self, old_tai: &Option<TAI>) -> String {
+        match old_tai {
+            Some(t) => {
+                self.plmn_vec_to_str(&t.plmn)
+            },
+            None => "Unknown".to_string()
+        }
+
+    }
 }
 
 impl Analyzer for ImsiRequestedAnalyzer {
@@ -106,7 +187,7 @@ impl Analyzer for ImsiRequestedAnalyzer {
     }
 
     fn get_version(&self) -> u32 {
-        3
+        4
     }
 
     fn analyze_information_element(
@@ -114,11 +195,30 @@ impl Analyzer for ImsiRequestedAnalyzer {
         ie: &InformationElement,
         packet_num: usize,
     ) -> Option<Event> {
+        // Set the enodeb plmn to the last sib1 we got, we should improve this once we have PCI data, this 
+        // is a naive approach. 
+        if let InformationElement::LTE(lte_ie) = ie
+            && let LteInformationElement::BcchDlSch(sch_msg) = &**lte_ie
+            && let BCCH_DL_SCH_MessageType::C1(c1) = &sch_msg.message
+            && let BCCH_DL_SCH_MessageType_c1::SystemInformationBlockType1(sib1) = c1 {
+                
+                let plmn = &sib1.cell_access_related_info.plmn_identity_list;
+                self.likely_enb_plmn = self.format_plmn_list(plmn);
+                
+                return None;
+        }
+
+
         if let InformationElement::LTE(inner) = ie {
             match &**inner {
                 LteInformationElement::NAS(payload) => match payload {
-                    NASMessage::EMMMessage(EMMMessage::EMMExtServiceRequest(_))
-                    | NASMessage::EMMMessage(EMMMessage::EMMAttachRequest(_)) => {
+                    NASMessage::EMMMessage(EMMMessage::EMMAttachRequest(request)) => {
+                        if self.likely_ue_plmn == "Unknown" {
+                            self.likely_ue_plmn = self.extract_plmn(&request.old_tai.inner);
+                        }
+                        self.transition(State::AttachRequest, packet_num);
+                    }
+                    NASMessage::EMMMessage(EMMMessage::EMMExtServiceRequest(_)) => {
                         self.transition(State::AttachRequest, packet_num);
                     }
                     NASMessage::EMMMessage(EMMMessage::EMMIdentityRequest(_)) => {
@@ -129,11 +229,19 @@ impl Analyzer for ImsiRequestedAnalyzer {
                         self.transition(State::AuthAccept, packet_num);
                     }
                     NASMessage::EMMMessage(EMMMessage::EMMServiceReject(_))
-                    | NASMessage::EMMMessage(EMMMessage::EMMAttachReject(_))
                     | NASMessage::EMMMessage(EMMMessage::EMMDetachRequestMO(_))
                     | NASMessage::EMMMessage(EMMMessage::EMMDetachRequestMT(_))
                     | NASMessage::EMMMessage(EMMMessage::EMMTrackingAreaUpdateReject(_)) => {
                         self.transition(State::Disconnect, packet_num);
+                    }
+                    NASMessage::EMMMessage(EMMMessage::EMMAttachReject(reject)) => {
+                        self.transition(State::Disconnect, packet_num);
+                        if reject.emm_cause.inner == AttachRejectEMMCause::EPSServicesAndNonEPSServicesNotAllowed {
+                            self.flag = Some(Event {
+                                event_type: EventType::Low,
+                                message: "Identity requested without authentication but its likely a false positive unless your SIM card has an active plan".to_string(),
+                            });
+                        }
                     }
                     _ => {}
                 },
@@ -148,6 +256,9 @@ impl Analyzer for ImsiRequestedAnalyzer {
                     _ => {}
                 },
 
+                // This causes two messages in the event of a false positive when we should always get an attach reject anyway so
+                // I'm commentingit out until I figure out a smarter way to deal with it. 
+                /*
                 LteInformationElement::DlDcch(rrc_payload) => {
                     if let DL_DCCH_MessageType::C1(DL_DCCH_MessageType_c1::RrcConnectionRelease(
                         _,
@@ -156,6 +267,7 @@ impl Analyzer for ImsiRequestedAnalyzer {
                         self.transition(State::Disconnect, packet_num)
                     }
                 }
+                */
                 _ => {}
             }
         };

--- a/lib/src/analysis/imsi_requested.rs
+++ b/lib/src/analysis/imsi_requested.rs
@@ -10,10 +10,11 @@ use log::debug;
 use pycrate_rs::nas::generated::emm::emm_attach_reject::EMMCauseEMMCause as AttachRejectEMMCause;
 use pycrate_rs::nas::generated::emm::emm_attach_request::TAI;
 use telcom_parser::lte_rrc::{BCCH_DL_SCH_MessageType, BCCH_DL_SCH_MessageType_c1};
-use telcom_parser::lte_rrc::{
-    /* DL_DCCH_MessageType, DL_DCCH_MessageType_c1,*/ UL_CCCH_MessageType, UL_CCCH_MessageType_c1,
-};
 use telcom_parser::lte_rrc::{MCC_MNC_Digit, PLMN_Identity, PLMN_IdentityList};
+use telcom_parser::lte_rrc::{
+    /* DL_DCCH_MessageType, DL_DCCH_MessageType_c1,*/ UL_CCCH_MessageType,
+    UL_CCCH_MessageType_c1,
+};
 
 const TIMEOUT_THRESHHOLD: usize = 50;
 
@@ -126,18 +127,24 @@ impl ImsiRequestedAnalyzer {
     // PLMN is represented in two very different ways in the LTE spec so we need
     // two very different functions to decode them. I hate this.
     fn plmn_identity_to_str(&mut self, plmn: &PLMN_Identity) -> String {
-        let mcc_digits: String = plmn.mcc
+        let mcc_digits: String = plmn
+            .mcc
             .as_ref()
-            .map(|mcc| mcc.0.iter()
-                .map(|MCC_MNC_Digit(n)| n.to_string())
-                .collect::<String>())
+            .map(|mcc| {
+                mcc.0
+                    .iter()
+                    .map(|MCC_MNC_Digit(n)| n.to_string())
+                    .collect::<String>()
+            })
             .unwrap_or_default();
-        
-        let mnc_digits: String = plmn.mnc
-            .0.iter()
+
+        let mnc_digits: String = plmn
+            .mnc
+            .0
+            .iter()
             .map(|MCC_MNC_Digit(n)| n.to_string())
             .collect::<String>();
-        
+
         format!("{}-{}", mcc_digits, mnc_digits)
     }
 

--- a/lib/src/analysis/imsi_requested.rs
+++ b/lib/src/analysis/imsi_requested.rs
@@ -85,9 +85,7 @@ impl ImsiRequestedAnalyzer {
                 if self.likely_enb_plmn == self.likely_ue_plmn {
                     self.flag = Some(Event {
                         event_type: EventType::High,
-                        message: format!(
-                            "Disconnected after Identity Request without Auth Accept on home network!"
-                        ),
+                        message: "Disconnected after Identity Request without Auth Accept on home network!".to_string(),
                     });
                 } else {
                     self.flag = Some(Event {
@@ -128,34 +126,22 @@ impl ImsiRequestedAnalyzer {
     // PLMN is represented in two very different ways in the LTE spec so we need
     // two very different functions to decode them. I hate this.
     fn plmn_identity_to_str(&mut self, plmn: &PLMN_Identity) -> String {
-        let mcc_digits: String = plmn
-            .mcc
+        let mcc_digits: String = plmn.mcc
             .as_ref()
-            .map(|mcc| {
-                mcc.0
-                    .iter()
-                    .filter_map(|d| match d {
-                        MCC_MNC_Digit(n) => Some(n.to_string()),
-                    })
-                    .collect::<Vec<_>>()
-                    .join("")
-            })
+            .map(|mcc| mcc.0.iter()
+                .map(|MCC_MNC_Digit(n)| n.to_string())
+                .collect::<String>())
             .unwrap_or_default();
-
-        let mnc_digits: String = plmn
-            .mnc
-            .0
-            .iter()
-            .filter_map(|d| match d {
-                MCC_MNC_Digit(n) => Some(n.to_string()),
-            })
-            .collect::<Vec<_>>()
-            .join("");
-
+        
+        let mnc_digits: String = plmn.mnc
+            .0.iter()
+            .map(|MCC_MNC_Digit(n)| n.to_string())
+            .collect::<String>();
+        
         format!("{}-{}", mcc_digits, mnc_digits)
     }
 
-    fn plmn_vec_to_str(&mut self, bytes: &Vec<u8>) -> String {
+    fn plmn_vec_to_str(&mut self, bytes: &[u8]) -> String {
         let mcc_digit1 = bytes[0] & 0x0F;
         let mcc_digit2 = (bytes[0] >> 4) & 0x0F;
         let mcc_digit3 = bytes[1] & 0x0F;

--- a/lib/src/analysis/imsi_requested.rs
+++ b/lib/src/analysis/imsi_requested.rs
@@ -83,7 +83,7 @@ impl ImsiRequestedAnalyzer {
 
             // IMSI to Disconnect without AuthAccept
             (State::IdentityRequest, State::Disconnect) => {
-                if self.likely_enb_plmn == self.likely_ue_plmn {
+                if self.likely_ue_plmn != "Unknown" && self.likely_enb_plmn == self.likely_ue_plmn {
                     self.flag = Some(Event {
                         event_type: EventType::High,
                         message: "Disconnected after Identity Request without Auth Accept on home network!".to_string(),
@@ -217,8 +217,9 @@ impl Analyzer for ImsiRequestedAnalyzer {
             match &**inner {
                 LteInformationElement::NAS(payload) => match payload {
                     NASMessage::EMMMessage(EMMMessage::EMMAttachRequest(request)) => {
-                        if self.likely_ue_plmn == "Unknown" {
-                            self.likely_ue_plmn = self.extract_plmn(&request.old_tai.inner);
+                        let plmn = self.extract_plmn(&request.old_tai.inner);
+                        if plmn != "Unknown" {
+                            self.likely_ue_plmn = plmn;
                         }
                         self.transition(State::AttachRequest, packet_num);
                     }

--- a/lib/src/analysis/imsi_requested.rs
+++ b/lib/src/analysis/imsi_requested.rs
@@ -90,9 +90,11 @@ impl ImsiRequestedAnalyzer {
 
             // IMSI to Disconnect without AuthAccept
             (State::IdentityRequest, State::Disconnect) => {
-                if self.likely_ue_plmn.as_ref().is_some_and(|p| {
-                    self.likely_enb_plmns.len() == 1 && self.likely_enb_plmns.contains(p)
-                }) {
+                if self
+                    .likely_ue_plmn
+                    .as_ref()
+                    .is_some_and(|p| self.likely_enb_plmns.contains(p))
+                {
                     self.flag = Some(Event {
                         event_type: EventType::High,
                         message: "Disconnected after Identity Request without Auth Accept on home network!".to_string(),

--- a/lib/src/analysis/imsi_requested.rs
+++ b/lib/src/analysis/imsi_requested.rs
@@ -5,7 +5,7 @@ use pycrate_rs::nas::emm::EMMMessage;
 
 use super::analyzer::{Analyzer, Event, EventType};
 use super::information_element::{InformationElement, LteInformationElement};
-use log::debug;
+use log::{debug, error};
 
 use pycrate_rs::nas::generated::emm::emm_attach_reject::EMMCauseEMMCause as AttachRejectEMMCause;
 use pycrate_rs::nas::generated::emm::emm_attach_request::TAI;
@@ -25,14 +25,15 @@ pub enum State {
     IdentityRequest,
     AuthAccept,
     Disconnect,
+    LikelyValidAttachReject,
 }
 
 pub struct ImsiRequestedAnalyzer {
     state: State,
     timeout_counter: usize,
     flag: Option<Event>,
-    likely_enb_plmn: String,
-    likely_ue_plmn: String,
+    likely_enb_plmns: Vec<String>,
+    likely_ue_plmn: Option<String>,
 }
 
 impl Default for ImsiRequestedAnalyzer {
@@ -47,10 +48,8 @@ impl ImsiRequestedAnalyzer {
             state: State::Unattached,
             timeout_counter: 0,
             flag: None,
-            // You will likely wonder why this isn't an Option<PLMN{mcc: u32, mnc: u32}>
-            // The answer is that I like strings.
-            likely_enb_plmn: "Unknown".to_string(),
-            likely_ue_plmn: "Unknown".to_string(),
+            likely_enb_plmns: vec![],
+            likely_ue_plmn: None,
         }
     }
 
@@ -81,19 +80,36 @@ impl ImsiRequestedAnalyzer {
                 });
             }
 
+            // Expected AttachReject for inactive SIMs
+            (_, State::LikelyValidAttachReject) => {
+                self.flag = Some(Event {
+                    event_type: EventType::Low,
+                    message: "Identity requested without authentication but its likely a false positive unless your SIM card has an active plan".to_string(),
+                });
+            }
+
             // IMSI to Disconnect without AuthAccept
             (State::IdentityRequest, State::Disconnect) => {
-                if self.likely_ue_plmn != "Unknown" && self.likely_enb_plmn == self.likely_ue_plmn {
+                if self.likely_ue_plmn.as_ref().is_some_and(|p| {
+                    self.likely_enb_plmns.len() == 1 && self.likely_enb_plmns.contains(p)
+                }) {
                     self.flag = Some(Event {
                         event_type: EventType::High,
                         message: "Disconnected after Identity Request without Auth Accept on home network!".to_string(),
                     });
                 } else {
+                    let enb_plmn_string = if self.likely_enb_plmns.is_empty() {
+                        "Unknown"
+                    } else {
+                        &self.likely_enb_plmns.join(", ")
+                    };
+                    let ue_plmn_string = self.likely_ue_plmn.as_deref().unwrap_or("Unknown");
+
                     self.flag = Some(Event {
                         event_type: EventType::Low,
                         message: format!(
                             "Disconnected after Identity Request without Auth Accept, but this could be a false positive roaming issue - Tower PLMN: {}, UE PLMN: {}",
-                            self.likely_enb_plmn, self.likely_ue_plmn
+                            enb_plmn_string, ue_plmn_string,
                         ),
                     });
                 }
@@ -111,22 +127,28 @@ impl ImsiRequestedAnalyzer {
                 );
             }
         }
-        self.state = next_state;
+
+        // LikelyValidAttachReject is a special case of Disconnect so after handling any special
+        // behavior above, we transition to the standard Disconnect state.
+        if next_state == State::LikelyValidAttachReject {
+            self.state = State::Disconnect;
+        } else {
+            self.state = next_state;
+        }
     }
 
     // Sometimes an ENB can have multiple PLMNS
-    fn format_plmn_list(&mut self, plmn_list: &PLMN_IdentityList) -> String {
+    fn format_plmn_list(&self, plmn_list: &PLMN_IdentityList) -> Vec<String> {
         plmn_list
             .0
             .iter()
             .map(|info| self.plmn_identity_to_str(&info.plmn_identity))
-            .collect::<Vec<_>>()
-            .join(", ")
+            .collect()
     }
 
     // PLMN is represented in two very different ways in the LTE spec so we need
     // two very different functions to decode them. I hate this.
-    fn plmn_identity_to_str(&mut self, plmn: &PLMN_Identity) -> String {
+    fn plmn_identity_to_str(&self, plmn: &PLMN_Identity) -> String {
         let mcc_digits: String = plmn
             .mcc
             .as_ref()
@@ -148,14 +170,20 @@ impl ImsiRequestedAnalyzer {
         format!("{}-{}", mcc_digits, mnc_digits)
     }
 
-    fn plmn_vec_to_str(&mut self, bytes: &[u8]) -> String {
-        let mcc_digit1 = bytes[0] & 0x0F;
-        let mcc_digit2 = (bytes[0] >> 4) & 0x0F;
-        let mcc_digit3 = bytes[1] & 0x0F;
+    fn tai_to_plmn_str(&self, maybe_tai: Option<&TAI>) -> Option<String> {
+        let plmn = &maybe_tai?.plmn;
+        if plmn.len() != 3 {
+            error!("TAI.plmn vector has unexpected length of {}", plmn.len());
+            return None;
+        }
 
-        let mnc_digit1 = bytes[2] & 0x0F;
-        let mnc_digit2 = (bytes[2] >> 4) & 0x0F;
-        let mnc_digit3 = (bytes[1] >> 4) & 0x0F;
+        let mcc_digit1 = plmn[0] & 0x0F;
+        let mcc_digit2 = (plmn[0] >> 4) & 0x0F;
+        let mcc_digit3 = plmn[1] & 0x0F;
+
+        let mnc_digit1 = plmn[2] & 0x0F;
+        let mnc_digit2 = (plmn[2] >> 4) & 0x0F;
+        let mnc_digit3 = (plmn[1] >> 4) & 0x0F;
 
         let mcc = mcc_digit1 as u32 * 100 + mcc_digit2 as u32 * 10 + mcc_digit3 as u32;
 
@@ -169,14 +197,7 @@ impl ImsiRequestedAnalyzer {
             )
         };
 
-        format!("{}-{}", mcc_str, mnc_str)
-    }
-
-    fn extract_plmn(&mut self, old_tai: &Option<TAI>) -> String {
-        match old_tai {
-            Some(t) => self.plmn_vec_to_str(&t.plmn),
-            None => "Unknown".to_string(),
-        }
+        Some(format!("{}-{}", mcc_str, mnc_str))
     }
 }
 
@@ -208,7 +229,7 @@ impl Analyzer for ImsiRequestedAnalyzer {
             && let BCCH_DL_SCH_MessageType_c1::SystemInformationBlockType1(sib1) = c1
         {
             let plmn = &sib1.cell_access_related_info.plmn_identity_list;
-            self.likely_enb_plmn = self.format_plmn_list(plmn);
+            self.likely_enb_plmns = self.format_plmn_list(plmn);
 
             return None;
         }
@@ -217,9 +238,9 @@ impl Analyzer for ImsiRequestedAnalyzer {
             match &**inner {
                 LteInformationElement::NAS(payload) => match payload {
                     NASMessage::EMMMessage(EMMMessage::EMMAttachRequest(request)) => {
-                        let plmn = self.extract_plmn(&request.old_tai.inner);
-                        if plmn != "Unknown" {
-                            self.likely_ue_plmn = plmn;
+                        let maybe_plmn = self.tai_to_plmn_str(request.old_tai.inner.as_ref());
+                        if maybe_plmn.is_some() {
+                            self.likely_ue_plmn = maybe_plmn;
                         }
                         self.transition(State::AttachRequest, packet_num);
                     }
@@ -240,14 +261,12 @@ impl Analyzer for ImsiRequestedAnalyzer {
                         self.transition(State::Disconnect, packet_num);
                     }
                     NASMessage::EMMMessage(EMMMessage::EMMAttachReject(reject)) => {
-                        self.transition(State::Disconnect, packet_num);
                         if reject.emm_cause.inner
                             == AttachRejectEMMCause::EPSServicesAndNonEPSServicesNotAllowed
                         {
-                            self.flag = Some(Event {
-                                event_type: EventType::Low,
-                                message: "Identity requested without authentication but its likely a false positive unless your SIM card has an active plan".to_string(),
-                            });
+                            self.transition(State::LikelyValidAttachReject, packet_num);
+                        } else {
+                            self.transition(State::Disconnect, packet_num);
                         }
                     }
                     _ => {}


### PR DESCRIPTION
## Pull Request Checklist

- [x] The Rayhunter team has recently expressed interest in reviewing a PR for this.
  - If not, this PR may be closed due our limited resources and need to prioritize how we spend them.
- [ ] Added or updated any documentation as needed to support the changes in this PR.
- [x] Code has been linted and run through `cargo fmt`.
- [x] If any new functionality has been added, unit tests were also added.
- [x] [CONTRIBUTING.md](https://github.com/EFForg/rayhunter/blob/main/CONTRIBUTING.md) has been read.
- [x] Your pull request is fewer than ~400 lines of code.

You must check one of:
- [ ] No generative AI (including LLMs) tools were used to create this PR.
- [x] Generative AI was used to create this PR. I certify that I have read and understand the code, and *that all comments and descriptions were authored by myself* and are not the product of generative AI.

I used an AI to assist me in writing plmn_vec_to_str and plmn_identity_to_str because I couldn't figure out the rust syntax but the logic behind it was figured out manually by me. I understand every line of code in those functions and feel confident about it. Feel free to suggest rewrites if the AI leaves a bad taste in your mouth, but the bit twiddling in plmn_vec_to_str is IMO the best way to do this, and I tested it extensively. **Every other LOC in this PR was artisinally hand crafted by me**

The issue this solves is that we get a lot of false positives which are mostly due to roaming errors, the user equipment roams onto an enodeb not belonging to its network. the network logically asks for the identity of the phone and then logically rejects it. These situations should mostly be considered false positives IMO, I'm much more interested when your home PLMN does this. (though its possible that an IMSI catcher could do this and be indistinguishable from a false positive I think that one would ideally want an IMSI catcher to operate on all of the major PLMNs to increase the chances of a phone camping on your network) 

This is a draft because I want to give it some thought before we publish this, my biggest concern is that we could start to get false negatives because of this, but I also don't want to continue to scare users with false positives. I think putting false positives as low severity hits that balance but I'm open to other ideas.

I know that @wgreenberg is going to disapprove of my use of strings instead of an Option containing a PLMN struct {mcc: u16, mnc: u16}. I have no justification for this other than that I like strings, and it should probably be fixed. This would also solve the issue we currently have where I am naively comparing two strings one of which may have multiple PLMN values. But right now I was just trying to get it good enough to make my analysis jobs easier. 

Two other potential issues are the naive way I'm getting PLMNs. I get the presumed PLMN for the ENB from the latest sib1 packet. This could be a problem if sibs come out of order. I could check the earfcn to solve this but I think checkign the PCI would be better, so once will lands that we can improve this. To get the PLMN of the UE I'm getting the PLMN from the phones previous tracking area the first time we see it. This seems to be the only place I can reliably find the PLMN other than in the IMSI itself, and I don't actually have a good way to do that right now! So far this seems accurate but I guess could end up generating false positives if the phone roamed onto another network before the start of this analysis. I'm not really sure how to make this more robust. 

The final issue is that I've had to comment out the state transition from a RRCConnectionRelease. Because if I leave that there it alerts once for that packet and then alerts again at low severity for the following AttachReject message if its the false positive EPSServicesAndNonEPSServicesNotAllowed reason. Since an RRCConectionRelease should always be followed or preceded by an AttachReject messgae I think this is okay for now but I would like to find a cleaner way to do it. 