### PR TITLE
fix(daemon): drain UI channel in headless mode to prevent panic

### DIFF
--- a/daemon/src/display/headless.rs
+++ b/daemon/src/display/headless.rs
@@ -7,10 +7,18 @@ use crate::config;
 use crate::display::DisplayState;
 
 pub fn update_ui(
-    _task_tracker: &TaskTracker,
+    task_tracker: &TaskTracker,
     _config: &config::Config,
-    _shutdown_token: CancellationToken,
-    _ui_update_rx: Receiver<DisplayState>,
+    shutdown_token: CancellationToken,
+    mut ui_update_rx: Receiver<DisplayState>,
 ) {
     info!("Headless mode, not spawning UI.");
+    task_tracker.spawn(async move {
+        loop {
+            tokio::select! {
+                _ = shutdown_token.cancelled() => break,
+                _ = ui_update_rx.recv() => {}
+            }
+        }
+    });
 }


### PR DESCRIPTION
The headless display (PinePhone) was dropping the UI update receiver immediately without consuming it. This caused sends from diag.rs to fail with SendError and panic. Fix: spawn a drain task in headless mode that consumes messages until shutdown, consistent with all other display implementations.

Affected location:
- daemon/src/display/headless.rs

Fixes #657

## Pull Request Checklist

- [x] The Rayhunter team has recently expressed interest in reviewing a PR for this.
  - If not, this PR may be closed due our limited resources and need to prioritize how we spend them.
- [x] Added or updated any documentation as needed to support the changes in this PR.
- [x] Code has been linted and run through `cargo fmt`.
- [x] If any new functionality has been added, unit tests were also added.
- [x] [CONTRIBUTING.md](https://github.com/EFForg/rayhunter/blob/main/CONTRIBUTING.md) has been read.
- [x] Your pull request is fewer than ~400 lines of code.

You must check one of:
- [ ] No generative AI (including LLMs) tools were used to create this PR.
- [x] Generative AI was used to create this PR. I certify that I have read and understand the code, and *that all comments and descriptions were authored by myself* and are not the product of generative AI.
