### PR TITLE
add donation link to gui

### DIFF
--- a/installer-gui/src/routes/+page.svelte
+++ b/installer-gui/src/routes/+page.svelte
@@ -75,6 +75,26 @@
                 />
             </svg>
         </a>
+        <a
+            class="flex flex-row gap-1 group"
+            href="https://eff.org/donate-rayhunter"
+            target="_blank"
+        >
+            <span class="hidden text-white group-hover:text-gray-400 lg:flex">Donate</span>
+            <svg
+                class="w-6 h-6 text-white group-hover:text-gray-400"
+                aria-hidden="true"
+                xmlns="http://www.w3.org/2000/svg"
+                width="24"
+                height="24"
+                fill="currentColor"
+                viewBox="0 0 24 24"
+            >
+                <path
+                    d="m12.75 20.66 6.184-7.098c2.677-2.884 2.559-6.506.754-8.705-.898-1.095-2.206-1.816-3.72-1.855-1.293-.034-2.652.43-3.963 1.537-1.31-1.108-2.67-1.571-3.962-1.537-1.515.04-2.823.76-3.72 1.855-1.806 2.2-1.924 5.821.753 8.705l6.184 7.098.245.281a.75.75 0 0 0 1.09 0l.246-.281Z"
+                />
+            </svg>
+        </a>
     </div>
 </div>
 <form class="flex justify-center pt-5" onsubmit={run_installer}>


### PR DESCRIPTION
i copied the banner in the daemon web UI when initially starting work on the GUI ages ago, but this was before we had a donations link

this PR just copies that over as well using the same [markup from the daemon](https://github.com/EFForg/rayhunter/blob/b934d0c75cbe1e76bdf46f54d5529f49c48d8c07/daemon/web/src/routes/%2Bpage.svelte#L207-L226)

## Pull Request Checklist

- [ ] The Rayhunter team has recently expressed interest in reviewing a PR for this.
  - If not, this PR may be closed due our limited resources and need to prioritize how we spend them.
- [x] Added or updated any documentation as needed to support the changes in this PR.
- [x] Code has been linted and run through `cargo fmt`.
- [ ] If any new functionality has been added, unit tests were also added.
- [x] [CONTRIBUTING.md](https://github.com/EFForg/rayhunter/blob/main/CONTRIBUTING.md) has been read.
- [x] Your pull request is fewer than ~400 lines of code.

You must check one of:
- [x] No generative AI (including LLMs) tools were used to create this PR.
- [ ] Generative AI was used to create this PR. I certify that I have read and understand the code, and *that all comments and descriptions were authored by myself* and are not the product of generative AI.
