### PR TITLE
fix local rayhunter-daemon command

### DIFF
--- a/doc/installing-from-source.md
+++ b/doc/installing-from-source.md
@@ -41,7 +41,7 @@ qmdl_store_path = "./qmdl"
 port = 8080
 debug_mode = true
 EOF
-cargo run --bin rayhunter-daemon -- ./config.toml
+cargo run -p rayhunter-daemon --bin rayhunter-daemon -- ./config.toml
 ```
 
 Open `http://127.0.0.1:8080`.

--- a/doc/installing-from-source.md
+++ b/doc/installing-from-source.md
@@ -41,7 +41,7 @@ qmdl_store_path = "./qmdl"
 port = 8080
 debug_mode = true
 EOF
-cargo run -p rayhunter-daemon -- ./config.toml
+cargo run --bin rayhunter-daemon -- ./config.toml
 ```
 
 Open `http://127.0.0.1:8080`.


### PR DESCRIPTION
when i run `cargo run -p rayhunter-daemon`, i get
```
error: `cargo run` could not determine which binary to run. Use the `--bin` option to specify a binary, or the `default-run` manifest key.
available binaries: gen_api, rayhunter-daemon
```
using `--bin` instead of `-p` fixes that

## Pull Request Checklist

- [ ] The Rayhunter team has recently expressed interest in reviewing a PR for this.
  - If not, this PR may be closed due our limited resources and need to prioritize how we spend them.
- [x] Added or updated any documentation as needed to support the changes in this PR.
- [x] Code has been linted and run through `cargo fmt`.
- [x] If any new functionality has been added, unit tests were also added.
- [x] [CONTRIBUTING.md](https://github.com/EFForg/rayhunter/blob/main/CONTRIBUTING.md) has been read.
- [x] Your pull request is fewer than ~400 lines of code.

You must check one of:
- [x] No generative AI (including LLMs) tools were used to create this PR.
- [ ] Generative AI was used to create this PR. I certify that I have read and understand the code, and *that all comments and descriptions were authored by myself* and are not the product of generative AI.