### PR TITLE
fix(installer): improve error message when port 4000 is already in use

### DIFF
--- a/installer/src/tplink.rs
+++ b/installer/src/tplink.rs
@@ -346,9 +346,13 @@ async fn tplink_launch_telnet_v5(admin_ip: &str) -> Result<(), Error> {
             admin_ip: admin_ip.to_owned(),
         });
 
-    let listener = tokio::net::TcpListener::bind("127.0.0.1:4000")
+    let bind_addr = "127.0.0.1:4000";
+    let listener = tokio::net::TcpListener::bind(bind_addr)
         .await
-        .unwrap();
+        .with_context(|| format!(
+            "Failed to bind to {bind_addr}. Is another process using this port?\n\
+             Try closing any application that might be listening on port 4000 and rerun the installer."
+        ))?;
 
     println!("Listening on http://{}", listener.local_addr().unwrap());
     println!("Please open above URL in your browser and log into the router to continue.");


### PR DESCRIPTION
Replace .unwrap() on TcpListener::bind with .with_context() so users see a clear message about the port conflict instead of a panic.

Fixes #906

## Pull Request Checklist

- [x] The Rayhunter team has recently expressed interest in reviewing a PR for this.
  - If not, this PR may be closed due our limited resources and need to prioritize how we spend them.
- [x] Added or updated any documentation as needed to support the changes in this PR.
- [x] Code has been linted and run through `cargo fmt`.
- [x] If any new functionality has been added, unit tests were also added.
- [x] [CONTRIBUTING.md](https://github.com/EFForg/rayhunter/blob/main/CONTRIBUTING.md) has been read.
- [x] Your pull request is fewer than ~400 lines of code.

You must check one of:
- [ ] No generative AI (including LLMs) tools were used to create this PR.
- [x] Generative AI was used to create this PR. I certify that I have read and understand the code, and *that all comments and descriptions were authored by myself* and are not the product of generative AI.
