### PR TITLE
Include ndjson in ZIP download

### DIFF
--- a/daemon/src/server.rs
+++ b/daemon/src/server.rs
@@ -333,7 +333,7 @@ pub async fn set_time_offset(Json(req): Json<SetTimeOffsetRequest>) -> StatusCod
         ("name" = String, Path, description = "QMDL filename to convert and download")
     ),
     summary = "Download a ZIP file",
-    description = "Stream a ZIP file to the client which contains the QMDL file {name} and a PCAP generated from the same file."
+    description = "Stream a ZIP file to the client which contains the QMDL file {name}, its NDJSON analysis report, its GPS NDJSON file (if present), and a PCAP generated from the QMDL."
 ))]
 pub async fn get_zip(
     State(state): State<Arc<ServerState>>,
@@ -366,14 +366,8 @@ pub async fn get_zip(
         let result: Result<(), Error> = async {
             let mut zip = ZipFileWriter::with_tokio(writer);
 
-            const EXCLUDED_FROM_ZIP: &[FileKind] = &[FileKind::Analysis];
-
             // Add stored files
             for &file_kind in FileKind::ALL {
-                if EXCLUDED_FROM_ZIP.contains(&file_kind) {
-                    continue;
-                }
-
                 let file_opt = {
                     let qmdl_store = qmdl_store_lock.read().await;
                     qmdl_store.open_file(entry_index, file_kind).await?
@@ -668,6 +662,7 @@ mod tests {
             filenames,
             vec![
                 format!("{entry_name}.qmdl"),
+                format!("{entry_name}.ndjson"),
                 format!("{entry_name}-gps.ndjson"),
                 format!("{entry_name}.pcapng"),
             ]


### PR DESCRIPTION
Fix https://github.com/EFForg/rayhunter/issues/1078

That bug was noticed due to a refactor, but in order to preserve
behavior, EXCLUDED_FROM_ZIP was introduced.

## Pull Request Checklist

- [x] The Rayhunter team has recently expressed interest in reviewing a PR for this.
  - If not, this PR may be closed due our limited resources and need to prioritize how we spend them.
- [ ] Added or updated any documentation as needed to support the changes in this PR.
- [x] Code has been linted and run through `cargo fmt`.
- [ ] If any new functionality has been added, unit tests were also added.
- [x] [CONTRIBUTING.md](https://github.com/EFForg/rayhunter/blob/main/CONTRIBUTING.md) has been read.
- [x] Your pull request is fewer than ~400 lines of code.

You must check one of:
- [x] No generative AI (including LLMs) tools were used to create this PR.
- [ ] Generative AI was used to create this PR. I certify that I have read and understand the code, and *that all comments and descriptions were authored by myself* and are not the product of generative AI.

