### PR TITLE
Add option to disable or autofix clock drift warnings

### DIFF
--- a/daemon/Cargo.toml
+++ b/daemon/Cargo.toml
@@ -45,7 +45,12 @@ reqwest = { version = "0.12.20", default-features = false, features = ["stream"]
 rustls-rustcrypto = { version = "0.0.2-alpha", optional = true }
 rustls-post-quantum = { version = "0.2.4", optional = true }
 async-trait = "0.1.88"
-utoipa = { version = "5.4.0", optional = true }
+# The "repr" feature makes ToSchema honor #[repr(uN)] on serde_repr enums.
+#
+# Using a feature is a pretty huge footgun, since feature unification can
+# silently change behavior across crates. We should switch to
+# https://github.com/juhaku/utoipa/pull/1539 as soon as it lands.
+utoipa = { version = "5.4.0", features = ["repr"], optional = true }
 url = "2.5.4"
 
 [dev-dependencies]

--- a/daemon/src/config.rs
+++ b/daemon/src/config.rs
@@ -28,6 +28,24 @@ pub enum UiLevel {
     TransFlag = 128,
 }
 
+/// How Rayhunter should keep its clock in sync when it drifts from a known-good
+/// time source. Currently the only source is the browser talking to the web UI;
+/// additional sources (e.g. network/NTP, GPS) may be added later.
+///
+/// Serialized as an integer: 0 = off (never warn or sync), 1 = autosync (silently
+/// correct the drift), 2 = prompt (warn and let the user choose).
+#[repr(u8)]
+#[derive(Debug, Clone, Copy, PartialEq, Serialize_repr, Deserialize_repr)]
+#[cfg_attr(feature = "apidocs", derive(utoipa::ToSchema))]
+pub enum ClockSyncMode {
+    /// Never warn about or correct clock drift.
+    Off = 0,
+    /// Silently sync the device clock to the time source when drift is detected.
+    Autosync = 1,
+    /// Show a warning and let the user choose whether to sync.
+    Prompt = 2,
+}
+
 #[repr(u8)]
 #[derive(Debug, Clone, Copy, PartialEq, Serialize_repr, Deserialize_repr)]
 #[cfg_attr(feature = "apidocs", derive(utoipa::ToSchema))]
@@ -62,6 +80,8 @@ pub struct Config {
     pub enabled_notifications: Vec<NotificationType>,
     /// Whether Rayhunter should periodically check GitHub for new releases
     pub auto_check_updates: bool,
+    /// How Rayhunter should handle its clock drifting from a known-good time source
+    pub clock_sync_mode: ClockSyncMode,
     /// Vector containing the list of enabled analyzers
     pub analyzers: AnalyzerConfig,
     /// Minimum disk space required to start a recording
@@ -137,6 +157,7 @@ impl Default for Config {
             ntfy_url: None,
             enabled_notifications: vec![NotificationType::Warning, NotificationType::LowBattery],
             auto_check_updates: true,
+            clock_sync_mode: ClockSyncMode::Prompt,
             min_space_to_start_recording_mb: 1,
             min_space_to_continue_recording_mb: 1,
             gps_mode: GpsMode::Disabled,

--- a/daemon/web/src/lib/components/ClockDriftAlert.svelte
+++ b/daemon/web/src/lib/components/ClockDriftAlert.svelte
@@ -1,5 +1,5 @@
 <script lang="ts">
-    import { get_daemon_time } from '$lib/utils.svelte';
+    import { get_daemon_time, get_config, set_time_offset, ClockSyncMode } from '$lib/utils.svelte';
     import ApiRequestButton from './ApiRequestButton.svelte';
 
     let show_alert = $state(false);
@@ -21,13 +21,33 @@
         if (check_completed) return;
 
         try {
+            const config = await get_config();
+            if (config.clock_sync_mode === ClockSyncMode.Off) {
+                check_completed = true;
+                return;
+            }
+
             const daemon_time_response = await get_daemon_time();
             const browser_now = new Date();
             const daemon_system_ms = new Date(daemon_time_response.system_time).getTime();
             const device_adjusted_ms = new Date(daemon_time_response.adjusted_time).getTime();
             const drift_seconds = Math.round((browser_now.getTime() - device_adjusted_ms) / 1000);
 
-            if (Math.abs(drift_seconds) > DRIFT_THRESHOLD_SECONDS && !dismissed) {
+            if (Math.abs(drift_seconds) <= DRIFT_THRESHOLD_SECONDS) {
+                check_completed = true;
+                return;
+            }
+
+            if (config.clock_sync_mode === ClockSyncMode.Autosync) {
+                // Offset needed: browser_time - daemon_system_time
+                await set_time_offset(
+                    Math.round((browser_now.getTime() - daemon_system_ms) / 1000)
+                );
+                check_completed = true;
+                return;
+            }
+
+            if (!dismissed) {
                 device_system_time = format_time(new Date(daemon_time_response.system_time));
                 device_adjusted_time = format_time(new Date(daemon_time_response.adjusted_time));
                 browser_time = format_time(browser_now);
@@ -100,7 +120,10 @@
             </tbody>
         </table>
         <p>Copy browser clock to device?</p>
-        <div class="flex flex-row gap-2 justify-end">
+        <div class="flex flex-row flex-wrap gap-2 items-center justify-end">
+            <p class="text-sm text-yellow-700 mr-auto">
+                Rayhunter can sync this automatically with the "Clock Sync" setting in Config.
+            </p>
             <button
                 class="font-medium py-2 px-4 rounded-md border border-gray-400 hover:bg-yellow-200"
                 onclick={dismiss}

--- a/daemon/web/src/lib/components/ConfigForm.svelte
+++ b/daemon/web/src/lib/components/ConfigForm.svelte
@@ -6,6 +6,7 @@
         get_wifi_status,
         scan_wifi_networks,
         GpsMode,
+        ClockSyncMode,
         enabled_notifications,
         type Config,
         type WifiStatus,
@@ -210,6 +211,31 @@
                             Colorblind Mode
                         </label>
                     </div>
+                </div>
+
+                <div>
+                    <label
+                        for="clock_sync_mode"
+                        class="block text-sm font-medium text-gray-700 mb-1"
+                    >
+                        Clock Sync
+                    </label>
+                    <select
+                        id="clock_sync_mode"
+                        bind:value={config.clock_sync_mode}
+                        class="w-full px-3 py-2 border border-gray-300 rounded-md focus:outline-hidden focus:ring-2 focus:ring-rayhunter-blue"
+                    >
+                        <option value={ClockSyncMode.Off}>Off (never warn or sync)</option>
+                        <option value={ClockSyncMode.Autosync}>
+                            Autosync (copy browser clock automatically)
+                        </option>
+                        <option value={ClockSyncMode.Prompt}>Prompt (ask before syncing)</option>
+                    </select>
+                    <p class="text-xs text-gray-500 mt-1">
+                        What to do when Rayhunter's clock drifts from your browser's. The offset
+                        isn't saved across daemon restarts, so autosync re-applies it whenever you
+                        open the web UI.
+                    </p>
                 </div>
 
                 <div class="border-t border-gray-200 pt-4 mt-6 space-y-3">

--- a/daemon/web/src/lib/utils.svelte.ts
+++ b/daemon/web/src/lib/utils.svelte.ts
@@ -46,6 +46,12 @@ export function gps_mode_label(mode: GpsMode | undefined | null): string {
     }
 }
 
+export enum ClockSyncMode {
+    Off = 0,
+    Autosync = 1,
+    Prompt = 2,
+}
+
 export interface Config {
     device: string;
     ui_level: number;
@@ -54,6 +60,7 @@ export interface Config {
     ntfy_url: string | null;
     enabled_notifications: enabled_notifications[];
     auto_check_updates: boolean;
+    clock_sync_mode: ClockSyncMode;
     analyzers: AnalyzerConfig;
     min_space_to_start_recording_mb: number;
     min_space_to_continue_recording_mb: number;
@@ -183,6 +190,10 @@ export interface UpdateStatus {
 
 export async function get_daemon_time(): Promise<TimeResponse> {
     return JSON.parse(await req('GET', '/api/time'));
+}
+
+export async function set_time_offset(offset_seconds: number): Promise<void> {
+    await req('POST', '/api/time-offset', { offset_seconds });
 }
 
 export async function get_update_status(): Promise<UpdateStatus> {

--- a/dist/config.toml.in
+++ b/dist/config.toml.in
@@ -32,6 +32,15 @@ enabled_notifications = ["Warning", "LowBattery"]
 # an update notice in the web UI.
 auto_check_updates = false
 
+# How Rayhunter handles its clock drifting from a known-good time source. Today
+# the only source is the browser talking to the web UI.
+#   0 = off (never warn or sync)
+#   1 = autosync (silently copy the source's clock to the device)
+#   2 = prompt (show a warning and let you choose) [default]
+# Note: the clock offset is kept in memory only and is lost when the daemon
+# restarts, so autosync re-applies it whenever you open the web UI.
+clock_sync_mode = 2
+
 # Disk Space Management
 # Minimum free space (MB) required to start recording
 min_space_to_start_recording_mb = 1

--- a/doc/configuration.md
+++ b/doc/configuration.md
@@ -15,6 +15,12 @@ Through web UI you can set:
   - *Disable button control*: built-in power button of the device is not used by Rayhunter.
   - *Double-tap power button to start new recording*: double clicking on a built-in power button of the device stops and immediately restarts the recording. This could be useful if Rayhunter's heuristics is triggered and you get the red line, and you want to "reset" the past warnings. Normally you can do that through web UI, but sometimes it is easier to double tap on power button.
 - **Colorblind Mode** enables color blind mode (blue line is shown instead of green line, red line remains red). Please note that this does not cover all types of color blindness, but switching green to blue should be about enough to differentiate the color change for most types of color blindness.
+- **Clock Sync** controls what happens when Rayhunter's clock drifts from the clock of the browser you're viewing the web UI with. Some devices have no battery-backed real-time clock, so they lose the time whenever they reboot, and an incorrect clock means incorrect timestamps on your recordings. The modes are:
+  - *Prompt (ask before syncing)*, the default, shows a warning with both clocks and lets you decide whether to copy the browser's time to the device.
+  - *Autosync (copy browser clock automatically)* silently corrects the device clock whenever you open the web UI and the difference is more than 30 seconds. Useful for devices that reset their clock on every reboot.
+  - *Off (never warn or sync)* disables both the warning and any automatic correction.
+
+  Note that the correction is an offset held in memory only: it is **not** written to the device's clock and is lost when the daemon restarts, so with *Autosync* it is re-applied each time you load the web UI.
 - **Automatically check for software updates** enables periodic checks against the Rayhunter GitHub releases page. When a newer release is found, the web UI shows a notice and, if ntfy update notifications are enabled, a notification is sent.
 - **ntfy URL**, which allows setting a [ntfy](https://ntfy.sh/) URL to which notifications of new detections will be sent. The topic should be unique to your device, e.g., `https://ntfy.sh/rayhunter_notifications_ba9di7ie` or `https://myserver.example.com/rayhunter_notifications_ba9di7ie`. The ntfy Android and iOS apps can then be used to receive notifications. More information can be found in the [ntfy docs](https://docs.ntfy.sh/).
 - **Enabled Notification Types** allows enabling or disabling the following types of notifications:


### PR DESCRIPTION
These things can get quite annoying over time, and on some devices the clock resets every reboot.

There are now extra options for automatically fixing clockdrift on pageload (could be confusing) or disabling the feature altogether.

In the future the enum could be extended for alternative clock sources.

Fix https://github.com/EFForg/rayhunter/issues/890

## Pull Request Checklist

- [ ] The Rayhunter team has recently expressed interest in reviewing a PR for this.
  - If not, this PR may be closed due our limited resources and need to prioritize how we spend them.
- [x] Added or updated any documentation as needed to support the changes in this PR.
- [x] Code has been linted and run through `cargo fmt`.
- [ ] If any new functionality has been added, unit tests were also added.
- [x] [CONTRIBUTING.md](https://github.com/EFForg/rayhunter/blob/main/CONTRIBUTING.md) has been read.
- [x] Your pull request is fewer than ~400 lines of code.

You must check one of:
- [ ] No generative AI (including LLMs) tools were used to create this PR.
- [x] Generative AI was used to create this PR. I certify that I have read and understand the code, and *that all comments and descriptions were authored by myself* and are not the product of generative AI.
