### PR TITLE
doc(pinephone): document adb toggle resets and AT interface conflicts

### DIFF
--- a/doc/pinephone.md
+++ b/doc/pinephone.md
@@ -48,6 +48,16 @@ Because the modem does not have its own display or network interface, Rayhunter 
 adb forward tcp:8080 tcp:8080
 ```
 
+The forward belongs to the adb connection to the modem, so it is dropped whenever that connection
+is re-established — for example after the modem resets. When this happens `adb devices` still lists
+the modem and Rayhunter keeps recording, but the web UI stops answering. Re-run the `adb forward`
+command to get it back:
+
+```sh
+adb forward --list          # empty means the forward is gone
+adb forward tcp:8080 tcp:8080
+```
+
 ## Shell access
 Use this command to enable adb access:
 
@@ -61,4 +71,40 @@ The modem won't be able to sleep (power save) with adb enabled, even if Rayhunte
 
 ```sh
 ./installer util pinephone-stop-adb
+```
+
+## Toggling adb resets the modem
+
+Both `pinephone-start-adb` and `pinephone-stop-adb` change the modem's USB composition with
+`AT+QCFG="usbcfg"`, and the modem resets whenever that value is written — even if the requested
+composition is the one already in use. The modem then needs roughly a minute to boot, during which
+the phone has **no cellular service**.
+
+Take this into account when scripting the commands: only enable adb when it is actually absent, and
+give the modem time to come back before trying again. Calling `pinephone-start-adb` in a retry loop
+that is faster than the modem's boot time keeps the modem in a permanent reset cycle. In that state
+ModemManager never completes its QMI probe (`port cdc-wdm0 timed out N consecutive times`, then
+`modem couldn't be initialized: Failed to load current capabilities`), and the phone loses mobile
+data entirely until the modem is left alone long enough to finish booting.
+
+## `Resource busy` when enabling adb
+
+On distributions where ModemManager (or another modem daemon such as `eg25-manager`) manages the
+EG25-G, it claims the AT interface that the installer needs, and enabling adb fails:
+
+```text
+Failed to start adb on the PinePhone's modem
+
+Caused by:
+    0: detach_and_claim_interface({USB_INTERFACE_NUMBER}) failed
+    1: Resource busy (os error 16)
+```
+
+Stop the daemon for the duration of the call and start it again afterwards. The modem resets as a
+result of the usbcfg write anyway, so ModemManager re-probes it when it comes back:
+
+```sh
+sudo systemctl stop ModemManager
+sudo ./installer util pinephone-start-adb
+sudo systemctl start ModemManager
 ```


### PR DESCRIPTION
While installing Rayhunter on a PinePhone (Kali, phosh), I ran into three specific behaviors that are not currently mentioned on the PinePhone page. Each of these required significant debugging time, and one temporarily disabled my mobile data, so I believe they are worth documenting.

I observed all three issues on a PinePhone with an EG25-G running Rayhunter v0.12.0:

1.  The adb forward disappears: The adb forward tcp:8080 tcp:8080 command is tied directly to the modem connection. When that connection re-establishes, the forward drops. Because adb devices still lists the modem and the daemon keeps recording, the web UI stops responding without an error. Re-running the forward command resolves this.
2.  Toggling adb resets the modem: The scripts pinephone-start-adb and pinephone-stop-adb write to AT+QCFG="usbcfg". The EG25-G resets on that write even if it is already using that configuration. The modem takes about a minute to reboot, during which there is no cellular service. Writing a supervisor script that re-runs the start script too frequently will continuously reset the modem, causing ModemManager's QMI probe to time out. Leaving the modem alone to finish its boot cycle allows adb and cellular to coexist normally.
3.  "Resource busy" when enabling adb: On distributions where ModemManager or eg25-manager is running, the manager holds the AT interface, causing the unlock to fail with a "Resource busy (os error 16)" error. Stopping the daemon while making the call resolves this, and the modem re-probes once it is back up.

This update is for documentation only. I have added three short sections to doc/pinephone.md covering the symptoms and the fix for each issue. No code changes were made.

## Pull Request Checklist

- [ ] The Rayhunter team has recently expressed interest in reviewing a PR for this.
- [x] Added or updated any documentation as needed to support the changes in this PR. (This PR *is* the documentation.)
- [x] Code has been linted and run through `cargo fmt`. (No code changed.)
- [x] If any new functionality has been added, unit tests were also added. (No new functionality.)
- [x] [CONTRIBUTING.md](https://github.com/EFForg/rayhunter/blob/main/CONTRIBUTING.md) has been read.
- [x] Your pull request is fewer than ~400 lines of code.

You must check one of:

- [ ] No generative AI (including LLMs) tools were used to create this PR.
- [x] Generative AI was used to create this PR. I certify that I have read and understand the code, and that all comments and descriptions were authored by myself and are not the product of generative AI.