### PR TITLE
Fix GitHub Pages deployment retries

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -657,13 +657,9 @@ jobs:
           name: api-docs
           path: api-docs
 
-  github_pages_publish:
-    name: Upload new documentation to Github Pages
+  github_pages_stage:
+    name: Stage Github Pages artifact
     if: ${{ github.ref == 'refs/heads/main' }}
-    permissions:
-      pages: write
-      contents: write
-      id-token: write
     needs:
       - mdbook_build
       - openapi_build
@@ -678,5 +674,22 @@ jobs:
         uses: actions/upload-pages-artifact@v3
         with:
           path: book
+
+  github_pages_publish:
+    name: Deploy documentation to Github Pages
+    needs:
+      - github_pages_stage
+    permissions:
+      pages: write
+      id-token: write
+    environment:
+      name: github-pages
+      url: ${{ steps.deployment.outputs.page_url }}
+    concurrency:
+      group: github-pages
+      cancel-in-progress: false
+    runs-on: ubuntu-latest
+    steps:
       - name: Deploy Github Pages
+        id: deployment
         uses: actions/deploy-pages@v4

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -660,6 +660,7 @@ jobs:
   github_pages_stage:
     name: Stage Github Pages artifact
     if: ${{ github.ref == 'refs/heads/main' }}
+    permissions: {}
     needs:
       - mdbook_build
       - openapi_build

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -101,7 +101,6 @@ jobs:
   mdbook_build:
     name: Build mdBook for Github Pages
     needs: mdbook_test
-    if: ${{ github.ref == 'refs/heads/main' }}
     permissions:
       contents: write
     runs-on: ubuntu-latest
@@ -659,7 +658,6 @@ jobs:
 
   github_pages_stage:
     name: Stage Github Pages artifact
-    if: ${{ github.ref == 'refs/heads/main' }}
     permissions: {}
     needs:
       - mdbook_build
@@ -678,6 +676,7 @@ jobs:
 
   github_pages_publish:
     name: Deploy documentation to Github Pages
+    if: ${{ github.ref == 'refs/heads/main' }}
     needs:
       - github_pages_stage
     permissions:


### PR DESCRIPTION
Split staging the Pages artifact from deploying it so retrying a failed deployment does not upload duplicate `github-pages` artifacts. Serialize Pages deployments to prevent overlapping pushes from colliding.

Failed workflow jobs:

- Initial deployment concurrency failure: https://github.com/EFForg/rayhunter/actions/runs/33410186858/job/99547923520
- Retry failure due to duplicate `github-pages` artifacts: https://github.com/EFForg/rayhunter/actions/runs/33410186858/job/99645408920

## Pull Request Checklist

- [x] The Rayhunter team has recently expressed interest in reviewing a PR for this.
  - If not, this PR may be closed due our limited resources and need to prioritize how we spend them.
- [x] Added or updated any documentation as needed to support the changes in this PR.
- [x] Code has been linted and run through `cargo fmt`.
- [x] If any new functionality has been added, unit tests were also added.
- [x] [CONTRIBUTING.md](https://github.com/EFForg/rayhunter/blob/main/CONTRIBUTING.md) has been read.
- [x] Your pull request is fewer than ~400 lines of code.

You must check one of:
- [ ] No generative AI (including LLMs) tools were used to create this PR.
- [x] Generative AI was used to create this PR. I certify that I have read and understand the code, and *that all comments and descriptions were authored by myself* and are not the product of generative AI.
