### PR TITLE
installer-gui frontend MVP part 1

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1824,7 +1824,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "cea14ef9355e3beab063703aa9dab15afd25f0667c341310c1e5274bb1d0da18"
 dependencies = [
  "libc",
- "windows-sys 0.52.0",
+ "windows-sys 0.59.0",
 ]
 
 [[package]]
@@ -2919,6 +2919,7 @@ dependencies = [
  "tauri",
  "tauri-build",
  "tauri-plugin-opener",
+ "tauri-plugin-process",
 ]
 
 [[package]]
@@ -2975,7 +2976,7 @@ checksum = "e04d7f318608d35d4b61ddd75cbdaee86b023ebe2bd5a66ee0915f0bf93095a9"
 dependencies = [
  "hermit-abi 0.5.1",
  "libc",
- "windows-sys 0.52.0",
+ "windows-sys 0.59.0",
 ]
 
 [[package]]
@@ -4917,7 +4918,7 @@ dependencies = [
  "errno",
  "libc",
  "linux-raw-sys 0.4.15",
- "windows-sys 0.52.0",
+ "windows-sys 0.59.0",
 ]
 
 [[package]]
@@ -4930,7 +4931,7 @@ dependencies = [
  "errno",
  "libc",
  "linux-raw-sys 0.9.4",
- "windows-sys 0.52.0",
+ "windows-sys 0.59.0",
 ]
 
 [[package]]
@@ -5820,6 +5821,16 @@ dependencies = [
 ]
 
 [[package]]
+name = "tauri-plugin-process"
+version = "2.3.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d55511a7bf6cd70c8767b02c97bf8134fa434daf3926cfc1be0a0f94132d165a"
+dependencies = [
+ "tauri",
+ "tauri-plugin",
+]
+
+[[package]]
 name = "tauri-runtime"
 version = "2.11.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -5941,7 +5952,7 @@ dependencies = [
  "getrandom 0.3.3",
  "once_cell",
  "rustix 1.0.7",
- "windows-sys 0.52.0",
+ "windows-sys 0.59.0",
 ]
 
 [[package]]
@@ -6881,7 +6892,7 @@ version = "0.1.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "cf221c93e13a30d793f7645a0e7762c55d169dbb0a49671918a2319d289b10bb"
 dependencies = [
- "windows-sys 0.52.0",
+ "windows-sys 0.59.0",
 ]
 
 [[package]]

--- a/installer-gui/.prettierignore
+++ b/installer-gui/.prettierignore
@@ -1,1 +1,2 @@
 package-lock.json
+src-tauri/gen/schemas

--- a/installer-gui/eslint.config.js
+++ b/installer-gui/eslint.config.js
@@ -22,7 +22,7 @@ export default ts.config(
         },
     },
     {
-        files: ['**/*.svelte'],
+        files: ['**/*.svelte', '**/*.svelte.ts'],
 
         languageOptions: {
             parserOptions: {
@@ -37,6 +37,17 @@ export default ts.config(
                 { argsIgnorePattern: '^_', varsIgnorePattern: '^_' },
             ],
             '@typescript-eslint/no-explicit-any': 'off',
+            '@typescript-eslint/naming-convention': [
+                'error',
+                {
+                    selector: 'function',
+                    format: ['snake_case'],
+                },
+                {
+                    selector: 'method',
+                    format: ['snake_case'],
+                },
+            ],
         },
     }
 );

--- a/installer-gui/package-lock.json
+++ b/installer-gui/package-lock.json
@@ -11,6 +11,7 @@
                 "@tailwindcss/vite": "^4.2.2",
                 "@tauri-apps/api": "^2",
                 "@tauri-apps/plugin-opener": "^2",
