### PR TITLE
make new false positive improvement case less special

### DIFF
--- a/lib/src/analysis/imsi_requested.rs
+++ b/lib/src/analysis/imsi_requested.rs
@@ -81,7 +81,7 @@ impl ImsiRequestedAnalyzer {
             }
 
             // Expected AttachReject for inactive SIMs
-            (_, State::LikelyValidAttachReject) => {
+            (State::IdentityRequest, State::LikelyValidAttachReject) => {
                 self.flag = Some(Event {
                     event_type: EventType::Low,
                     message: "Identity requested without authentication but its likely a false positive unless your SIM card has an active plan".to_string(),


### PR DESCRIPTION
## Pull Request Checklist

- [x] The Rayhunter team has recently expressed interest in reviewing a PR for this.
  - If not, this PR may be closed due our limited resources and need to prioritize how we spend them.
- [x] Added or updated any documentation as needed to support the changes in this PR.
- [x] Code has been linted and run through `cargo fmt`.
- [x] If any new functionality has been added, unit tests were also added.
- [x] [CONTRIBUTING.md](https://github.com/EFForg/rayhunter/blob/main/CONTRIBUTING.md) has been read.
- [x] Your pull request is fewer than ~400 lines of code.

You must check one of:
- [x] No generative AI (including LLMs) tools were used to create this PR.
- [ ] Generative AI was used to create this PR. I certify that I have read and understand the code, and *that all comments and descriptions were authored by myself* and are not the product of generative AI.

in cooper's code in #1014, we created a low priority event whenever we saw a Attach Reject message with the cause EPSServicesAndNonEPSServicesNotAllowed regardless of the current ImsiRequestedAnalyzer state. see https://github.com/EFForg/rayhunter/blob/ac1be4de0c0ac61bb86018197b1ce1ffc3fd47ec/lib/src/analysis/imsi_requested.rs#L241-L250

i kept this behavior when refactoring, but is this really what we want? i feel like we only want to create an event here when we're transitioning from the IdentityRequest state

this PR makes the change of also checking for that state which reduces the frequency this event is flagged a little bit