### PR TITLE
frontend bugfix: Handle `null` input in `ExpandableInput`, make `ntfy_url` nullable

### DIFF
--- a/daemon/web/src/lib/components/ExpandableInput.svelte
+++ b/daemon/web/src/lib/components/ExpandableInput.svelte
@@ -25,7 +25,7 @@
         return text !== null && text.trim() !== '';
     }
 
-    let expanded = $state(has_value (value));
+    let expanded = $state(has_value(value));
     let inputElement = $state<HTMLInputElement | null>(null);
 
     function handle_checkbox_change(e: Event) {

--- a/daemon/web/src/lib/components/ExpandableInput.svelte
+++ b/daemon/web/src/lib/components/ExpandableInput.svelte
@@ -11,7 +11,7 @@
         inputHelp = '',
         children,
     }: {
-        value: string;
+        value: string | null;
         checkboxId: string;
         inputId: string;
         label: string;
@@ -21,7 +21,11 @@
         children?: Snippet;
     } = $props();
 
-    let expanded = $state(value.trim() !== '');
+    function has_value(text: string | null) {
+        return text !== null && text.trim() !== '';
+    }
+
+    let expanded = $state(has_value (value));
     let inputElement = $state<HTMLInputElement | null>(null);
 
     function handle_checkbox_change(e: Event) {
@@ -34,7 +38,7 @@
     }
 
     function handle_input_blur() {
-        if (value.trim() === '') {
+        if (!has_value(value)) {
             expanded = false;
         }
     }

--- a/daemon/web/src/lib/utils.svelte.ts
+++ b/daemon/web/src/lib/utils.svelte.ts
@@ -50,7 +50,7 @@ export interface Config {
     ui_level: number;
     colorblind_mode: boolean;
     key_input_mode: number;
-    ntfy_url: string;
+    ntfy_url: string | null;
     enabled_notifications: enabled_notifications[];
     analyzers: AnalyzerConfig;
     min_space_to_start_recording_mb: number;


### PR DESCRIPTION
## Pull Request Checklist

- [ ] The Rayhunter team has recently expressed interest in reviewing a PR for this.
  - If not, this PR may be closed due our limited resources and need to prioritize how we spend them.
- [X] Added or updated any documentation as needed to support the changes in this PR.
- [X] Code has been linted and run through `cargo fmt`.
- [X] If any new functionality has been added, unit tests were also added.
- [X] [CONTRIBUTING.md](https://github.com/EFForg/rayhunter/blob/main/CONTRIBUTING.md) has been read.
- [X] Your pull request is fewer than ~400 lines of code.

You must check one of:
- [X] No generative AI (including LLMs) tools were used to create this PR.
- [ ] Generative AI was used to create this PR. I certify that I have read and understand the code, and *that all comments and descriptions were authored by myself* and are not the product of generative AI.

The UI `Config` interface is out-of-sync with the daemon. In the daemon, `ntfy_url` is `Option<String>`, but in the frontend, it is `string` (it should be `string | null`). When trying to load the config form, it never changes from "Loading config...", as there is a `TypeError` in `ExpandableInput`, which expects a `string`, but is given `null` [here](https://github.com/EFForg/rayhunter/blob/e83ba9922dfa9a6e006cf948b74b5f44aab12d20/daemon/web/src/lib/components/ConfigForm.svelte#L218).