+                "@tauri-apps/plugin-process": "^2.3.1",
                 "tailwindcss": "^4.1.16"
             },
             "devDependencies": {
@@ -1226,6 +1227,15 @@
             "license": "MIT OR Apache-2.0",
             "dependencies": {
                 "@tauri-apps/api": "^2.11.0"
+            }
+        },
+        "node_modules/@tauri-apps/plugin-process": {
+            "version": "2.3.1",
+            "resolved": "https://registry.npmjs.org/@tauri-apps/plugin-process/-/plugin-process-2.3.1.tgz",
+            "integrity": "sha512-nCa4fGVaDL/B9ai03VyPOjfAHRHSBz5v6F/ObsB73r/dA3MHHhZtldaDMIc0V/pnUw9ehzr2iEG+XkSEyC0JJA==",
+            "license": "MIT OR Apache-2.0",
+            "dependencies": {
+                "@tauri-apps/api": "^2.8.0"
             }
         },
         "node_modules/@tybys/wasm-util": {

--- a/installer-gui/package.json
+++ b/installer-gui/package.json
@@ -19,6 +19,7 @@
         "@tailwindcss/vite": "^4.2.2",
         "@tauri-apps/api": "^2",
         "@tauri-apps/plugin-opener": "^2",
+        "@tauri-apps/plugin-process": "^2.3.1",
         "tailwindcss": "^4.1.16"
     },
     "devDependencies": {

--- a/installer-gui/src-tauri/Cargo.toml
+++ b/installer-gui/src-tauri/Cargo.toml
@@ -25,3 +25,4 @@ anyhow = "1.0.100"
 shlex = "1"
 installer = { path = "../../installer" }
 log = "0.4.20"
+tauri-plugin-process = "2"

--- a/installer-gui/src-tauri/Cargo.toml
+++ b/installer-gui/src-tauri/Cargo.toml
@@ -16,13 +16,13 @@ crate-type = ["staticlib", "cdylib", "rlib"]
 tauri-build = { version = "2", features = [] }
 
 [dependencies]
-clap = { version = "4.5.37" }
-tauri = { version = "2", features = [] }
-tauri-plugin-opener = "2"
-serde = { version = "1", features = ["derive"] }
-serde_json = "1"
 anyhow = "1.0.100"
-shlex = "1"
+clap = { version = "4.5.37" }
 installer = { path = "../../installer" }
 log = "0.4.20"
+serde = { version = "1", features = ["derive"] }
+serde_json = "1"
+shlex = "1"
+tauri = { version = "2", features = [] }
+tauri-plugin-opener = "2"
 tauri-plugin-process = "2"

--- a/installer-gui/src-tauri/capabilities/default.json
+++ b/installer-gui/src-tauri/capabilities/default.json
@@ -3,5 +3,5 @@
     "identifier": "default",
     "description": "Capability for the main window",
     "windows": ["main"],
-    "permissions": ["core:default", "opener:default"]
+    "permissions": ["core:default", "opener:default", "process:default"]
 }

--- a/installer-gui/src-tauri/src/lib.rs
+++ b/installer-gui/src-tauri/src/lib.rs
@@ -41,6 +41,7 @@ fn rayhunter_options() -> introspect::Command<'static> {
 #[cfg_attr(mobile, tauri::mobile_entry_point)]
 pub fn run() {
     tauri::Builder::default()
+        .plugin(tauri_plugin_process::init())
         .plugin(tauri_plugin_opener::init())
         .invoke_handler(tauri::generate_handler![install_rayhunter])
         .invoke_handler(tauri::generate_handler![rayhunter_options])

--- a/installer-gui/src-tauri/src/lib.rs
+++ b/installer-gui/src-tauri/src/lib.rs
@@ -43,8 +43,10 @@ pub fn run() {
     tauri::Builder::default()
         .plugin(tauri_plugin_process::init())
         .plugin(tauri_plugin_opener::init())
-        .invoke_handler(tauri::generate_handler![install_rayhunter])
-        .invoke_handler(tauri::generate_handler![rayhunter_options])
+        .invoke_handler(tauri::generate_handler![
+            install_rayhunter,
+            rayhunter_options
+        ])
         .run(tauri::generate_context!())
         .expect("error while running tauri application");
 }

--- a/installer-gui/src/app.css
+++ b/installer-gui/src/app.css
@@ -5,3 +5,9 @@
     --color-rayhunter-dark-blue: #3f3da0;
     --color-rayhunter-green: #94ea18;
 }
+
+@layer components {
+    .rayhunter-button {
+        @apply px-6 py-2 rounded-lg shadow-md;
+    }
+}

