### PR TITLE
Read the home PLMN from the SIM for the imsi_requested heuristic

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1824,7 +1824,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "cea14ef9355e3beab063703aa9dab15afd25f0667c341310c1e5274bb1d0da18"
 dependencies = [
  "libc",
- "windows-sys 0.52.0",
+ "windows-sys 0.59.0",
 ]
 
 [[package]]
@@ -2975,7 +2975,7 @@ checksum = "e04d7f318608d35d4b61ddd75cbdaee86b023ebe2bd5a66ee0915f0bf93095a9"
 dependencies = [
  "hermit-abi 0.5.1",
  "libc",
- "windows-sys 0.52.0",
+ "windows-sys 0.59.0",
 ]
 
 [[package]]
@@ -3180,9 +3180,9 @@ dependencies = [
 
 [[package]]
 name = "libc"
-version = "0.2.172"
+version = "0.2.189"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d750af042f7ef4f724306de029d18836c26c1765a54a6a3f094cbd23a7267ffa"
+checksum = "3eaf3ede3fee6db1a4c2ee091bf8a8b4dccdc6d17f656fb07896ee72867612f2"
 
 [[package]]
 name = "libdbus-sys"
@@ -3404,6 +3404,19 @@ dependencies = [
 ]
 
 [[package]]
+name = "mio-serial"
+version = "5.0.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6d4ba3f20276f21b7cad3f1b54c97489cf096a3894fd627cc6951cb3abdd4c60"
+dependencies = [
+ "log",
+ "mio",
+ "nix 0.31.3",
+ "serialport",
+ "windows-sys 0.61.2",
+]
+
+[[package]]
 name = "muda"
 version = "0.19.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3456,6 +3469,17 @@ checksum = "650eef8c711430f1a879fdd01d4745a7deea475becfb90269c06775983bbf086"
 
 [[package]]
 name = "nix"
+version = "0.26.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "598beaf3cc6fdd9a5dfb1630c2800c7acd31df7aaf0f565796fba2b53ca1af1b"
+dependencies = [
+ "bitflags 1.3.2",
+ "cfg-if",
+ "libc",
+]
+
+[[package]]
+name = "nix"
 version = "0.29.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "71e2746dc3a24dd78b3cfcb7be93368c6de9963d30f43a6a73998a9cf4b17b46"
@@ -3477,6 +3501,18 @@ dependencies = [
  "cfg_aliases",
  "libc",
  "memoffset",
+]
+
+[[package]]
+name = "nix"
+version = "0.31.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "cf20d2fde8ff38632c426f1165ed7436270b44f199fc55284c38276f9db47c3d"
+dependencies = [
+ "bitflags 2.9.1",
+ "cfg-if",
+ "cfg_aliases",
+ "libc",
 ]
 
 [[package]]
@@ -4602,6 +4638,7 @@ dependencies = [
  "tempfile",
  "thiserror 1.0.69",
  "tokio",
+ "tokio-serial",
  "utoipa",
 ]
 
@@ -4917,7 +4954,7 @@ dependencies = [
  "errno",
  "libc",
  "linux-raw-sys 0.4.15",
- "windows-sys 0.52.0",
+ "windows-sys 0.59.0",
 ]
 
 [[package]]
@@ -4930,7 +4967,7 @@ dependencies = [
  "errno",
  "libc",
  "linux-raw-sys 0.9.4",
- "windows-sys 0.52.0",
+ "windows-sys 0.59.0",
 ]
 
 [[package]]
@@ -5309,6 +5346,24 @@ dependencies = [
  "proc-macro2",
  "quote",
  "syn 2.0.101",
+]
+
+[[package]]
+name = "serialport"
+version = "4.9.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a4d91116f97173694f1642263b2ff837f80d933aa837e2314969f6728f661df3"
+dependencies = [
+ "bitflags 2.9.1",
+ "cfg-if",
+ "core-foundation 0.10.1",
+ "core-foundation-sys",
+ "io-kit-sys",
+ "mach2",
+ "nix 0.26.4",
+ "scopeguard",
+ "unescaper",
+ "windows-sys 0.52.0",
 ]
 
 [[package]]
@@ -5941,7 +5996,7 @@ dependencies = [
  "getrandom 0.3.3",
  "once_cell",
  "rustix 1.0.7",
- "windows-sys 0.52.0",
+ "windows-sys 0.59.0",
 ]
 
 [[package]]
@@ -6134,6 +6189,21 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8e727b36a1a0e8b74c376ac2211e40c2c8af09fb4013c60d910495810f008e9b"
 dependencies = [
  "rustls",
+ "tokio",
+]
+
+[[package]]
+name = "tokio-serial"
+version = "5.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "dd00f5f8b1e01c3e5afccd9e42ed80c2ad2df6d007877f29f8592c62e69cd116"
+dependencies = [
+ "cfg-if",
+ "futures-core",
+ "futures-sink",
+ "log",
+ "mio-serial",
+ "serialport",
  "tokio",
 ]
 
@@ -6409,6 +6479,15 @@ dependencies = [
  "memoffset",
  "tempfile",
  "winapi",
+]
+
+[[package]]
+name = "unescaper"
+version = "0.1.10"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7285e83a80ce76f5e7bce79fa41f68d78ba62d1003cf27bf748ab24413808cf4"
+dependencies = [
+ "thiserror 2.0.12",
 ]
 
 [[package]]
@@ -6881,7 +6960,7 @@ version = "0.1.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "cf221c93e13a30d793f7645a0e7762c55d169dbb0a49671918a2319d289b10bb"
 dependencies = [
- "windows-sys 0.52.0",
+ "windows-sys 0.59.0",
 ]
 
 [[package]]

--- a/check/src/json.rs
+++ b/check/src/json.rs
@@ -56,6 +56,7 @@ impl<T: AsyncWrite + Unpin> IncrementalJsonWriter<T> {
 
 #[cfg(test)]
 mod test {
+    use rayhunter::DeviceMetadata;
     use rayhunter::analysis::analyzer::{
         AnalyzerConfig, Event, EventType, Harness, ReportMetadata,
     };
@@ -87,7 +88,8 @@ mod test {
 
     async fn create_test_writer(path: &str) -> (IncrementalJsonWriter<DuplexStream>, DuplexStream) {
         let (writer, reader) = duplex(1_000_000);
-        let harness = Harness::new_with_config(&AnalyzerConfig::default());
+        let harness =
+            Harness::new_with_config(&AnalyzerConfig::default(), &DeviceMetadata::default());
         (
             IncrementalJsonWriter::new(writer, path, &harness.get_metadata())
                 .await
@@ -109,7 +111,11 @@ mod test {
         let value = parse_json(reader).await;
         let expected = ExpectedJsonLayout {
             path: "test_path".to_string(),
-            metadata: Harness::new_with_config(&AnalyzerConfig::default()).get_metadata(),
+            metadata: Harness::new_with_config(
+                &AnalyzerConfig::default(),
+                &DeviceMetadata::default(),
+            )
+            .get_metadata(),
             reports: vec![],
         };
         assert_eq!(value, expected);

--- a/check/src/main.rs
+++ b/check/src/main.rs
@@ -3,6 +3,7 @@ use clap::Parser;
 use log::{debug, error, info, warn};
 use pcap_file_tokio::pcapng::{Block, PcapNgReader};
 use rayhunter::{
+    DeviceMetadata,
     analysis::analyzer::{AnalysisRow, AnalyzerConfig, Event, EventType, Harness},
     gsmtap::parser as gsmtap_parser,
     pcap::GsmtapPcapWriter,
@@ -110,7 +111,8 @@ async fn analyze_pcap(
     show_skipped: bool,
     json_writer: Option<&mut IncrementalJsonWriter<File>>,
 ) {
-    let mut harness = Harness::new_with_config(&AnalyzerConfig::default());
+    let mut harness =
+        Harness::new_with_config(&AnalyzerConfig::default(), &DeviceMetadata::default());
     let pcap_file = &mut File::open(&pcap_path).await.expect("failed to open file");
     let mut pcap_reader = PcapNgReader::new(pcap_file)
         .await
@@ -140,7 +142,8 @@ async fn analyze_qmdl(
     show_skipped: bool,
     json_writer: Option<&mut IncrementalJsonWriter<File>>,
 ) {
-    let mut harness = Harness::new_with_config(&AnalyzerConfig::default());
+    let mut harness =
+        Harness::new_with_config(&AnalyzerConfig::default(), &DeviceMetadata::default());
     let qmdl_file = &mut File::open(&qmdl_path).await.expect("failed to open file");
     let mut qmdl_reader = QmdlMessageReader::new(qmdl_file)
         .await
@@ -205,7 +208,7 @@ async fn main() {
     };
     rayhunter::init_logging(level);
 
-    let harness = Harness::new_with_config(&AnalyzerConfig::default());
+    let harness = Harness::new_with_config(&AnalyzerConfig::default(), &DeviceMetadata::default());
     let metadata = harness.get_metadata();
     info!("Analyzers:");
     for analyzer in &metadata.analyzers {

--- a/daemon/Cargo.toml
+++ b/daemon/Cargo.toml
@@ -25,7 +25,7 @@ wifi-station = "0.10.1"
 toml = "0.8.8"
 serde = { version = "1.0.193", features = ["derive"] }
 serde_repr = "0.1"
-tokio = { version = "1.44.2", default-features = false, features = ["fs", "signal", "process", "rt"] }
+tokio = { version = "1.44.2", default-features = false, features = ["fs", "signal", "process", "rt", "time"] }
 axum = { version = "0.8", default-features = false, features = ["http1", "tokio", "json"] }
 thiserror = "1.0.52"
 libc = "0.2.150"

--- a/daemon/src/analysis.rs
+++ b/daemon/src/analysis.rs
@@ -7,6 +7,8 @@ use axum::{
     http::StatusCode,
 };
 use log::{error, info};
+use rayhunter::Device;
+use rayhunter::DeviceMetadata;
 use rayhunter::analysis::analyzer::{AnalyzerConfig, EventType, Harness};
 use rayhunter::diag::{DiagParsingError, Message, MessagesContainer};
 use rayhunter::qmdl::QmdlMessageReader;
@@ -32,8 +34,12 @@ pub struct AnalysisWriter {
 // lets us simply append new rows to the end without parsing the entire JSON
 // object beforehand.
 impl AnalysisWriter {
-    pub async fn new(file: File, analyzer_config: &AnalyzerConfig) -> Result<Self, std::io::Error> {
-        let harness = Harness::new_with_config(analyzer_config);
+    pub async fn new(
+        file: File,
+        analyzer_config: &AnalyzerConfig,
+        device_metadata: &DeviceMetadata,
+    ) -> Result<Self, std::io::Error> {
+        let harness = Harness::new_with_config(analyzer_config, device_metadata);
 
         let mut result = Self {
             writer: BufWriter::new(file),
@@ -143,6 +149,7 @@ async fn perform_analysis(
     name: &str,
     qmdl_store_lock: Arc<RwLock<RecordingStore>>,
     analyzer_config: &AnalyzerConfig,
+    device_metadata: &DeviceMetadata,
 ) -> Result<(), String> {
     info!("Opening QMDL and analysis file for {name}...");
     let (analysis_file, mut qmdl_reader) = {
@@ -166,7 +173,7 @@ async fn perform_analysis(
         (analysis_file, qmdl_reader)
     };
 
-    let mut analysis_writer = AnalysisWriter::new(analysis_file, analyzer_config)
+    let mut analysis_writer = AnalysisWriter::new(analysis_file, analyzer_config, device_metadata)
         .await
         .map_err(|e| format!("{e:?}"))?;
 
@@ -197,16 +204,27 @@ pub fn run_analysis_thread(
     qmdl_store_lock: Arc<RwLock<RecordingStore>>,
     analysis_status_lock: Arc<RwLock<AnalysisStatus>>,
     analyzer_config: AnalyzerConfig,
+    device: Device,
+    debug_mode: bool,
 ) {
     task_tracker.spawn(async move {
         loop {
             match analysis_rx.recv().await {
                 Some(AnalysisCtrlMessage::NewFilesQueued) => {
                     let count = queued_len(analysis_status_lock.clone()).await;
+                    let mut device_metadata = DeviceMetadata::default();
+                    if !debug_mode {
+                        device_metadata.home_plmn = rayhunter::sim::home_plmn(&device).await;
+                    }
                     for _ in 0..count {
                         let name = dequeue_to_running(analysis_status_lock.clone()).await;
-                        if let Err(err) =
-                            perform_analysis(&name, qmdl_store_lock.clone(), &analyzer_config).await
+                        if let Err(err) = perform_analysis(
+                            &name,
+                            qmdl_store_lock.clone(),
+                            &analyzer_config,
+                            &device_metadata,
+                        )
+                        .await
                         {
                             error!("failed to analyze {name}: {err}");
                         }

--- a/daemon/src/diag.rs
+++ b/daemon/src/diag.rs
@@ -20,6 +20,7 @@ use tokio::sync::{RwLock, oneshot};
 use tokio_stream::wrappers::LinesStream;
 use tokio_util::task::TaskTracker;
 
+use rayhunter::DeviceMetadata;
 #[cfg(feature = "apidocs")]
 use rayhunter::analysis::analyzer::ReportMetadata;
 use rayhunter::analysis::analyzer::{AnalysisLineNormalizer, AnalyzerConfig, EventType};
@@ -60,6 +61,7 @@ pub struct DiagTask {
     ui_update_sender: Sender<display::DisplayState>,
     analysis_sender: Sender<AnalysisCtrlMessage>,
     analyzer_config: AnalyzerConfig,
+    device: Device,
     notification_channel: tokio::sync::mpsc::Sender<Notification>,
     min_space_to_start_mb: u64,
     min_space_to_continue_mb: u64,
@@ -112,6 +114,7 @@ impl DiagTask {
         ui_update_sender: Sender<display::DisplayState>,
         analysis_sender: Sender<AnalysisCtrlMessage>,
         analyzer_config: AnalyzerConfig,
+        device: Device,
         notification_channel: tokio::sync::mpsc::Sender<Notification>,
         min_space_to_start_mb: u64,
         min_space_to_continue_mb: u64,
@@ -122,6 +125,7 @@ impl DiagTask {
             ui_update_sender,
             analysis_sender,
             analyzer_config,
+            device,
             notification_channel,
             min_space_to_start_mb,
             min_space_to_continue_mb,
@@ -187,9 +191,13 @@ impl DiagTask {
         }
         self.stop_current_recording(qmdl_store).await;
         let qmdl_writer = Box::new(QmdlWriter::new(qmdl_gz_file));
-        let analysis_writer = AnalysisWriter::new(analysis_file, &self.analyzer_config)
-            .await
-            .map_err(RecordingStoreError::WriteFileError)?;
+        let device_metadata = DeviceMetadata {
+            home_plmn: rayhunter::sim::home_plmn(&self.device).await,
+        };
+        let analysis_writer =
+            AnalysisWriter::new(analysis_file, &self.analyzer_config, &device_metadata)
+                .await
+                .map_err(RecordingStoreError::WriteFileError)?;
         self.state = DiagState::Recording {
             qmdl_writer,
             analysis_writer: Box::new(analysis_writer),
@@ -480,6 +488,7 @@ pub fn run_diag_read_thread(
             ui_update_sender,
             analysis_sender,
             analyzer_config,
+            device.clone(),
             notification_channel,
             min_space_to_start_mb,
             min_space_to_continue_mb,

--- a/daemon/src/main.rs
+++ b/daemon/src/main.rs
@@ -281,6 +281,8 @@ async fn run_with_config(
         qmdl_store_lock.clone(),
         analysis_status_lock.clone(),
         config.analyzers.clone(),
+        config.device.clone(),
+        config.debug_mode,
     );
 
     run_shutdown_thread(

--- a/lib/Cargo.toml
+++ b/lib/Cargo.toml
@@ -24,13 +24,18 @@ pcap-file-tokio = "0.1.0"
 pycrate-rs = { git = "https://github.com/EFForg/pycrate-rs" }
 thiserror = "1.0.50"
 telcom-parser = { path = "../telcom-parser" }
-tokio = { version = "1.44.2", default-features = false, features = ["time", "rt", "macros", "fs"] }
+tokio = { version = "1.44.2", default-features = false, features = ["time", "rt", "macros", "fs", "io-util"] }
 futures = { version = "0.3.30", default-features = false }
 serde = { version = "1.0.197", features = ["derive"] }
 serde_json = "1.0"
 num_enum = "0.7.4"
 utoipa = { version = "5.4.0", optional = true }
 async-compression = { version = "0.4.41", features = ["tokio", "gzip"] }
+
+# Only needed by the `sim` module, which is unix-only. Kept out of the default
+# dependency set so that `check` can still target windows.
+[target.'cfg(unix)'.dependencies]
+tokio-serial = { version = "5.5", default-features = false }
 
 [dev-dependencies]
 tempfile = "3"

--- a/lib/src/analysis/analyzer.rs
+++ b/lib/src/analysis/analyzer.rs
@@ -4,6 +4,7 @@ use pcap_file_tokio::pcapng::blocks::enhanced_packet::EnhancedPacketBlock;
 use serde::{Deserialize, Serialize};
 use std::borrow::Cow;
 
+use crate::DeviceMetadata;
 use crate::analysis::diagnostic::DiagnosticAnalyzer;
 use crate::diag::{DiagParsingError, Message, MessagesContainer};
 use crate::gsmtap::{GsmtapHeader, GsmtapMessage, GsmtapType, parser as gsmtap_parser};
@@ -337,11 +338,16 @@ impl Harness {
         }
     }
 
-    pub fn new_with_config(analyzer_config: &AnalyzerConfig) -> Self {
+    pub fn new_with_config(
+        analyzer_config: &AnalyzerConfig,
+        device_metadata: &DeviceMetadata,
+    ) -> Self {
         let mut harness = Harness::new();
 
         if analyzer_config.imsi_requested {
-            harness.add_analyzer(Box::new(ImsiRequestedAnalyzer::new()));
+            harness.add_analyzer(Box::new(ImsiRequestedAnalyzer::new(
+                device_metadata.home_plmn.clone(),
+            )));
         }
         if analyzer_config.connection_redirect_2g_downgrade {
             harness.add_analyzer(Box::new(ConnectionRedirect2GDowngradeAnalyzer {}));

--- a/lib/src/analysis/imsi_requested.rs
+++ b/lib/src/analysis/imsi_requested.rs
@@ -1,4 +1,5 @@
 use std::borrow::Cow;
+use std::collections::BTreeSet;
 
 use pycrate_rs::nas::NASMessage;
 use pycrate_rs::nas::emm::EMMMessage;
@@ -35,18 +36,18 @@ pub struct ImsiRequestedAnalyzer {
     flag: Option<Event>,
     likely_enb_plmns: Vec<String>,
     likely_ue_plmn: Option<String>,
-    /// From the SIM (EF_HPLMNwAcT). `None` means unknown, not a mismatch.
-    home_plmn: Option<String>,
+    /// From the SIM (EF_HPLMNwAcT). Empty means unknown, not a mismatch.
+    home_plmn: BTreeSet<String>,
 }
 
 impl Default for ImsiRequestedAnalyzer {
     fn default() -> Self {
-        Self::new(None)
+        Self::new(BTreeSet::new())
     }
 }
 
 impl ImsiRequestedAnalyzer {
-    pub fn new(home_plmn: Option<String>) -> Self {
+    pub fn new(home_plmn: BTreeSet<String>) -> Self {
         Self {
             state: State::Unattached,
             timeout_counter: 0,
@@ -62,10 +63,13 @@ impl ImsiRequestedAnalyzer {
     fn enb_is_home_network(&self) -> bool {
         // home_plmn and likely_ue_plmn can disagree, so we check both. Incorrectly returning true
         // is safer than Incorrectly returning false, as severity is higher on the home network.
-        [self.likely_ue_plmn.as_ref(), self.home_plmn.as_ref()]
-            .into_iter()
-            .flatten()
-            .any(|plmn| self.likely_enb_plmns.contains(plmn))
+        self.likely_ue_plmn
+            .as_ref()
+            .is_some_and(|p| self.likely_enb_plmns.contains(p))
+            || self
+                .home_plmn
+                .iter()
+                .any(|p| self.likely_enb_plmns.contains(p))
     }
 
     fn transition(&mut self, next_state: State, packet_num: usize) {
@@ -117,7 +121,15 @@ impl ImsiRequestedAnalyzer {
                         &self.likely_enb_plmns.join(", ")
                     };
                     let ue_plmn_string = self.likely_ue_plmn.as_deref().unwrap_or("Unknown");
-                    let home_plmn_string = self.home_plmn.as_deref().unwrap_or("Unknown");
+                    let home_plmn_string = if self.home_plmn.is_empty() {
+                        "Unknown".to_string()
+                    } else {
+                        self.home_plmn
+                            .iter()
+                            .cloned()
+                            .collect::<Vec<_>>()
+                            .join(", ")
+                    };
 
                     self.flag = Some(Event {
                         event_type: EventType::Low,

--- a/lib/src/analysis/imsi_requested.rs
+++ b/lib/src/analysis/imsi_requested.rs
@@ -5,6 +5,7 @@ use pycrate_rs::nas::emm::EMMMessage;
 
 use super::analyzer::{Analyzer, Event, EventType};
 use super::information_element::{InformationElement, LteInformationElement};
+use crate::plmn::{PACKED_BCD_LEN, decode_packed_bcd};
 use log::{debug, error};
 
 use pycrate_rs::nas::generated::emm::emm_attach_reject::EMMCauseEMMCause as AttachRejectEMMCause;
@@ -34,23 +35,37 @@ pub struct ImsiRequestedAnalyzer {
     flag: Option<Event>,
     likely_enb_plmns: Vec<String>,
     likely_ue_plmn: Option<String>,
+    /// From the SIM (EF_HPLMNwAcT). `None` means unknown, not a mismatch.
+    home_plmn: Option<String>,
 }
 
 impl Default for ImsiRequestedAnalyzer {
     fn default() -> Self {
-        Self::new()
+        Self::new(None)
     }
 }
 
 impl ImsiRequestedAnalyzer {
-    pub fn new() -> Self {
+    pub fn new(home_plmn: Option<String>) -> Self {
         Self {
             state: State::Unattached,
             timeout_counter: 0,
             flag: None,
             likely_enb_plmns: vec![],
             likely_ue_plmn: None,
+            home_plmn,
         }
+    }
+
+    /// Whether the tower broadcasts a PLMN this subscriber has a legitimate
+    /// relationship with.
+    fn enb_is_home_network(&self) -> bool {
+        // home_plmn and likely_ue_plmn can disagree, so we check both. Incorrectly returning true
+        // is safer than Incorrectly returning false, as severity is higher on the home network.
+        [self.likely_ue_plmn.as_ref(), self.home_plmn.as_ref()]
+            .into_iter()
+            .flatten()
+            .any(|plmn| self.likely_enb_plmns.contains(plmn))
     }
 
     fn transition(&mut self, next_state: State, packet_num: usize) {
@@ -90,11 +105,7 @@ impl ImsiRequestedAnalyzer {
 
             // IMSI to Disconnect without AuthAccept
             (State::IdentityRequest, State::Disconnect) => {
-                if self
-                    .likely_ue_plmn
-                    .as_ref()
-                    .is_some_and(|p| self.likely_enb_plmns.contains(p))
-                {
+                if self.enb_is_home_network() {
                     self.flag = Some(Event {
                         event_type: EventType::High,
                         message: "Disconnected after Identity Request without Auth Accept on home network!".to_string(),
@@ -106,12 +117,13 @@ impl ImsiRequestedAnalyzer {
                         &self.likely_enb_plmns.join(", ")
                     };
                     let ue_plmn_string = self.likely_ue_plmn.as_deref().unwrap_or("Unknown");
+                    let home_plmn_string = self.home_plmn.as_deref().unwrap_or("Unknown");
 
                     self.flag = Some(Event {
                         event_type: EventType::Low,
                         message: format!(
-                            "Disconnected after Identity Request without Auth Accept, but this could be a false positive roaming issue - Tower PLMN: {}, UE PLMN: {}",
-                            enb_plmn_string, ue_plmn_string,
+                            "Disconnected after Identity Request without Auth Accept, but this could be a false positive roaming issue - Tower PLMN: {}, UE PLMN: {}, SIM home PLMN: {}",
+                            enb_plmn_string, ue_plmn_string, home_plmn_string,
                         ),
                     });
                 }
@@ -174,32 +186,11 @@ impl ImsiRequestedAnalyzer {
 
     fn tai_to_plmn_str(&self, maybe_tai: Option<&TAI>) -> Option<String> {
         let plmn = &maybe_tai?.plmn;
-        if plmn.len() != 3 {
+        if plmn.len() != PACKED_BCD_LEN {
             error!("TAI.plmn vector has unexpected length of {}", plmn.len());
             return None;
         }
-
-        let mcc_digit1 = plmn[0] & 0x0F;
-        let mcc_digit2 = (plmn[0] >> 4) & 0x0F;
-        let mcc_digit3 = plmn[1] & 0x0F;
-
-        let mnc_digit1 = plmn[2] & 0x0F;
-        let mnc_digit2 = (plmn[2] >> 4) & 0x0F;
-        let mnc_digit3 = (plmn[1] >> 4) & 0x0F;
-
-        let mcc = mcc_digit1 as u32 * 100 + mcc_digit2 as u32 * 10 + mcc_digit3 as u32;
-
-        let mcc_str = format!("{:03}", mcc);
-        let mnc_str = if mnc_digit3 == 0xF {
-            format!("{:02}", mnc_digit1 * 10 + mnc_digit2)
-        } else {
-            format!(
-                "{:03}",
-                mnc_digit1 as u32 * 100 + mnc_digit2 as u32 * 10 + mnc_digit3 as u32
-            )
-        };
-
-        Some(format!("{}-{}", mcc_str, mnc_str))
+        decode_packed_bcd(plmn)
     }
 }
 
@@ -215,7 +206,7 @@ impl Analyzer for ImsiRequestedAnalyzer {
     }
 
     fn get_version(&self) -> u32 {
-        4
+        5
     }
 
     fn analyze_information_element(

--- a/lib/src/lib.rs
+++ b/lib/src/lib.rs
@@ -51,9 +51,6 @@ pub enum Device {
 
 /// Facts about the device rayhunter is running on, gathered at runtime and
 /// made available to analyzers.
-///
-/// Every field is optional. `None` means unknown and must never be used to
-/// lower the severity of a finding.
 #[derive(PartialEq, Debug, Clone, Default, Deserialize, Serialize)]
 #[serde(default)]
 #[cfg_attr(feature = "apidocs", derive(utoipa::ToSchema))]

--- a/lib/src/lib.rs
+++ b/lib/src/lib.rs
@@ -1,3 +1,5 @@
+use std::collections::BTreeSet;
+
 use serde::{Deserialize, Serialize};
 
 /// Initialize logging with the given default level, suppressing noisy warnings
@@ -56,7 +58,7 @@ pub enum Device {
 #[serde(default)]
 #[cfg_attr(feature = "apidocs", derive(utoipa::ToSchema))]
 pub struct DeviceMetadata {
-    /// The subscriber's home PLMN as `"MCC-MNC"`, read from EF_HPLMNwAcT
-    /// (`6F62`) on the SIM.
-    pub home_plmn: Option<String>,
+    /// The subscriber's home PLMNs as `"MCC-MNC"`, read from EF_HPLMNwAcT
+    /// (`6F62`) on the SIM. Empty when unknown.
+    pub home_plmn: BTreeSet<String>,
 }

--- a/lib/src/lib.rs
+++ b/lib/src/lib.rs
@@ -18,14 +18,17 @@ pub mod gsmtap;
 pub mod hdlc;
 pub mod log_codes;
 pub mod pcap;
+pub mod plmn;
 pub mod qmdl;
 #[cfg(test)]
 mod test_util;
 pub mod util;
 
-// bin/check.rs may target windows and does not use this mod
+// bin/check.rs may target windows and does not use these mods
 #[cfg(target_family = "unix")]
 pub mod diag_device;
+#[cfg(target_family = "unix")]
+pub mod sim;
 
 // re-export telcom_parser, since we use its types in our API
 pub use telcom_parser;
@@ -42,4 +45,18 @@ pub enum Device {
     Pinephone,
     Uz801,
     Moxee,
+}
+
+/// Facts about the device rayhunter is running on, gathered at runtime and
+/// made available to analyzers.
+///
+/// Every field is optional. `None` means unknown and must never be used to
+/// lower the severity of a finding.
+#[derive(PartialEq, Debug, Clone, Default, Deserialize, Serialize)]
+#[serde(default)]
+#[cfg_attr(feature = "apidocs", derive(utoipa::ToSchema))]
+pub struct DeviceMetadata {
+    /// The subscriber's home PLMN as `"MCC-MNC"`, read from EF_HPLMNwAcT
+    /// (`6F62`) on the SIM.
+    pub home_plmn: Option<String>,
 }

--- a/lib/src/plmn.rs
+++ b/lib/src/plmn.rs
@@ -2,8 +2,7 @@
 //! USIM elementary files (EF_HPLMNwAcT, EF_EHPLMN, EF_FPLMN).
 //!
 //! TS 31.102 §4.2.54 defines the PLMN in EF_HPLMNwAcT as coded "according to
-//! TS 24.008". The nibble order below is easiest to check against pysim's
-//! decoders, permalinked at commit `25e43e1`:
+//! TS 24.008". The nibble order below is easiest to check against pysim's:
 //! <https://github.com/osmocom/pysim/blob/25e43e1540144be9026a2733bc3a4271b8fa7d25/pySim/utils.py#L150-L183>
 //!
 //! ```text

--- a/lib/src/plmn.rs
+++ b/lib/src/plmn.rs
@@ -1,6 +1,11 @@
 //! The "packed BCD" PLMN encoding, used by 3GPP NAS IEs (`TAI`, `LAI`) and by
 //! USIM elementary files (EF_HPLMNwAcT, EF_EHPLMN, EF_FPLMN).
 //!
+//! TS 31.102 §4.2.54 defines the PLMN in EF_HPLMNwAcT as coded "according to
+//! TS 24.008". The nibble order below is easiest to check against pysim's
+//! decoders, permalinked at commit `25e43e1`:
+//! <https://github.com/osmocom/pysim/blob/25e43e1540144be9026a2733bc3a4271b8fa7d25/pySim/utils.py#L150-L183>
+//!
 //! ```text
 //! byte0: [MCC2][MCC1]
 //! byte1: [MNC3][MCC3]     MNC3 == 0xF when the MNC is 2 digits
@@ -19,6 +24,7 @@ pub fn decode_packed_bcd(bytes: &[u8]) -> Option<String> {
     };
 
     // Unused entries in USIM PLMN lists are padded with 0xFF.
+    // <https://github.com/osmocom/pysim/blob/25e43e1540144be9026a2733bc3a4271b8fa7d25/pySim/ts_51_011.py#L868-L869>
     if *b0 == 0xFF && *b1 == 0xFF && *b2 == 0xFF {
         return None;
     }

--- a/lib/src/plmn.rs
+++ b/lib/src/plmn.rs
@@ -1,0 +1,103 @@
+//! The "packed BCD" PLMN encoding, used by 3GPP NAS IEs (`TAI`, `LAI`) and by
+//! USIM elementary files (EF_HPLMNwAcT, EF_EHPLMN, EF_FPLMN).
+//!
+//! ```text
+//! byte0: [MCC2][MCC1]
+//! byte1: [MNC3][MCC3]     MNC3 == 0xF when the MNC is 2 digits
+//! byte2: [MNC2][MNC1]
+//! ```
+
+pub const PACKED_BCD_LEN: usize = 3;
+
+/// Decode a 3-byte packed-BCD PLMN into an `"MCC-MNC"` string.
+///
+/// `None` for a wrong-length slice, an unused (all-`0xFF`) list slot, or a
+/// non-numeric digit.
+pub fn decode_packed_bcd(bytes: &[u8]) -> Option<String> {
+    let [b0, b1, b2] = bytes else {
+        return None;
+    };
+
+    // Unused entries in USIM PLMN lists are padded with 0xFF.
+    if *b0 == 0xFF && *b1 == 0xFF && *b2 == 0xFF {
+        return None;
+    }
+
+    let mcc_digits = [b0 & 0x0F, (b0 >> 4) & 0x0F, b1 & 0x0F];
+    let mnc_digit_3 = (b1 >> 4) & 0x0F;
+    let mnc_digits_1_2 = [b2 & 0x0F, (b2 >> 4) & 0x0F];
+
+    // The MCC is always three digits, none of which may be the filler.
+    if mcc_digits.iter().any(|d| *d > 9) || mnc_digits_1_2.iter().any(|d| *d > 9) {
+        return None;
+    }
+
+    let mut out = String::with_capacity(7);
+    for d in mcc_digits {
+        out.push((b'0' + d) as char);
+    }
+    out.push('-');
+    for d in mnc_digits_1_2 {
+        out.push((b'0' + d) as char);
+    }
+    match mnc_digit_3 {
+        0xF => {}
+        d if d <= 9 => out.push((b'0' + d) as char),
+        _ => return None,
+    }
+
+    Some(out)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn decodes_two_digit_mnc() {
+        assert_eq!(
+            decode_packed_bcd(&[0x32, 0xF2, 0x30]),
+            Some("232-03".to_string())
+        );
+    }
+
+    #[test]
+    fn decodes_three_digit_mnc() {
+        assert_eq!(
+            decode_packed_bcd(&[0x13, 0x00, 0x62]),
+            Some("310-260".to_string())
+        );
+    }
+
+    #[test]
+    fn two_and_three_digit_mncs_are_distinguishable() {
+        let two = decode_packed_bcd(&[0x32, 0xF2, 0x30]).unwrap();
+        let three = decode_packed_bcd(&[0x32, 0x02, 0x30]).unwrap();
+        assert_eq!(two, "232-03");
+        assert_eq!(three, "232-030");
+        assert_ne!(two, three);
+    }
+
+    #[test]
+    fn rejects_unused_padding_entry() {
+        assert_eq!(decode_packed_bcd(&[0xFF, 0xFF, 0xFF]), None);
+    }
+
+    #[test]
+    fn rejects_wrong_length() {
+        assert_eq!(decode_packed_bcd(&[]), None);
+        assert_eq!(decode_packed_bcd(&[0x32, 0xF2]), None);
+        assert_eq!(decode_packed_bcd(&[0x32, 0xF2, 0x30, 0x00]), None);
+    }
+
+    #[test]
+    fn rejects_filler_in_mcc() {
+        assert_eq!(decode_packed_bcd(&[0xF2, 0xF2, 0x30]), None);
+        assert_eq!(decode_packed_bcd(&[0x32, 0xFF, 0x30]), None);
+    }
+
+    #[test]
+    fn rejects_filler_in_first_two_mnc_digits() {
+        assert_eq!(decode_packed_bcd(&[0x32, 0xF2, 0x3F]), None);
+    }
+}

--- a/lib/src/qmdl.rs
+++ b/lib/src/qmdl.rs
@@ -363,7 +363,7 @@ mod test {
         let writer_size = {
             let mut writer = QmdlWriter::new(&mut buf);
             for container in &containers {
-                writer.write_container(&container).await.unwrap();
+                writer.write_container(container).await.unwrap();
             }
             if do_close {
                 writer.close().await.unwrap()

--- a/lib/src/sim/generic_at.rs
+++ b/lib/src/sim/generic_at.rs
@@ -130,8 +130,7 @@ fn decode_hex(s: &str) -> Option<Vec<u8>> {
 fn parse_hplmnwact(payload: &[u8]) -> BTreeSet<String> {
     payload
         .chunks(RECORD_LEN)
-        .filter(|record| record.len() >= PACKED_BCD_LEN)
-        .filter_map(|record| decode_packed_bcd(&record[..PACKED_BCD_LEN]))
+        .filter_map(|record| decode_packed_bcd(record.get(..PACKED_BCD_LEN)?))
         .collect()
 }
 

--- a/lib/src/sim/generic_at.rs
+++ b/lib/src/sim/generic_at.rs
@@ -1,0 +1,222 @@
+use std::time::Duration;
+
+use log::debug;
+use tokio::io::{AsyncReadExt, AsyncWriteExt};
+use tokio_serial::SerialPortBuilderExt;
+
+use crate::plmn::{PACKED_BCD_LEN, decode_packed_bcd};
+use crate::sim::SimError;
+
+/// Ignored by SMD, but required to open the port.
+const BAUD_RATE: u32 = 115_200;
+
+const TIMEOUT: Duration = Duration::from_secs(3);
+
+/// READ BINARY (176) of EF_HPLMNwAcT (28514 = `0x6F62`), 10 bytes.
+const READ_EF_HPLMNWACT: &str = "AT+CRSM=176,28514,0,0,10";
+
+/// 3-byte packed-BCD PLMN plus a 2-byte Access Technology identifier.
+const RECORD_LEN: usize = 5;
+
+pub async fn get_home_plmn(port: &str) -> Result<String, SimError> {
+    let response = send_at_command(port, READ_EF_HPLMNWACT).await?;
+    let (sw1, sw2, payload) = parse_crsm_response(&response)?;
+
+    // 0x9000 is success; 0x91/0x9E/0x9F mean success with extra data available.
+    if !matches!(sw1, 0x90 | 0x91 | 0x9E | 0x9F) {
+        return Err(SimError::AtCommandError(format!(
+            "reading EF_HPLMNwAcT failed with status {sw1},{sw2}"
+        )));
+    }
+
+    parse_hplmnwact(&payload).ok_or_else(|| {
+        SimError::AtCommandError("EF_HPLMNwAcT contained no usable PLMN".to_string())
+    })
+}
+
+/// Send one AT command and read until a terminating status line. Command echo
+/// is left enabled, so parse by line, not by position.
+async fn send_at_command(port: &str, command: &str) -> Result<String, SimError> {
+    let at = async {
+        let mut serial = tokio_serial::new(port, BAUD_RATE)
+            .open_native_async()
+            .map_err(|e| SimError::AtCommandError(format!("couldn't open {port}: {e}")))?;
+
+        serial.write_all(format!("{command}\r").as_bytes()).await?;
+
+        let mut response = String::new();
+        let mut chunk = [0u8; 512];
+        while !is_terminated(&response) {
+            let n = serial.read(&mut chunk).await?;
+            if n == 0 {
+                break;
+            }
+            response.push_str(&String::from_utf8_lossy(&chunk[..n]));
+        }
+        Ok::<_, SimError>(response)
+    };
+
+    let response = tokio::time::timeout(TIMEOUT, at).await.map_err(|_| {
+        SimError::AtCommandError(format!("timed out waiting for a response to {command:?}"))
+    })??;
+
+    debug!("AT command {command:?} -> {response:?}");
+    Ok(response)
+}
+
+/// Whether a response buffer has reached a terminating status line.
+fn is_terminated(response: &str) -> bool {
+    response.lines().map(str::trim).any(|line| {
+        line == "OK"
+            || line == "ERROR"
+            || line.starts_with("+CME ERROR:")
+            || line.starts_with("+CMS ERROR:")
+    })
+}
+
+/// Pull `sw1`, `sw2` and the payload out of a `+CRSM: <sw1>,<sw2>[,"<hex>"]`
+/// line. The payload is absent on failure statuses.
+fn parse_crsm_response(response: &str) -> Result<(u8, u8, Vec<u8>), SimError> {
+    let line = response
+        .lines()
+        .map(str::trim)
+        .find(|line| line.starts_with("+CRSM:"))
+        .ok_or_else(|| {
+            SimError::AtCommandError(format!("no +CRSM line in response {response:?}"))
+        })?;
+
+    let mut fields = line.trim_start_matches("+CRSM:").trim().split(',');
+    let mut next_u8 = |what: &str| -> Result<u8, SimError> {
+        fields
+            .next()
+            .map(str::trim)
+            .and_then(|f| f.parse::<u8>().ok())
+            .ok_or_else(|| SimError::AtCommandError(format!("couldn't parse {what} from {line:?}")))
+    };
+    let sw1 = next_u8("sw1")?;
+    let sw2 = next_u8("sw2")?;
+
+    let payload = match fields.next() {
+        Some(field) => decode_hex(field.trim().trim_matches('"')).ok_or_else(|| {
+            SimError::AtCommandError(format!("couldn't decode hex payload in {line:?}"))
+        })?,
+        None => Vec::new(),
+    };
+
+    Ok((sw1, sw2, payload))
+}
+
+/// Decode a hex string, ignoring any whitespace within it.
+fn decode_hex(s: &str) -> Option<Vec<u8>> {
+    let digits: Vec<u8> = s
+        .bytes()
+        .filter(|b| !b.is_ascii_whitespace())
+        .map(|b| (b as char).to_digit(16).map(|d| d as u8))
+        .collect::<Option<Vec<u8>>>()?;
+
+    if !digits.len().is_multiple_of(2) {
+        return None;
+    }
+    Some(digits.chunks(2).map(|c| (c[0] << 4) | c[1]).collect())
+}
+
+/// Pull the first usable PLMN out of an EF_HPLMNwAcT payload. Further records
+/// are dropped (usually the same PLMN on another access technology).
+fn parse_hplmnwact(payload: &[u8]) -> Option<String> {
+    payload
+        .chunks(RECORD_LEN)
+        .filter(|record| record.len() >= PACKED_BCD_LEN)
+        .find_map(|record| decode_packed_bcd(&record[..PACKED_BCD_LEN]))
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn detects_terminators() {
+        assert!(is_terminated("\r\nOK\r\n"));
+        assert!(is_terminated("\r\nERROR\r\n"));
+        assert!(is_terminated("\r\n+CME ERROR: unknown\r\n"));
+        assert!(!is_terminated("\r\n+CRSM: 144,0,\"32F230"));
+        assert!(!is_terminated(""));
+    }
+
+    #[test]
+    fn parses_successful_crsm_response() {
+        // Real response from a TP-Link M7350.
+        let raw =
+            "AT+CRSM=176,28514,0,0,10\r\n\r\n+CRSM: 144,0,\"32F230400032F2308000\"\r\n\r\nOK\r\n";
+        let (sw1, sw2, payload) = parse_crsm_response(raw).unwrap();
+        assert_eq!((sw1, sw2), (144, 0));
+        assert_eq!(
+            payload,
+            vec![0x32, 0xF2, 0x30, 0x40, 0x00, 0x32, 0xF2, 0x30, 0x80, 0x00]
+        );
+    }
+
+    #[test]
+    fn parses_file_not_found_without_payload() {
+        let (sw1, sw2, payload) = parse_crsm_response("\r\n+CRSM: 106,130\r\n\r\nOK\r\n").unwrap();
+        assert_eq!((sw1, sw2), (106, 130));
+        assert!(payload.is_empty());
+    }
+
+    #[test]
+    fn errors_when_no_crsm_line_present() {
+        assert!(parse_crsm_response("\r\n+CME ERROR: unknown\r\n").is_err());
+    }
+
+    #[test]
+    fn rejects_malformed_hex() {
+        assert_eq!(decode_hex("32F"), None);
+        assert_eq!(decode_hex("32FZ"), None);
+    }
+
+    #[test]
+    fn parses_real_tplink_payload() {
+        // 232-03 on E-UTRAN (0x4000), then the same PLMN on UTRAN (0x8000).
+        let payload = [0x32, 0xF2, 0x30, 0x40, 0x00, 0x32, 0xF2, 0x30, 0x80, 0x00];
+        assert_eq!(parse_hplmnwact(&payload), Some("232-03".to_string()));
+    }
+
+    #[test]
+    fn parses_real_orbic_payload() {
+        // 311-480 (Verizon) on E-UTRAN, then an unused record: covers a
+        // 3-digit MNC and trailing 0xFF padding.
+        let payload = [0x13, 0x01, 0x84, 0x40, 0x00, 0xFF, 0xFF, 0xFF, 0x00, 0x00];
+        assert_eq!(parse_hplmnwact(&payload), Some("311-480".to_string()));
+    }
+
+    #[test]
+    fn parses_real_orbic_response_end_to_end() {
+        let raw = "\r\n+CRSM: 144,0,\"1301844000FFFFFF0000\"\r\n\r\nOK\r\n";
+        let (sw1, _, payload) = parse_crsm_response(raw).unwrap();
+        assert_eq!(sw1, 144);
+        assert_eq!(parse_hplmnwact(&payload), Some("311-480".to_string()));
+    }
+
+    #[test]
+    fn skips_unused_leading_records() {
+        let payload = [0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0x32, 0xF2, 0x30, 0x40, 0x00];
+        assert_eq!(parse_hplmnwact(&payload), Some("232-03".to_string()));
+    }
+
+    #[test]
+    fn handles_three_digit_mnc() {
+        let payload = [0x13, 0x00, 0x62, 0x40, 0x00];
+        assert_eq!(parse_hplmnwact(&payload), Some("310-260".to_string()));
+    }
+
+    #[test]
+    fn returns_none_for_empty_or_padded_file() {
+        assert_eq!(parse_hplmnwact(&[]), None);
+        assert_eq!(parse_hplmnwact(&[0xFF; 10]), None);
+    }
+
+    #[test]
+    fn ignores_trailing_partial_record() {
+        let payload = [0x32, 0xF2, 0x30, 0x40, 0x00, 0xFF, 0xFF];
+        assert_eq!(parse_hplmnwact(&payload), Some("232-03".to_string()));
+    }
+}

--- a/lib/src/sim/generic_at.rs
+++ b/lib/src/sim/generic_at.rs
@@ -1,15 +1,5 @@
 //! Reading the subscriber's home PLMN list off the SIM over a serial AT
 //! command interface.
-//!
-//! On the supported devices the modem exposes a Qualcomm Shared Memory Driver
-//! (SMD) character device that speaks the AT command set. We use it to issue a
-//! single RESTRICTED SIM ACCESS command, which asks the modem to run one APDU
-//! against the (U)SIM on our behalf and hand back the raw response.
-//!
-//! Wire formats are cited inline. pysim permalinks (pinned to commit `25e43e1`)
-//! are preferred where they cover the format, being cheaper to cross-check than
-//! a spec PDF; TS 27.007 is linked directly because pysim doesn't implement
-//! `+CRSM`.
 
 use std::collections::BTreeSet;
 use std::time::Duration;

--- a/lib/src/sim/generic_at.rs
+++ b/lib/src/sim/generic_at.rs
@@ -1,3 +1,4 @@
+use std::collections::BTreeSet;
 use std::time::Duration;
 
 use log::debug;
@@ -18,7 +19,7 @@ const READ_EF_HPLMNWACT: &str = "AT+CRSM=176,28514,0,0,10";
 /// 3-byte packed-BCD PLMN plus a 2-byte Access Technology identifier.
 const RECORD_LEN: usize = 5;
 
-pub async fn get_home_plmn(port: &str) -> Result<String, SimError> {
+pub async fn get_home_plmn(port: &str) -> Result<BTreeSet<String>, SimError> {
     let response = send_at_command(port, READ_EF_HPLMNWACT).await?;
     let (sw1, sw2, payload) = parse_crsm_response(&response)?;
 
@@ -29,9 +30,13 @@ pub async fn get_home_plmn(port: &str) -> Result<String, SimError> {
         )));
     }
 
-    parse_hplmnwact(&payload).ok_or_else(|| {
-        SimError::AtCommandError("EF_HPLMNwAcT contained no usable PLMN".to_string())
-    })
+    let plmns = parse_hplmnwact(&payload);
+    if plmns.is_empty() {
+        return Err(SimError::AtCommandError(
+            "EF_HPLMNwAcT contained no usable PLMN".to_string(),
+        ));
+    }
+    Ok(plmns)
 }
 
 /// Send one AT command and read until a terminating status line. Command echo
@@ -120,18 +125,23 @@ fn decode_hex(s: &str) -> Option<Vec<u8>> {
     Some(digits.chunks(2).map(|c| (c[0] << 4) | c[1]).collect())
 }
 
-/// Pull the first usable PLMN out of an EF_HPLMNwAcT payload. Further records
-/// are dropped (usually the same PLMN on another access technology).
-fn parse_hplmnwact(payload: &[u8]) -> Option<String> {
+/// Pull every usable PLMN out of an EF_HPLMNwAcT payload. Records for the same
+/// PLMN on different access technologies collapse into one set entry.
+fn parse_hplmnwact(payload: &[u8]) -> BTreeSet<String> {
     payload
         .chunks(RECORD_LEN)
         .filter(|record| record.len() >= PACKED_BCD_LEN)
-        .find_map(|record| decode_packed_bcd(&record[..PACKED_BCD_LEN]))
+        .filter_map(|record| decode_packed_bcd(&record[..PACKED_BCD_LEN]))
+        .collect()
 }
 
 #[cfg(test)]
 mod tests {
     use super::*;
+
+    fn set(plmns: &[&str]) -> BTreeSet<String> {
+        plmns.iter().map(|p| p.to_string()).collect()
+    }
 
     #[test]
     fn detects_terminators() {
@@ -177,7 +187,7 @@ mod tests {
     fn parses_real_tplink_payload() {
         // 232-03 on E-UTRAN (0x4000), then the same PLMN on UTRAN (0x8000).
         let payload = [0x32, 0xF2, 0x30, 0x40, 0x00, 0x32, 0xF2, 0x30, 0x80, 0x00];
-        assert_eq!(parse_hplmnwact(&payload), Some("232-03".to_string()));
+        assert_eq!(parse_hplmnwact(&payload), set(&["232-03"]));
     }
 
     #[test]
@@ -185,7 +195,7 @@ mod tests {
         // 311-480 (Verizon) on E-UTRAN, then an unused record: covers a
         // 3-digit MNC and trailing 0xFF padding.
         let payload = [0x13, 0x01, 0x84, 0x40, 0x00, 0xFF, 0xFF, 0xFF, 0x00, 0x00];
-        assert_eq!(parse_hplmnwact(&payload), Some("311-480".to_string()));
+        assert_eq!(parse_hplmnwact(&payload), set(&["311-480"]));
     }
 
     #[test]
@@ -193,30 +203,37 @@ mod tests {
         let raw = "\r\n+CRSM: 144,0,\"1301844000FFFFFF0000\"\r\n\r\nOK\r\n";
         let (sw1, _, payload) = parse_crsm_response(raw).unwrap();
         assert_eq!(sw1, 144);
-        assert_eq!(parse_hplmnwact(&payload), Some("311-480".to_string()));
+        assert_eq!(parse_hplmnwact(&payload), set(&["311-480"]));
     }
 
     #[test]
     fn skips_unused_leading_records() {
         let payload = [0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0x32, 0xF2, 0x30, 0x40, 0x00];
-        assert_eq!(parse_hplmnwact(&payload), Some("232-03".to_string()));
+        assert_eq!(parse_hplmnwact(&payload), set(&["232-03"]));
     }
 
     #[test]
     fn handles_three_digit_mnc() {
         let payload = [0x13, 0x00, 0x62, 0x40, 0x00];
-        assert_eq!(parse_hplmnwact(&payload), Some("310-260".to_string()));
+        assert_eq!(parse_hplmnwact(&payload), set(&["310-260"]));
     }
 
     #[test]
     fn returns_none_for_empty_or_padded_file() {
-        assert_eq!(parse_hplmnwact(&[]), None);
-        assert_eq!(parse_hplmnwact(&[0xFF; 10]), None);
+        assert!(parse_hplmnwact(&[]).is_empty());
+        assert!(parse_hplmnwact(&[0xFF; 10]).is_empty());
     }
 
     #[test]
     fn ignores_trailing_partial_record() {
         let payload = [0x32, 0xF2, 0x30, 0x40, 0x00, 0xFF, 0xFF];
-        assert_eq!(parse_hplmnwact(&payload), Some("232-03".to_string()));
+        assert_eq!(parse_hplmnwact(&payload), set(&["232-03"]));
+    }
+
+    #[test]
+    fn keeps_distinct_plmns() {
+        // 232-03 on E-UTRAN, then 232-07 on UTRAN.
+        let payload = [0x32, 0xF2, 0x30, 0x40, 0x00, 0x32, 0xF2, 0x70, 0x80, 0x00];
+        assert_eq!(parse_hplmnwact(&payload), set(&["232-03", "232-07"]));
     }
 }

--- a/lib/src/sim/generic_at.rs
+++ b/lib/src/sim/generic_at.rs
@@ -20,42 +20,25 @@ const TIMEOUT: Duration = Duration::from_secs(3);
 ///
 /// EF_HPLMNwAcT is the file whose "data field shall contain the HPLMN code, or
 /// codes together with the respected access technology" -- that is, the
-/// operator(s) the card considers to be its own home network. That's exactly
-/// what the `imsi_requested` heuristic needs in order to tell roaming apart from
-/// a serving network that only claims to be home. TS 31.102 §4.2.54 gives
+/// operator(s) the card considers to be its own home network. TS 31.102 §4.2.54 gives
 /// "Identifier: '6F62'", "Structure: Transparent" and "File size: 5n (n >= 1)
-/// bytes"; its clause 5.2 counterpart, "HPLMN selector with Access Technology
-/// request", is the read procedure a normal ME follows, which is what we're
-/// imitating.
+/// bytes".
 ///
 /// Syntax is table 78 of 3GPP TS 27.007 §8.18, p. 138 of
 /// <https://www.etsi.org/deliver/etsi_ts/127000_127099/127007/19.06.00_60/ts_127007v190600p.pdf>:
+///     +CRSM=<command>,<fileid>,<P1>,<P2>,<P3>
+/// where:
+/// * `command` = `176`, or READ BINARY
+/// * `fileid` = `28514`, or `0x6F62`, which is `EFHPLMNwAcT`'s file ID
+/// * `<P1>,<P2>,<P3>` = `0,0,10`, or offset 0, read 10 bytes, i.e. the first two 5-byte records.
 ///
-/// * `176` = READ BINARY, which "reads a string of bytes from the current
-///   transparent EF" (TS 102 221 §11.1.3.1). §8.18 lists the permitted
-///   `<command>` values in decimal; `176` is `0xB0`, its INS byte per table 10.5
-///   of TS 102 221.
-/// * `28514` = `0x6F62`, the `<fileid>`, "identifier of a elementary datafile on
-///   SIM":
-///   <https://github.com/osmocom/pysim/blob/25e43e1540144be9026a2733bc3a4271b8fa7d25/pySim/ts_31_102.py#L1668>
-/// * `0,0,10` are `<P1>,<P2>,<P3>`, "parameters passed on by the MT to the SIM":
-///   offset 0, read 10 bytes, i.e. the first two 5-byte records.
-///
-///   §8.18 defers the coding to TS 51.011, which defers to TS 31.101 §11.1.3,
-///   which defers to ETSI TS 102 221 §11.1.3.2:
+///   If a nonzero offset is needed, refer to TS 102 221 §11.1.3.2:
 ///   <https://www.etsi.org/deliver/etsi_ts/102200_102299/102221/18.03.00_60/ts_102221v180300p.pdf>
-///   There, P2 is "Offset low" and per table 11.10 "b7 to b1 [of P1] is the
-///   offset to the first byte to read" -- so the offset is 15 bits split across
-///   P1 and P2, not a clean two-byte field. Immaterial at offset 0, but worth
-///   knowing before reading further into a file.
 ///
 /// Two records is arbitrary. The file is "5n (n >= 1) bytes" with no upper
 /// bound and we never tried reading more.
 const READ_EF_HPLMNWACT: &str = "AT+CRSM=176,28514,0,0,10";
 
-/// 3-byte PLMN plus 2-byte Access Technology Identifier, i.e. pysim's
-/// `EF_xPLMNwAcT(rec_len=5)`, whose test vectors are the same shape as ours:
-/// <https://github.com/osmocom/pysim/blob/25e43e1540144be9026a2733bc3a4271b8fa7d25/pySim/ts_51_011.py#L859-L865>
 const RECORD_LEN: usize = 5;
 
 pub async fn get_home_plmn(port: &str) -> Result<BTreeSet<String>, SimError> {
@@ -80,19 +63,6 @@ pub async fn get_home_plmn(port: &str) -> Result<BTreeSet<String>, SimError> {
 /// Table 10.7 ("Status byte coding - normal processing") of ETSI TS 102 221
 /// V18.3.0 §10.2.1.1 lists exactly three normal endings, and this matches them:
 /// <https://www.etsi.org/deliver/etsi_ts/102200_102299/102221/18.03.00_60/ts_102221v180300p.pdf>
-///
-/// * `'90' '00'` -- "Normal ending of the command". Note SW2 is `'00'`, not
-///   `'XX'`, so `90` is only a success when paired with zero.
-/// * `'91' 'XX'` -- "Normal ending of the command, with extra information from
-///   the proactive UICC containing a command for the terminal."
-/// * `'92' 'XX'` -- "Normal ending of the command, with extra information
-///   concerning an ongoing data transfer session."
-///
-/// GSM-era `9Exx`/`9Fxx` come from a different table
-/// (<https://github.com/osmocom/pysim/blob/25e43e1540144be9026a2733bc3a4271b8fa7d25/pySim/ts_51_011.py#L1217-L1218>)
-/// and are excluded: they mean the card is holding data for a follow-up GET
-/// RESPONSE, but `+CRSM` returns the payload inline, so accepting them would
-/// parse a payload we never fetched.
 fn is_normal_ending(sw1: u8, sw2: u8) -> bool {
     matches!((sw1, sw2), (0x90, 0x00) | (0x91 | 0x92, _))
 }

--- a/lib/src/sim/generic_at.rs
+++ b/lib/src/sim/generic_at.rs
@@ -1,3 +1,16 @@
+//! Reading the subscriber's home PLMN list off the SIM over a serial AT
+//! command interface.
+//!
+//! On the supported devices the modem exposes a Qualcomm Shared Memory Driver
+//! (SMD) character device that speaks the AT command set. We use it to issue a
+//! single RESTRICTED SIM ACCESS command, which asks the modem to run one APDU
+//! against the (U)SIM on our behalf and hand back the raw response.
+//!
+//! Wire formats are cited inline. pysim permalinks (pinned to commit `25e43e1`)
+//! are preferred where they cover the format, being cheaper to cross-check than
+//! a spec PDF; TS 27.007 is linked directly because pysim doesn't implement
+//! `+CRSM`.
+
 use std::collections::BTreeSet;
 use std::time::Duration;
 
@@ -8,23 +21,58 @@ use tokio_serial::SerialPortBuilderExt;
 use crate::plmn::{PACKED_BCD_LEN, decode_packed_bcd};
 use crate::sim::SimError;
 
-/// Ignored by SMD, but required to open the port.
+/// Required to open the port. Unverified whether SMD honours it at all.
 const BAUD_RATE: u32 = 115_200;
 
 const TIMEOUT: Duration = Duration::from_secs(3);
 
-/// READ BINARY (176) of EF_HPLMNwAcT (28514 = `0x6F62`), 10 bytes.
+/// Ask the modem to read the first two records of EF_HPLMNwAcT off the SIM.
+///
+/// EF_HPLMNwAcT is the file whose "data field shall contain the HPLMN code, or
+/// codes together with the respected access technology" -- that is, the
+/// operator(s) the card considers to be its own home network. That's exactly
+/// what the `imsi_requested` heuristic needs in order to tell roaming apart from
+/// a serving network that only claims to be home. TS 31.102 §4.2.54 gives
+/// "Identifier: '6F62'", "Structure: Transparent" and "File size: 5n (n >= 1)
+/// bytes"; its clause 5.2 counterpart, "HPLMN selector with Access Technology
+/// request", is the read procedure a normal ME follows, which is what we're
+/// imitating.
+///
+/// Syntax is table 78 of 3GPP TS 27.007 §8.18, p. 138 of
+/// <https://www.etsi.org/deliver/etsi_ts/127000_127099/127007/19.06.00_60/ts_127007v190600p.pdf>:
+///
+/// * `176` = READ BINARY, which "reads a string of bytes from the current
+///   transparent EF" (TS 102 221 §11.1.3.1). §8.18 lists the permitted
+///   `<command>` values in decimal; `176` is `0xB0`, its INS byte per table 10.5
+///   of TS 102 221.
+/// * `28514` = `0x6F62`, the `<fileid>`, "identifier of a elementary datafile on
+///   SIM":
+///   <https://github.com/osmocom/pysim/blob/25e43e1540144be9026a2733bc3a4271b8fa7d25/pySim/ts_31_102.py#L1668>
+/// * `0,0,10` are `<P1>,<P2>,<P3>`, "parameters passed on by the MT to the SIM":
+///   offset 0, read 10 bytes, i.e. the first two 5-byte records.
+///
+///   §8.18 defers the coding to TS 51.011, which defers to TS 31.101 §11.1.3,
+///   which defers to ETSI TS 102 221 §11.1.3.2:
+///   <https://www.etsi.org/deliver/etsi_ts/102200_102299/102221/18.03.00_60/ts_102221v180300p.pdf>
+///   There, P2 is "Offset low" and per table 11.10 "b7 to b1 [of P1] is the
+///   offset to the first byte to read" -- so the offset is 15 bits split across
+///   P1 and P2, not a clean two-byte field. Immaterial at offset 0, but worth
+///   knowing before reading further into a file.
+///
+/// Two records is arbitrary. The file is "5n (n >= 1) bytes" with no upper
+/// bound and we never tried reading more.
 const READ_EF_HPLMNWACT: &str = "AT+CRSM=176,28514,0,0,10";
 
-/// 3-byte packed-BCD PLMN plus a 2-byte Access Technology identifier.
+/// 3-byte PLMN plus 2-byte Access Technology Identifier, i.e. pysim's
+/// `EF_xPLMNwAcT(rec_len=5)`, whose test vectors are the same shape as ours:
+/// <https://github.com/osmocom/pysim/blob/25e43e1540144be9026a2733bc3a4271b8fa7d25/pySim/ts_51_011.py#L859-L865>
 const RECORD_LEN: usize = 5;
 
 pub async fn get_home_plmn(port: &str) -> Result<BTreeSet<String>, SimError> {
     let response = send_at_command(port, READ_EF_HPLMNWACT).await?;
     let (sw1, sw2, payload) = parse_crsm_response(&response)?;
 
-    // 0x9000 is success; 0x91/0x9E/0x9F mean success with extra data available.
-    if !matches!(sw1, 0x90 | 0x91 | 0x9E | 0x9F) {
+    if !is_normal_ending(sw1, sw2) {
         return Err(SimError::AtCommandError(format!(
             "reading EF_HPLMNwAcT failed with status {sw1},{sw2}"
         )));
@@ -39,8 +87,32 @@ pub async fn get_home_plmn(port: &str) -> Result<BTreeSet<String>, SimError> {
     Ok(plmns)
 }
 
-/// Send one AT command and read until a terminating status line. Command echo
-/// is left enabled, so parse by line, not by position.
+/// Table 10.7 ("Status byte coding - normal processing") of ETSI TS 102 221
+/// V18.3.0 §10.2.1.1 lists exactly three normal endings, and this matches them:
+/// <https://www.etsi.org/deliver/etsi_ts/102200_102299/102221/18.03.00_60/ts_102221v180300p.pdf>
+///
+/// * `'90' '00'` -- "Normal ending of the command". Note SW2 is `'00'`, not
+///   `'XX'`, so `90` is only a success when paired with zero.
+/// * `'91' 'XX'` -- "Normal ending of the command, with extra information from
+///   the proactive UICC containing a command for the terminal."
+/// * `'92' 'XX'` -- "Normal ending of the command, with extra information
+///   concerning an ongoing data transfer session."
+///
+/// GSM-era `9Exx`/`9Fxx` come from a different table
+/// (<https://github.com/osmocom/pysim/blob/25e43e1540144be9026a2733bc3a4271b8fa7d25/pySim/ts_51_011.py#L1217-L1218>)
+/// and are excluded: they mean the card is holding data for a follow-up GET
+/// RESPONSE, but `+CRSM` returns the payload inline, so accepting them would
+/// parse a payload we never fetched.
+fn is_normal_ending(sw1: u8, sw2: u8) -> bool {
+    matches!((sw1, sw2), (0x90, 0x00) | (0x91 | 0x92, _))
+}
+
+/// Send one AT command and read until a terminating status line.
+///
+/// `\r` terminates the command line. Command echo is left enabled, so parse by
+/// line, not by position. pysim likewise leaves the modem's echo setting alone
+/// and detects it instead:
+/// <https://github.com/osmocom/pysim/blob/25e43e1540144be9026a2733bc3a4271b8fa7d25/pySim/transport/modem_atcmd.py#L108-L124>
 async fn send_at_command(port: &str, command: &str) -> Result<String, SimError> {
     let at = async {
         let mut serial = tokio_serial::new(port, BAUD_RATE)
@@ -69,7 +141,15 @@ async fn send_at_command(port: &str, command: &str) -> Result<String, SimError> 
     Ok(response)
 }
 
-/// Whether a response buffer has reached a terminating status line.
+/// Whether a response buffer has reached a final result code. Same set pysim
+/// terminates on:
+/// <https://github.com/osmocom/pysim/blob/25e43e1540144be9026a2733bc3a4271b8fa7d25/pySim/transport/modem_atcmd.py#L80-L88>
+///
+/// `+CME ERROR: <err>` is "similar to the regular ERROR result code" and is what
+/// `+CRSM` returns "when the command cannot be passed to the SIM" (3GPP TS 27.007
+/// §9.2 and §8.18). `+CMS ERROR:` is the SMS-flavoured equivalent from TS 27.005
+/// and shouldn't turn up here, but firmware is careless about error namespaces
+/// and treating it as terminal beats waiting out the timeout.
 fn is_terminated(response: &str) -> bool {
     response.lines().map(str::trim).any(|line| {
         line == "OK"
@@ -79,8 +159,15 @@ fn is_terminated(response: &str) -> bool {
     })
 }
 
-/// Pull `sw1`, `sw2` and the payload out of a `+CRSM: <sw1>,<sw2>[,"<hex>"]`
-/// line. The payload is absent on failure statuses.
+/// Parse `+CRSM: <sw1>,<sw2>[,<response>]`, per table 78 of 3GPP TS 27.007
+/// §8.18 ("Restricted SIM access +CRSM"), p. 138 of
+/// <https://www.etsi.org/deliver/etsi_ts/127000_127099/127007/19.06.00_60/ts_127007v190600p.pdf>.
+///
+/// `<sw1>`/`<sw2>` are a pair of status codes that have to be checked together,
+/// see [`is_normal_ending`]. They're always present; `<response>` is not, since
+/// it's the "response of a successful completion of the command previously
+/// issued". Both are "integer type", hence decimal parsing even though every
+/// status word table is written in hex (`144,0` is `0x90,0x00`).
 fn parse_crsm_response(response: &str) -> Result<(u8, u8, Vec<u8>), SimError> {
     let line = response
         .lines()
@@ -125,8 +212,18 @@ fn decode_hex(s: &str) -> Option<Vec<u8>> {
     Some(digits.chunks(2).map(|c| (c[0] << 4) | c[1]).collect())
 }
 
-/// Pull every usable PLMN out of an EF_HPLMNwAcT payload. Records for the same
-/// PLMN on different access technologies collapse into one set entry.
+/// Pull every usable PLMN out of an EF_HPLMNwAcT payload: a flat array of
+/// 5-byte records, decoded like pysim's `EF_xPLMNwAcT`, including the all-`0xFF`
+/// skip:
+/// <https://github.com/osmocom/pysim/blob/25e43e1540144be9026a2733bc3a4271b8fa7d25/pySim/ts_51_011.py#L868-L872>
+///
+/// The AcT mask is dropped. Bit 15 is UTRAN, while E-UTRAN is a 3-bit field at
+/// bits 14-12 (`0x7000`):
+/// <https://github.com/osmocom/pysim/blob/25e43e1540144be9026a2733bc3a4271b8fa7d25/pySim/utils.py#L186-L207>
+///
+/// So one operator can appear twice, as `..8000` (UTRAN) and `..4000` (E-UTRAN
+/// WB-S1 + NB-S1); the set collapses those. Trailing partial records are
+/// ignored.
 fn parse_hplmnwact(payload: &[u8]) -> BTreeSet<String> {
     payload
         .chunks(RECORD_LEN)
@@ -149,6 +246,26 @@ mod tests {
         assert!(is_terminated("\r\n+CME ERROR: unknown\r\n"));
         assert!(!is_terminated("\r\n+CRSM: 144,0,\"32F230"));
         assert!(!is_terminated(""));
+    }
+
+    #[test]
+    fn accepts_only_normal_ending_status_words() {
+        // TS 102 221 table 10.7, normal processing.
+        assert!(is_normal_ending(0x90, 0x00));
+        assert!(is_normal_ending(0x91, 0x20));
+        assert!(is_normal_ending(0x92, 0x01));
+
+        // 0x90 is only a success paired with sw2 == 0x00.
+        assert!(!is_normal_ending(0x90, 0x04));
+
+        // GSM-only codes: +CRSM gives us the payload inline, so treating these
+        // as success would mean silently parsing data we never fetched.
+        assert!(!is_normal_ending(0x9E, 0x0A));
+        assert!(!is_normal_ending(0x9F, 0x0A));
+
+        // "File not found" and friends.
+        assert!(!is_normal_ending(0x6A, 0x82));
+        assert!(!is_normal_ending(0x6F, 0x00));
     }
 
     #[test]

--- a/lib/src/sim/mod.rs
+++ b/lib/src/sim/mod.rs
@@ -1,0 +1,39 @@
+use log::{debug, info, warn};
+use thiserror::Error;
+
+use crate::Device;
+
+pub mod generic_at;
+
+#[derive(Error, Debug)]
+pub enum SimError {
+    #[error("Reading the SIM is not supported for this device")]
+    UnsupportedDevice,
+    #[error("AT command error: {0}")]
+    AtCommandError(String),
+    #[error("IO error: {0}")]
+    IoError(#[from] std::io::Error),
+}
+
+/// Read the subscriber's home PLMN from the SIM, as `"MCC-MNC"`.
+pub async fn home_plmn(device: &Device) -> Option<String> {
+    let result = match device {
+        Device::Tplink | Device::Orbic => generic_at::get_home_plmn("/dev/smd7").await,
+        _ => Err(SimError::UnsupportedDevice),
+    };
+
+    match result {
+        Ok(plmn) => {
+            info!("read home PLMN {plmn} from SIM");
+            Some(plmn)
+        }
+        Err(SimError::UnsupportedDevice) => {
+            debug!("reading the home PLMN from the SIM isn't supported for this device");
+            None
+        }
+        Err(e) => {
+            warn!("couldn't read the home PLMN from the SIM: {e}");
+            None
+        }
+    }
+}

--- a/lib/src/sim/mod.rs
+++ b/lib/src/sim/mod.rs
@@ -1,6 +1,6 @@
 use std::collections::BTreeSet;
 
-use log::{debug, info, warn};
+use log::{info, warn};
 use thiserror::Error;
 
 use crate::Device;
@@ -31,7 +31,7 @@ pub async fn home_plmn(device: &Device) -> BTreeSet<String> {
             plmns
         }
         Err(SimError::UnsupportedDevice) => {
-            debug!("reading the home PLMN from the SIM isn't supported for this device");
+            info!("reading the home PLMN from the SIM isn't supported for this device");
             BTreeSet::new()
         }
         Err(e) => {

--- a/lib/src/sim/mod.rs
+++ b/lib/src/sim/mod.rs
@@ -1,3 +1,5 @@
+use std::collections::BTreeSet;
+
 use log::{debug, info, warn};
 use thiserror::Error;
 
@@ -15,25 +17,26 @@ pub enum SimError {
     IoError(#[from] std::io::Error),
 }
 
-/// Read the subscriber's home PLMN from the SIM, as `"MCC-MNC"`.
-pub async fn home_plmn(device: &Device) -> Option<String> {
+/// Read the subscriber's home PLMNs from the SIM, as `"MCC-MNC"`. Empty on any
+/// failure, which callers must treat as "unknown".
+pub async fn home_plmn(device: &Device) -> BTreeSet<String> {
     let result = match device {
         Device::Tplink | Device::Orbic => generic_at::get_home_plmn("/dev/smd7").await,
         _ => Err(SimError::UnsupportedDevice),
     };
 
     match result {
-        Ok(plmn) => {
-            info!("read home PLMN {plmn} from SIM");
-            Some(plmn)
+        Ok(plmns) => {
+            info!("read home PLMNs {plmns:?} from SIM");
+            plmns
         }
         Err(SimError::UnsupportedDevice) => {
             debug!("reading the home PLMN from the SIM isn't supported for this device");
-            None
+            BTreeSet::new()
         }
         Err(e) => {
             warn!("couldn't read the home PLMN from the SIM: {e}");
-            None
+            BTreeSet::new()
         }
     }
 }


### PR DESCRIPTION
As noted in https://github.com/EFForg/rayhunter/pull/1014, the current approach to detecting roaming has some issues. Analyzer state is not persistent, so restarting analysis will wipe the recorded likely_ue_plmn.

We now read EF_HPLMNwAcT ("the list of PLMNs the UE should prefer when selecting its home network") and parse the response. If either this new value or likely_ue_plmn is in likely_enb_plmn, we raise the severity. This should strictly reduce the amount of false-negatives (findings incorrectly marked as low-sev), with potential for new false-positives (incorrectly marked as high-sev)

Other values considered:

* EF_IMSI: Doesn't seem to work correctly with merged operators. A tele.ring SIM (now part of T-Mobile AT) has 232-03 in EF_HPLMNwAcT while the IMSI still says 232-07. 232-03 is what appears in diag logs.

* EF_EHPLMN: Seemed like it would be useful but was empty in TP-Link (on the same tele.ring SIM)

Also tested on orbic with verizon sim card. Even though the device has no signal at all, it returns a plausible PLMN of 311-480. I can't compare that to any captures here though.

DeviceMetadata is intentionally rebuilt every time analysis is restarted, I'd imagine that would help work around any transient hardware bugs.

`generic_at.rs` contains a lot of ugly "LLM"-y code for parsing serial responses, and I'm getting flashbacks to installer code. But it doesn't seem like we'd want to incur another dependency for that.

This PR does not really handle re-analysis, either on the device or using `rayhunter-check`. Especially re-analysis turns to garbage if the SIM card is switched between analyzer runs. I figured that's useful in some situations where we are fixing bugs affecting DeviceMetadata and do need it to be recomputed, but maybe at some point we want to 1) persist DeviceMetadata with recordings 2) give users the option to reset/recreate DeviceMetadata on re-analysis

## Pull Request Checklist

- [x] The Rayhunter team has recently expressed interest in reviewing a PR for this.
  - If not, this PR may be closed due our limited resources and need to prioritize how we spend them.
- [x] Added or updated any documentation as needed to support the changes in this PR.
- [x] Code has been linted and run through `cargo fmt`.
- [x] If any new functionality has been added, unit tests were also added.
- [x] [CONTRIBUTING.md](https://github.com/EFForg/rayhunter/blob/main/CONTRIBUTING.md) has been read.
- [ ] Your pull request is fewer than ~400 lines of code. -- **Close enough?**

You must check one of:
- [ ] No generative AI (including LLMs) tools were used to create this PR.
- [x] Generative AI was used to create this PR. I certify that I have read and understand the code, and *that all comments and descriptions were authored by myself* and are not the product of generative AI.
