### PR TITLE
refactor(daemon): centralize reqwest client creation

### DIFF
--- a/daemon/src/http_client.rs
+++ b/daemon/src/http_client.rs
@@ -1,0 +1,29 @@
+//! Shared constructors for the daemon's outbound HTTP client.
+//!
+//! All `reqwest` clients in the daemon are created here so they share a
+//! consistent User-Agent and a default timeout (see #1057).
+
+use std::time::Duration;
+
+/// Default request timeout for the shared HTTP client. Individual requests can
+/// still override this with `RequestBuilder::timeout`.
+const DEFAULT_TIMEOUT: Duration = Duration::from_secs(30);
+
+/// The User-Agent sent with every outbound HTTP request from the daemon.
+pub fn user_agent() -> String {
+    format!("rayhunter/{}", env!("CARGO_PKG_VERSION"))
+}
+
+/// A [`reqwest::ClientBuilder`] preconfigured with the shared User-Agent and
+/// default timeout. Use this when a caller needs to customize the client
+/// further (e.g. a longer upload timeout); otherwise prefer [`client`].
+pub fn builder() -> reqwest::ClientBuilder {
+    reqwest::Client::builder()
+        .user_agent(user_agent())
+        .timeout(DEFAULT_TIMEOUT)
+}
+
+/// Builds a [`reqwest::Client`] with the shared User-Agent and default timeout.
+pub fn client() -> reqwest::Result<reqwest::Client> {
+    builder().build()
+}

--- a/daemon/src/lib.rs
+++ b/daemon/src/lib.rs
@@ -6,6 +6,7 @@ pub mod diag;
 pub mod display;
 pub mod error;
 pub mod gps;
+pub mod http_client;
 pub mod key_input;
 pub mod notifications;
 pub mod pcap;

--- a/daemon/src/main.rs
+++ b/daemon/src/main.rs
@@ -6,6 +6,7 @@ mod diag;
 mod display;
 mod error;
 mod gps;
+mod http_client;
 mod key_input;
 mod notifications;
 mod pcap;

--- a/daemon/src/notifications.rs
+++ b/daemon/src/notifications.rs
@@ -111,7 +111,13 @@ pub fn run_notification_worker(
             && !url.is_empty()
         {
             let mut notification_statuses = HashMap::new();
-            let http_client = reqwest::Client::new();
+            let http_client = match crate::http_client::client() {
+                Ok(client) => client,
+                Err(err) => {
+                    error!("failed to create notification HTTP client: {err}");
+                    return;
+                }
+            };
 
             loop {
                 // Get any notifications since the last time we checked
@@ -277,7 +283,7 @@ mod tests {
         let timeout: u64 = 2;
         let url = setup_timeout_server(timeout).await;
 
-        let http_client = reqwest::Client::new();
+        let http_client = crate::http_client::client().unwrap();
         let result = send_notification(
             &http_client,
             &url,

--- a/daemon/src/server.rs
+++ b/daemon/src/server.rs
@@ -227,7 +227,12 @@ pub async fn test_notification(
         ));
     }
 
-    let http_client = reqwest::Client::new();
+    let http_client = crate::http_client::client().map_err(|err| {
+        (
+            StatusCode::INTERNAL_SERVER_ERROR,
+            format!("failed to create HTTP client: {err}"),
+        )
+    })?;
     let message = "Test notification from Rayhunter".to_string();
 
     crate::notifications::send_notification(

--- a/daemon/src/update.rs
+++ b/daemon/src/update.rs
@@ -100,7 +100,6 @@ async fn refresh_update_status(
     let response = http_client
         .get(GITHUB_LATEST_RELEASE_URL)
         .timeout(Duration::from_secs(5))
-        .header(reqwest::header::USER_AGENT, "rayhunter-update-checker")
         .send()
         .await
         .map_err(|err| format!("failed to query GitHub releases: {err}"))?;
@@ -156,7 +155,7 @@ pub fn run_update_check_worker(
     enabled_notifications: Vec<NotificationType>,
 ) {
     task_tracker.spawn(async move {
-        let http_client = match reqwest::Client::builder().build() {
+        let http_client = match crate::http_client::client() {
             Ok(client) => client,
             Err(err) => {
                 error!("failed to create update check client: {err}");

--- a/daemon/src/webdav.rs
+++ b/daemon/src/webdav.rs
@@ -56,7 +56,7 @@ impl WebDavClient {
             url.push('/');
         }
         Ok(Self {
-            client: reqwest::Client::builder().timeout(timeout).build()?,
+            client: crate::http_client::builder().timeout(timeout).build()?,
             url,
             username,
             password,


### PR DESCRIPTION
Closes #1057.

Adds a single `http_client` factory (`daemon/src/http_client.rs`) that builds every outbound reqwest client with a shared `rayhunter/<version>` User-Agent and a default timeout, then routes the notification worker, update checker, webdav uploader, and the test-notification handler through it.

Before this, each spot built its own client inconsistently: a few used a bare `reqwest::Client::new()`, the update checker used `Client::builder().build()` with a `rayhunter-update-checker` User-Agent set per-request, and webdav set a timeout but no User-Agent. Now they share the same UA and default timeout. Callers that need a specific timeout still override it — webdav keeps its configurable upload timeout, and the update check keeps its 5s per-request timeout.

Verified with `cargo clippy --all-targets` and `cargo test -p rayhunter-daemon` (all green).