--- a/installer-gui/src/lib/InstallProgress.svelte
+++ b/installer-gui/src/lib/InstallProgress.svelte
@@ -1,0 +1,97 @@
+<script lang="ts">
+    import { onDestroy, tick } from 'svelte';
+    import { invoke } from '@tauri-apps/api/core';
+    import { emit, listen } from '@tauri-apps/api/event';
+    import { exit } from '@tauri-apps/plugin-process';
+
+    import StylizedButton from '$lib/StylizedButton.svelte';
+
+    type InstallerState = 'Running' | 'Succeeded' | 'Failed';
+
+    let {
+        installerArgs,
+        reselect_args,
+    }: {
+        installerArgs: string;
+        reselect_args: () => void;
+    } = $props();
+
+    let currentState: InstallerState = $state('Running');
+    let installerOutput = $state('');
+    let outputDiv: HTMLDivElement | undefined;
+
+    const listenPromise = listen<string>('installer-output', (event) => {
+        // The number in the comparison specifies the number of pixels the
+        // scrollbar needs to be from the bottom to autoscroll as new text is
+        // added. The current value was chosen somewhat arbitrarily.
+        const autoscroll =
+            outputDiv && outputDiv.scrollHeight - outputDiv.scrollTop - outputDiv.clientHeight < 25;
+
+        installerOutput += event.payload;
+
+        if (autoscroll) {
+            tick().then(() => {
+                if (outputDiv) {
+                    outputDiv.scrollTop = outputDiv.scrollHeight;
+                }
+            });
+        }
+    });
+
+    onDestroy(async () => {
+        const unlisten = await listenPromise;
+        unlisten();
+    });
+
+    async function run_installer() {
+        // We await to ensure the listener is set up before continuing.
+        await listenPromise;
+
+        try {
+            await invoke('install_rayhunter', { args: installerArgs });
+            currentState = 'Succeeded';
+        } catch (error) {
+            // Just to be safe and ensure correct output order, we use emit
+            // rather than modifying installerOutput directly.
+            emit('installer-output', error);
+            currentState = 'Failed';
+        }
+    }
+
+    run_installer();
+</script>
+
+<div class="mx-8">
+    <h1 class="font-semibold mb-4 text-center text-2xl">
+        {#if currentState === 'Running'}
+            Installing Rayhunter
+        {:else if currentState === 'Succeeded'}
+            Installation succeeded!
+        {:else}
+            Installation failed!
+        {/if}
+    </h1>
+    <div
+        bind:this={outputDiv}
+        class="bg-gray-800 max-h-[60vh] 2xl:max-h-[70vh] overflow-y-auto p-4 rounded-xl text-gray-200 whitespace-pre-line"
+    >
+        {installerOutput}
+    </div>
+    {#if currentState !== 'Running'}
+        <div class="flex justify-evenly mt-6">
+            {#if currentState === 'Succeeded'}
+                <StylizedButton label="Install another device" onclick={reselect_args} />
+                <StylizedButton color="blue" label="Exit" onclick={() => exit(0)} />
+            {:else}
+                <StylizedButton color="blue" label="Retry" onclick={reselect_args} />
+                <a
+                    class="rayhunter-button"
+                    href="https://github.com/EFForg/rayhunter/issues"
+                    target="_blank"
+                >
+                    Report Issue
+                </a>
+            {/if}
+        </div>
+    {/if}
+</div>

--- a/installer-gui/src/lib/StylizedButton.svelte
+++ b/installer-gui/src/lib/StylizedButton.svelte
@@ -1,0 +1,23 @@
+<script lang="ts">
+    let {
+        color = 'white',
+        disabled = false,
+        label,
+        onclick,
+    }: {
+        color?: 'blue' | 'white';
+        disabled?: boolean;
+        label: string;
+        onclick: () => void;
+    } = $props();
+</script>
+
+<button
+    class="
+        {color === 'blue' ? 'bg-rayhunter-blue text-white' : ''}
+        {disabled ? '' : 'cursor-pointer'} rayhunter-button"
+    {disabled}
+    {onclick}
+>
+    {label}
+</button>

--- a/installer-gui/src/routes/+page.svelte
+++ b/installer-gui/src/routes/+page.svelte
@@ -16,7 +16,9 @@
     }
 </script>
 
-<div class="mb-4 p-4 xl:px-8 bg-rayhunter-blue drop-shadow flex flex-row justify-between items-center">
+<div
+    class="mb-4 p-4 xl:px-8 bg-rayhunter-blue drop-shadow flex flex-row justify-between items-center"
+>
     <!-- https://www.w3.org/WAI/tutorials/images/decorative/ -->
     <img src="/rayhunter_text.png" alt="" class="h-10 xl:h-12" />
     <div class="flex flex-row gap-4">

--- a/installer-gui/src/routes/+page.svelte
+++ b/installer-gui/src/routes/+page.svelte
@@ -1,31 +1,22 @@
 <script lang="ts">
-    import { invoke } from '@tauri-apps/api/core';
-    import { listen } from '@tauri-apps/api/event';
+    import InstallProgress from '$lib/InstallProgress.svelte';
+    import StylizedButton from '$lib/StylizedButton.svelte';
 
-    let buttonEnabled = $state(true);
+    type GUIScreen = 'ArgSelection' | 'Installation';
+
+    let currentScreen: GUIScreen = $state('ArgSelection');
     let installerArgs = $state('');
-    let installerOutput = $state('');
 
-    listen<string>('installer-output', (event) => {
-        installerOutput += event.payload;
-    });
+    function reselect_args() {
+        currentScreen = 'ArgSelection';
+    }
 
-    async function run_installer(event: Event) {
-        event.preventDefault();
-        buttonEnabled = false;
-        installerOutput = '';
-        try {
-            await invoke('install_rayhunter', { args: installerArgs });
-        } catch (error) {
-            installerOutput +=
-                'Rayhunter GUI installer encountered an internal error. Error was:\n';
-            installerOutput += error;
-        }
-        buttonEnabled = true;
+    function submit_args() {
+        currentScreen = 'Installation';
     }
 </script>
 
-<div class="p-4 xl:px-8 bg-rayhunter-blue drop-shadow flex flex-row justify-between items-center">
+<div class="mb-4 p-4 xl:px-8 bg-rayhunter-blue drop-shadow flex flex-row justify-between items-center">
     <!-- https://www.w3.org/WAI/tutorials/images/decorative/ -->
     <img src="/rayhunter_text.png" alt="" class="h-10 xl:h-12" />
     <div class="flex flex-row gap-4">
@@ -97,22 +88,18 @@
         </a>
     </div>
 </div>
-<form class="flex justify-center pt-5" onsubmit={run_installer}>
-    <input
-        class="mr-1 px-5 py-2 rounded-lg shadow-md"
-        placeholder="Enter CLI installer args..."
-        autocapitalize="off"
-        autocorrect="off"
-        spellcheck="false"
-        bind:value={installerArgs}
-    />
-    <button
-        class="{buttonEnabled ? 'cursor-pointer' : ''} px-5 py-2 rounded-lg shadow-md"
-        disabled={!buttonEnabled}
-        type="submit">Run</button
-    >
-</form>
-<p class="p-4">Installer output:</p>
-<p class="bg-gray-100 px-5 py-2 rounded-lg shadow-md whitespace-pre-line">
-    {installerOutput}
-</p>
+{#if currentScreen === 'ArgSelection'}
+    <div class="flex justify-center pt-5">
+        <input
+            class="mr-1 px-5 py-2 rounded-lg shadow-md"
+            placeholder="Enter CLI installer args..."
+            autocapitalize="off"
+            autocorrect="off"
+            spellcheck="false"
+            bind:value={installerArgs}
+        />
+        <StylizedButton label="Run" onclick={submit_args} />
+    </div>
+{:else}
+    <InstallProgress {installerArgs} {reselect_args} />
+{/if}

--- a/installer/src/lib.rs
+++ b/installer/src/lib.rs
@@ -276,8 +276,6 @@ struct Serial {
 }
 
 async fn run(args: Args) -> Result<(), Error> {
-    env_logger::Builder::from_env(Env::default().default_filter_or("off")).init();
-
     match args.command {
         Command::Tmobile(args) => tmobile::install(args).await.context("Failed to install rayhunter on the Tmobile TMOHS1. Make sure your computer is connected to the hotspot using USB tethering or WiFi.")?,
         #[cfg(not(target_os = "android"))]
@@ -398,6 +396,8 @@ pub fn version() -> &'static str {
 /// This function is public so the binary can call it, library users should use `run_with_callback`
 /// instead.
 pub async fn main_cli() -> Result<(), Error> {
+    env_logger::Builder::from_env(Env::default().default_filter_or("off")).init();
+
     let args = Args::parse();
     run(args).await
 }


### PR DESCRIPTION
this PR is part 1 of 2 of adding a real frontend to installer-gui

it's pretty minimal and there's a lot more we could/should do in the long term to make it more user friendly, but my hope is this will serve as a reasonable starting point for us. the design here is based loosely on beigebox's penpot mockup

the main thing this PR does is moves the active installation window that displays the CLI installer's output to a separate screen and fleshes it out a bit. the initial screen is still ugly as hell, but i plan to completely redo it in my second PR. my hope is i've split things up in a way that any reviewer doesn't need to look ahead to that work much, but it can be found [here](https://github.com/bmw/rayhunter/compare/installer-gui-frontend-part1...bmw:rayhunter:installer-gui-frontend-part2) as needed/desired

## Pull Request Checklist

- [x] The Rayhunter team has recently expressed interest in reviewing a PR for this.
  - If not, this PR may be closed due our limited resources and need to prioritize how we spend them.
- [ ] Added or updated any documentation as needed to support the changes in this PR.
- [x] Code has been linted and run through `cargo fmt`.
- [ ] If any new functionality has been added, unit tests were also added.
- [x] [CONTRIBUTING.md](https://github.com/EFForg/rayhunter/blob/main/CONTRIBUTING.md) has been read.
- [x] Your pull request is fewer than ~400 lines of code.

You must check one of:
- [x] No generative AI (including LLMs) tools were used to create this PR.
- [ ] Generative AI was used to create this PR. I certify that I have read and understand the code, and *that all comments and descriptions were authored by myself* and are not the product of generative AI.
