### PR TITLE
Add no-NAS analyzer

### DIFF
--- a/daemon/src/analysis.rs
+++ b/daemon/src/analysis.rs
@@ -58,6 +58,19 @@ impl AnalysisWriter {
             }
             max_type = cmp::max(max_type, row.get_max_event_type());
         }
+
+        Ok(max_type)
+    }
+
+    /// Give analyzers a chance to report findings that aren't triggered by a packet.
+    ///
+    /// This needs to happen even when no messages are coming in.
+    pub async fn poll(&mut self) -> Result<EventType, std::io::Error> {
+        let row = self.harness.poll();
+        let max_type = row.get_max_event_type();
+        if !row.is_empty() {
+            self.write(&row).await?;
+        }
         Ok(max_type)
     }
 
@@ -180,6 +193,9 @@ async fn perform_analysis(
             .analyze_message(maybe_message)
             .await
             .map_err(|e| format!("{e:?}"))?;
+
+        // Poll analyzers here as well, as reanalyzing/check doesn't poll analyzers every 30s.
+        analysis_writer.poll().await.map_err(|e| format!("{e:?}"))?;
     }
 
     analysis_writer

--- a/daemon/src/diag.rs
+++ b/daemon/src/diag.rs
@@ -37,6 +37,9 @@ use crate::stats::DiskStats;
 
 const DISK_CHECK_BYTES_INTERVAL: usize = 256 * 1024;
 
+/// How often to give analyzers a chance to report findings on their own.
+const ANALYZER_POLL_INTERVAL: Duration = Duration::from_secs(30);
+
 pub enum DiagDeviceCtrlMessage {
     StopRecording,
     StartRecording {
@@ -423,32 +426,58 @@ impl DiagTask {
                 }
             };
 
-            if max_type > EventType::Informational {
-                info!("a heuristic triggered on this run!");
-                self.notification_channel
-                    .send(Notification::new(
-                        NotificationType::Warning,
-                        format!("Rayhunter has detected a {:?} severity event", max_type),
-                        Some(Duration::from_secs(60 * 5)),
-                    ))
-                    .await
-                    .expect("Failed to send to notification channel");
-            }
-
-            if max_type > self.max_type_seen {
-                self.max_type_seen = max_type;
-                if self.max_type_seen > EventType::Informational {
-                    self.ui_update_sender
-                        .send(display::DisplayState::WarningDetected {
-                            event_type: self.max_type_seen,
-                        })
-                        .await
-                        .expect("couldn't send ui update message: {}");
-                }
-            }
+            self.report_max_event_type(max_type).await;
         } else {
             debug!("no qmdl_writer set, continuing...");
         }
+    }
+
+    /// Notify the user and update the display if analysis turned up anything.
+    async fn report_max_event_type(&mut self, max_type: EventType) {
+        if max_type > EventType::Informational {
+            info!("a heuristic triggered on this run!");
+            self.notification_channel
+                .send(Notification::new(
+                    NotificationType::Warning,
+                    format!("Rayhunter has detected a {:?} severity event", max_type),
+                    Some(Duration::from_secs(60 * 5)),
+                ))
+                .await
+                .expect("Failed to send to notification channel");
+        }
+
+        if max_type > self.max_type_seen {
+            self.max_type_seen = max_type;
+            if self.max_type_seen > EventType::Informational {
+                self.ui_update_sender
+                    .send(display::DisplayState::WarningDetected {
+                        event_type: self.max_type_seen,
+                    })
+                    .await
+                    .expect("couldn't send ui update message: {}");
+            }
+        }
+    }
+
+    /// Give analyzers a chance to report findings that aren't triggered by a packet,
+    /// e.g. ones that alert on the *absence* of some message.
+    async fn poll_analyzers(&mut self) {
+        let DiagState::Recording {
+            analysis_writer, ..
+        } = &mut self.state
+        else {
+            return;
+        };
+
+        let max_type = match analysis_writer.poll().await {
+            Ok(t) => t,
+            Err(e) => {
+                warn!("failed to poll analyzers: {e}");
+                return;
+            }
+        };
+
+        self.report_max_event_type(max_type).await;
     }
 }
 
