### PR TITLE
fix clippy errors on new rust version

### DIFF
--- a/lib/src/analysis/test_analyzer.rs
+++ b/lib/src/analysis/test_analyzer.rs
@@ -55,15 +55,15 @@ impl Analyzer for TestAnalyzer {
                 mcc_string = "nomcc".to_string();
             }
             let mnc = &plmn[0].plmn_identity.mnc;
-            let mnc_string: String;
+
             // MNC can be 2 or 3 digits
-            if mnc.0.len() == 3 {
-                mnc_string = format!("{}{}{}", mnc.0[0].0, mnc.0[1].0, mnc.0[2].0);
+            let mnc_string: String = if mnc.0.len() == 3 {
+                format!("{}{}{}", mnc.0[0].0, mnc.0[1].0, mnc.0[2].0)
             } else if mnc.0.len() == 2 {
-                mnc_string = format!("{}{}", mnc.0[0].0, mnc.0[1].0);
+                format!("{}{}", mnc.0[0].0, mnc.0[1].0)
             } else {
-                mnc_string = format!("{:?}", mnc.0);
-            }
+                format!("{:?}", mnc.0)
+            };
 
             return Some(Event {
                 event_type: EventType::Low,


### PR DESCRIPTION
rust 1.98.0 came out recently creating a new clippy warning which broke tests on https://github.com/EFForg/rayhunter/pull/1116. this PR fixes it

## Pull Request Checklist

- [x] The Rayhunter team has recently expressed interest in reviewing a PR for this.
  - If not, this PR may be closed due our limited resources and need to prioritize how we spend them.
- [x] Added or updated any documentation as needed to support the changes in this PR.
- [x] Code has been linted and run through `cargo fmt`.
- [x] If any new functionality has been added, unit tests were also added.
- [x] [CONTRIBUTING.md](https://github.com/EFForg/rayhunter/blob/main/CONTRIBUTING.md) has been read.
- [x] Your pull request is fewer than ~400 lines of code.

You must check one of:
- [x] No generative AI (including LLMs) tools were used to create this PR.
- [ ] Generative AI was used to create this PR. I certify that I have read and understand the code, and *that all comments and descriptions were authored by myself* and are not the product of generative AI.
