### PR TITLE
fix rayhunter-check --pcapify docs

### DIFF
--- a/check/src/main.rs
+++ b/check/src/main.rs
@@ -23,7 +23,7 @@ struct Args {
     #[arg(short = 'p', long, help = "A file or directory of packet captures")]
     path: PathBuf,
 
-    #[arg(short = 'P', long, help = "Convert qmdl files to pcap before analysis")]
+    #[arg(short = 'P', long, help = "Convert qmdl files to pcap after analysis")]
     pcapify: bool,
 
     #[arg(long, help = "Show why some packets were skipped during analysis")]

--- a/doc/reanalyzing.md
+++ b/doc/reanalyzing.md
@@ -26,12 +26,12 @@ You can build `rayhunter-check` from source with the following command:
 rayhunter-check [OPTIONS] --path <PATH>
 
 Options:
-  -p, --path <PATH>   Path to the PCAP, or QMDL file. If given a directory will 
-                        recursively scan all pcap, qmdl, and subdirectories 
-  -P, --pcapify       Turn QMDL file into PCAP     
-      --show-skipped  Show skipped messages
-  -q, --quiet         Print only warnings
-  -d, --debug         Print debug info 
+  -p, --path <PATH>   A file or directory of packet captures
+  -P, --pcapify       Convert qmdl files to pcap after analysis
+      --show-skipped  Show why some packets were skipped during analysis
+  -j, --json <JSON>   Output report to a JSON file
+  -q, --quiet         Only print warnings/errors to stdout
+  -d, --debug         Show debug messages
   -h, --help          Print help
   -V, --version       Print version
 ```


### PR DESCRIPTION
`--pcapify` does its conversion to pcap after it analyzes the qmdl and not before. see https://github.com/EFForg/rayhunter/blob/782bdbb5defe5a67e84d1940b97378d0a42df06d/check/src/main.rs#L246-L249

## Pull Request Checklist

- [ ] The Rayhunter team has recently expressed interest in reviewing a PR for this.
  - If not, this PR may be closed due our limited resources and need to prioritize how we spend them.
- [x] Added or updated any documentation as needed to support the changes in this PR.
- [x] Code has been linted and run through `cargo fmt`.
- [x] If any new functionality has been added, unit tests were also added.
- [x] [CONTRIBUTING.md](https://github.com/EFForg/rayhunter/blob/main/CONTRIBUTING.md) has been read.
- [x] Your pull request is fewer than ~400 lines of code.

You must check one of:
- [x] No generative AI (including LLMs) tools were used to create this PR.
- [ ] Generative AI was used to create this PR. I certify that I have read and understand the code, and *that all comments and descriptions were authored by myself* and are not the product of generative AI.