@@ -490,8 +519,16 @@ pub fn run_diag_read_thread(
             .send(DiagDeviceCtrlMessage::StartRecording { response_tx: None })
             .await
             .unwrap();
+        // Poll analyzers regularly, so that heuristics reporting on the absence of
+        // messages still fire when the modem goes quiet.
+        let mut poll_interval = tokio::time::interval(ANALYZER_POLL_INTERVAL);
+        poll_interval.set_missed_tick_behavior(tokio::time::MissedTickBehavior::Skip);
+
         loop {
             tokio::select! {
+                _ = poll_interval.tick() => {
+                    diag_task.poll_analyzers().await;
+                }
                 msg = qmdl_file_rx.recv() => {
                     match msg {
                         Some(DiagDeviceCtrlMessage::StartRecording { response_tx }) => {

--- a/daemon/web/src/lib/components/ConfigForm.svelte
+++ b/daemon/web/src/lib/components/ConfigForm.svelte
@@ -741,6 +741,18 @@
 
                         <div class="flex items-center">
                             <input
+                                id="no_nas_messages"
+                                type="checkbox"
+                                bind:checked={config.analyzers.no_nas_messages}
+                                class="h-4 w-4 text-rayhunter-blue focus:ring-rayhunter-blue border-gray-300 rounded-sm"
+                            />
+                            <label for="no_nas_messages" class="ml-2 block text-sm text-gray-700">
+                                No NAS Messages Heuristic (experimental)
+                            </label>
+                        </div>
+
+                        <div class="flex items-center">
+                            <input
                                 id="test_analyzer"
                                 type="checkbox"
                                 bind:checked={config.analyzers.test_analyzer}

--- a/daemon/web/src/lib/utils.svelte.ts
+++ b/daemon/web/src/lib/utils.svelte.ts
@@ -11,6 +11,7 @@ export interface AnalyzerConfig {
     incomplete_sib: boolean;
     test_analyzer: boolean;
     diagnostic_analyzer: boolean;
+    no_nas_messages: boolean;
 }
 
 export enum enabled_notifications {

--- a/dist/config.toml.in
+++ b/dist/config.toml.in
@@ -83,3 +83,4 @@ nas_null_cipher = true
 incomplete_sib = true
 test_analyzer = false
 diagnostic_analyzer = true
+no_nas_messages = false

--- a/doc/heuristics.md
+++ b/doc/heuristics.md
@@ -76,6 +76,18 @@ On its own this might just be a misconfigured base station (though we have only 
 ### Diagnostic Information 
 This analyzer displays some diagnostic information about when your device connects and disconnects from certain towers. It is helpful for analysis of suspicious PCAPs. The informational warnings in here can safely be ignored until there is a low, medium, or high severity warning. 
 
+### No NAS Messages
+
+*(disabled by default)*
+
+This analyzer warns once per recording if 5 minutes have passed without a single NAS (*Non-Access Stratum*) message being observed. NAS is the signaling layer between your device and the core network, and a working SIM card will regularly produce NAS traffic (attach, tracking area updates, authentication, etc.).
+
+If Rayhunter never sees any NAS messages, the most likely explanation is that the SIM card isn't working: it may be missing, deactivated, not provisioned for the network, or not seated properly. In that case Rayhunter can still see broadcast messages from nearby towers, but it can't observe the signaling that most of the other heuristics rely on, so the recording is largely useless for detecting IMSI catchers.
+
+This heuristic is experimental. It may false-positive if you are in an area with no coverage at all, or if your device stays idle on a single cell for a long time without needing to talk to the core network.
+
 ### Test Analyzer
+
+*(disabled by default)*
 
 This analyzer is great for testing if your Rayhunter installation works. It will alert every time a new tower is seen (specifically every time a tower broadcasts a SIB1 message.) It is designed to be very noisy so we do not recommend leaving it on but if this alerts it means your Rayhunter device is working! 

--- a/lib/src/analysis/analyzer.rs
+++ b/lib/src/analysis/analyzer.rs
@@ -3,6 +3,7 @@ use log::debug;
 use pcap_file_tokio::pcapng::blocks::enhanced_packet::EnhancedPacketBlock;
 use serde::{Deserialize, Serialize};
 use std::borrow::Cow;
+use std::time::{Duration, Instant};
 
 use crate::analysis::diagnostic::DiagnosticAnalyzer;
 use crate::diag::{DiagParsingError, Message, MessagesContainer};
@@ -13,8 +14,8 @@ use super::{
     connection_redirect_downgrade::ConnectionRedirect2GDowngradeAnalyzer,
     imsi_requested::ImsiRequestedAnalyzer, incomplete_sib::IncompleteSibAnalyzer,
     information_element::InformationElement, nas_null_cipher::NasNullCipherAnalyzer,
-    null_cipher::NullCipherAnalyzer, priority_2g_downgrade::LteSib6And7DowngradeAnalyzer,
-    test_analyzer::TestAnalyzer,
+    no_nas_messages::NoNasMessagesAnalyzer, null_cipher::NullCipherAnalyzer,
+    priority_2g_downgrade::LteSib6And7DowngradeAnalyzer, test_analyzer::TestAnalyzer,
 };
 
 /// A list of booleans which stores information about which analyzers are enabled
@@ -30,6 +31,7 @@ pub struct AnalyzerConfig {
     pub incomplete_sib: bool,
     pub test_analyzer: bool,
     pub imsi_requested: bool,
+    pub no_nas_messages: bool,
 }
 
 impl Default for AnalyzerConfig {
@@ -43,6 +45,7 @@ impl Default for AnalyzerConfig {
             nas_null_cipher: true,
             incomplete_sib: true,
             test_analyzer: false,
+            no_nas_messages: false,
         }
     }
 }
@@ -136,6 +139,16 @@ pub trait Analyzer {
         ie: &InformationElement,
         packet_num: usize,
     ) -> Option<Event>;
+
+    /// The harness calls this method in irregular intervalls to inform the analyzer that some
+    /// amount of time has passed.
+    ///
+    /// `elapsed` is how much time the [Harness] believes has passed since the last
+    /// call. The value is the max delta of either OS time or modem time.
+    fn poll(&mut self, elapsed: Duration) -> Option<Event> {
+        let _ = elapsed;
+        None
+    }
 
     /// Returns a version number for this Analyzer. This should only ever
     /// increase in value, and do so whenever substantial changes are made to
@@ -318,9 +331,69 @@ impl<'de> Deserialize<'de> for AnalysisRow {
     }
 }
 
+/// Estimates how much time has passed between [Harness::poll] calls.
+///
+/// This comes from two sources:
+///
+/// - Packet timestamps
+/// - The device's system clock
+///
+/// We need to use both:
+///
+/// - Packet timestamps are not available when there are no packets (i.e. no reception at all)
+/// - System clock cannot be used during offline analysis (reanalyze, rayhunter-check)
+///
+/// So we just use whichever clock moves fastest.
+///
+/// An alternative design would be to periodically record and persist system time as part of
+/// captures, but this would bloat storage quite a bit.
+struct AnalysisClock {
+    last_tick: Instant,
+    /// Timestamp of the most recent packet we saw, from the modem's clock.
+    latest_packet: Option<DateTime<FixedOffset>>,
+    /// Value of `latest_packet` at the previous tick.
+    last_tick_packet: Option<DateTime<FixedOffset>>,
+}
+
+impl Default for AnalysisClock {
+    fn default() -> Self {
+        Self {
+            last_tick: Instant::now(),
+            latest_packet: None,
+            last_tick_packet: None,
+        }
+    }
+}
+
+impl AnalysisClock {
+    fn observe_packet(&mut self, timestamp: DateTime<FixedOffset>) {
+        // Guard against the modem's clock jumping backwards, e.g. on a counter reset.
+        if self.latest_packet.is_none_or(|latest| timestamp > latest) {
+            self.latest_packet = Some(timestamp);
+        }
+    }
+
+    /// How much time has passed since the last call.
+    fn tick(&mut self) -> Duration {
+        let wall_clock = self.last_tick.elapsed();
+        self.last_tick = Instant::now();
+
+        let packet_clock = self
+            .last_tick_packet
+            .zip(self.latest_packet)
+            .and_then(|(previous, latest)| (latest - previous).to_std().ok())
+            .unwrap_or(Duration::ZERO);
+        self.last_tick_packet = self.latest_packet;
+
+        wall_clock.max(packet_clock)
+    }
+}
+
 pub struct Harness {
     analyzers: Vec<Box<dyn Analyzer + Send>>,
     packet_num: usize,
+    /// Tracks how much time has passed, for [Analyzer::poll].
+    clock: AnalysisClock,
 }
 
 impl Default for Harness {
@@ -334,6 +407,7 @@ impl Harness {
         Self {
             analyzers: Vec::new(),
             packet_num: 0,
+            clock: AnalysisClock::default(),
         }
     }
 
@@ -363,6 +437,10 @@ impl Harness {
 
         if analyzer_config.test_analyzer {
             harness.add_analyzer(Box::new(TestAnalyzer {}))
+        }
+
+        if analyzer_config.no_nas_messages {
+            harness.add_analyzer(Box::new(NoNasMessagesAnalyzer::new()))
         }
 
         if analyzer_config.diagnostic_analyzer {
@@ -430,6 +508,12 @@ impl Harness {
                 return row;
             }
         };
+        // Note the time before parsing: most messages are log types we don't decode,
+        // but they still tell us how much time the recording covers.
+        if let Message::Log { timestamp, .. } = &qmdl_message {
+            self.clock.observe_packet(timestamp.to_datetime());
+        }
+
         let (timestamp, gsmtap_msg) = match gsmtap_parser::parse(qmdl_message) {
             Ok(Some(msg)) => msg,
             Ok(None) => return row,
@@ -478,6 +562,22 @@ impl Harness {
             .collect()
     }
 
+    /// Collect any [Events](Event) the [Analyzers](Analyzer) produced based on time passing,
+    /// without a packet triggering them.
+    ///
+    /// Call this regularly.
+    ///
+    /// Returns an empty row if there's nothing to report, so callers should check
+    /// [AnalysisRow::is_empty] before writing it out.
+    pub fn poll(&mut self) -> AnalysisRow {
+        let elapsed = self.clock.tick();
+        AnalysisRow {
+            packet_timestamp: None,
+            skipped_message_reason: None,
+            events: self.analyzers.iter_mut().map(|a| a.poll(elapsed)).collect(),
+        }
+    }
+
     pub fn get_metadata(&self) -> ReportMetadata {
         let mut analyzers = Vec::new();
         for analyzer in &self.analyzers {
@@ -502,6 +602,52 @@ impl Harness {
 mod tests {
     use super::*;
     use serde_json::json;
+
+    fn packet_time(seconds: i64) -> DateTime<FixedOffset> {
+        DateTime::parse_from_rfc3339("2025-01-01T00:00:00+00:00").unwrap()
+            + chrono::TimeDelta::seconds(seconds)
+    }
+
+    #[test]
+    fn test_clock_uses_packet_timestamps_when_replaying() {
+        let mut clock = AnalysisClock::default();
+        // the first tick has no previous packet to compare against
+        clock.observe_packet(packet_time(0));
+        assert!(clock.tick() < Duration::from_secs(1));
+
+        // replaying an hour of packets in an instant should still report an hour
+        clock.observe_packet(packet_time(3600));
+        assert_eq!(clock.tick(), Duration::from_secs(3600));
+
+        // and no new packets means no packet-clock progress
+        assert!(clock.tick() < Duration::from_secs(1));
+    }
+
+    #[test]
+    fn test_clock_prefers_whichever_source_advanced_more() {
+        let mut clock = AnalysisClock::default();
+        clock.observe_packet(packet_time(0));
+        clock.tick();
+
+        // no packets at all: we fall back to (a very small amount of) wall-clock time
+        let elapsed = clock.tick();
+        assert!(elapsed < Duration::from_secs(1));
+
+        // packets that jump far ahead dominate the tiny wall-clock delta
+        clock.observe_packet(packet_time(600));
+        assert_eq!(clock.tick(), Duration::from_secs(600));
+    }
+
+    #[test]
+    fn test_clock_ignores_backwards_packet_timestamps() {
+        let mut clock = AnalysisClock::default();
+        clock.observe_packet(packet_time(3600));
+        clock.tick();
+
+        // a modem clock reset shouldn't rewind our notion of elapsed time
+        clock.observe_packet(packet_time(0));
+        assert!(clock.tick() < Duration::from_secs(1));
+    }
 
     #[test]
     fn test_analysis_row_deserialize_old_format() {

--- a/lib/src/analysis/mod.rs
+++ b/lib/src/analysis/mod.rs
@@ -5,6 +5,7 @@ pub mod imsi_requested;
 pub mod incomplete_sib;
 pub mod information_element;
 pub mod nas_null_cipher;
+pub mod no_nas_messages;
 pub mod null_cipher;
 pub mod priority_2g_downgrade;
 pub mod test_analyzer;

--- a/lib/src/analysis/no_nas_messages.rs
+++ b/lib/src/analysis/no_nas_messages.rs
@@ -1,0 +1,162 @@
+use std::borrow::Cow;
+use std::time::Duration;
+
+use super::analyzer::{Analyzer, Event, EventType};
+use super::information_element::{InformationElement, LteInformationElement};
+
+const NAS_TIMEOUT: Duration = Duration::from_secs(5 * 60);
+
+/// Warns if no NAS messages have been observed for [NAS_TIMEOUT], which usually
+/// means the SIM card isn't working (or isn't inserted).
+///
+/// Only one warning is emitted per recording.
+#[derive(Default)]
+pub struct NoNasMessagesAnalyzer {
+    /// Time since the last NAS message, or since the start of the recording if we
+    /// haven't seen one yet.
+    since_last_nas: Duration,
+    warned: bool,
+}
+
+impl NoNasMessagesAnalyzer {
+    pub fn new() -> Self {
+        Self::default()
+    }
+}
+
+fn is_nas(ie: &InformationElement) -> bool {
+    match ie {
+        InformationElement::LTE(inner) => matches!(**inner, LteInformationElement::NAS(_)),
+        _ => false,
+    }
+}
+
+impl Analyzer for NoNasMessagesAnalyzer {
+    fn get_name(&self) -> Cow<'_, str> {
+        Cow::from("No NAS Messages")
+    }
+
+    fn get_description(&self) -> Cow<'_, str> {
+        Cow::from(
+            "Warns if no NAS messages have been seen for 5 minutes, which usually means the SIM card is not working and the recording is not usable for detecting IMSI catchers.",
+        )
+    }
+
+    fn get_version(&self) -> u32 {
+        1
+    }
+
+    fn analyze_information_element(
+        &mut self,
+        ie: &InformationElement,
+        _packet_num: usize,
+    ) -> Option<Event> {
+        if is_nas(ie) {
+            self.since_last_nas = Duration::ZERO;
+        }
+        None
+    }
+
+    fn poll(&mut self, elapsed: Duration) -> Option<Event> {
+        if self.warned {
+            return None;
+        }
+        self.since_last_nas += elapsed;
+        if self.since_last_nas < NAS_TIMEOUT {
+            return None;
+        }
+        self.warned = true;
+        Some(Event {
+            event_type: EventType::Low,
+            message: "No NAS messages seen in 5 minutes, SIM possibly not working".to_string(),
+        })
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::gsmtap::{GsmtapHeader, GsmtapMessage, GsmtapType, LteNasSubtype, LteRrcSubtype};
+
+    fn information_element(gsmtap_type: GsmtapType, payload: Vec<u8>) -> InformationElement {
+        InformationElement::try_from(&GsmtapMessage {
+            header: GsmtapHeader::new(gsmtap_type),
+            payload,
+        })
+        .expect("failed to build test information element")
+    }
+
+    /// An EMM Identity Request, i.e. a NAS message.
+    fn nas_information_element() -> InformationElement {
+        let ie = information_element(
+            GsmtapType::LteNas(LteNasSubtype::Plain),
+            vec![0x07, 0x55, 0x01],
+        );
+        assert!(is_nas(&ie));
+        ie
+    }
+
+    /// An LTE RRC UL-CCCH RRCConnectionRequest, i.e. not a NAS message.
+    fn rrc_information_element() -> InformationElement {
+        let ie = information_element(
+            GsmtapType::LteRrc(LteRrcSubtype::UlCcch),
+            vec![0x40, 0x0c, 0x8e, 0xc9, 0x42, 0x89, 0xe0],
+        );
+        assert!(!is_nas(&ie));
+        ie
+    }
+
+    const MINUTE: Duration = Duration::from_secs(60);
+
+    #[test]
+    fn test_warns_once_after_timeout() {
+        let mut analyzer = NoNasMessagesAnalyzer::new();
+
+        for _ in 0..4 {
+            assert!(analyzer.poll(MINUTE).is_none());
+        }
+
+        let event = analyzer.poll(MINUTE).expect("expected a warning");
+        assert_eq!(event.event_type, EventType::Low);
+        assert_eq!(
+            event.message,
+            "No NAS messages seen in 5 minutes, SIM possibly not working"
+        );
+
+        // ...but only once
+        assert!(analyzer.poll(MINUTE).is_none());
+    }
+
+    /// The whole point of polling: we warn even if the modem never produces a single
+    /// message we can decode.
+    #[test]
+    fn test_warns_without_any_packets() {
+        let mut analyzer = NoNasMessagesAnalyzer::new();
+        assert!(analyzer.poll(NAS_TIMEOUT).is_some());
+    }
+
+    #[test]
+    fn test_nas_messages_reset_the_timer() {
+        let mut analyzer = NoNasMessagesAnalyzer::new();
+        let nas = nas_information_element();
+
+        // keep resetting the timer just before it expires
+        for _ in 0..3 {
+            assert!(analyzer.poll(NAS_TIMEOUT - MINUTE).is_none());
+            assert!(analyzer.analyze_information_element(&nas, 1).is_none());
+        }
+
+        // ...but once they stop, we warn
+        assert!(analyzer.poll(NAS_TIMEOUT).is_some());
+    }
+
+    #[test]
+    fn test_non_nas_messages_do_not_reset_the_timer() {
+        let mut analyzer = NoNasMessagesAnalyzer::new();
+        let rrc = rrc_information_element();
+
+        assert!(analyzer.poll(NAS_TIMEOUT - MINUTE).is_none());
+        assert!(analyzer.analyze_information_element(&rrc, 1).is_none());
+        assert!(analyzer.poll(MINUTE).is_some());
+    }
+}


### PR DESCRIPTION
Fix https://github.com/EFForg/rayhunter/issues/882

Add a new heuristic that alerts if there hasn't been any NAS message in the past 5 minutes. The heuristic is disabled by default.

I've tested it:

* on tplink using with and without a SIM. With a SIM it's silent, without a SIM it alerts
* on orbic without a SIM

If there is no SIM-card inserted on TP-Link, I only see GsmRrSignallingMessage, which we appear to skip entirely in log_to_gsmtap. This leads to a situation where the analyzer does not get called at all with any messages, so with the current trait it could never produce an event.

To fix that, I extended the analyzer trait so that analyzers can observe time advancing without there being messages. Analyzers now periodically get their `poll` method called regardless of whether there are new messages to analyze.

Polling an analyzer without relying on traffic from QMDL to drive the clock should also cause this heuristic to alert on cases where `/dev/diag` is just outright broken.

This method could also later be used in `imsi_requested.rs` which currently relies on packet counters as a kind of "clock".

## Pull Request Checklist

- [x] The Rayhunter team has recently expressed interest in reviewing a PR for this.
  - If not, this PR may be closed due our limited resources and need to prioritize how we spend them.
- [x] Added or updated any documentation as needed to support the changes in this PR.
- [x] Code has been linted and run through `cargo fmt`.
- [x] If any new functionality has been added, unit tests were also added.
- [x] [CONTRIBUTING.md](https://github.com/EFForg/rayhunter/blob/main/CONTRIBUTING.md) has been read.
- [ ] Your pull request is fewer than ~400 lines of code. (close enough)

You must check one of:
- [ ] No generative AI (including LLMs) tools were used to create this PR.
- [x] Generative AI was used to create this PR. I certify that I have read and understand the code, and *that all comments and descriptions were authored by myself* and are not the product of generative AI.
