### PR TITLE
Expose CLI help and default values in the installer GUI

### DIFF
--- a/installer-gui/src-tauri/src/introspect.rs
+++ b/installer-gui/src-tauri/src/introspect.rs
@@ -45,6 +45,7 @@ impl Command<'_> {
 struct Argument<'a> {
     advanced: bool,
     flag: String,
+    help: String,
     label: &'a str,
     takes_values: bool,
 }
@@ -54,6 +55,31 @@ struct Subcommand<'a> {
     arguments: Vec<Argument<'a>>,
     command: &'a str,
     label: &'a str,
+}
+
+fn argument_help(argument: &clap::Arg) -> String {
+    let mut help = argument
+        .get_help()
+        .map(ToString::to_string)
+        .unwrap_or_default();
+    let default_values = argument.get_default_values();
+
+    if !argument.is_hide_default_value_set() && !default_values.is_empty() {
+        if !help.is_empty() {
+            help.push(' ');
+        }
+        help.push_str("[default: ");
+        help.push_str(
+            &default_values
+                .iter()
+                .map(|value| value.to_string_lossy())
+                .collect::<Vec<_>>()
+                .join(" "),
+        );
+        help.push(']');
+    }
+
+    help
 }
 
 impl Argument<'_> {
@@ -70,6 +96,7 @@ impl Argument<'_> {
         Ok(Argument {
             advanced: modifier.advanced,
             flag: format!("--{}", partial_flag),
+            help: argument_help(argument),
             label: modifier.gui_label,
             takes_values: argument.get_action().takes_values(),
         })
@@ -113,5 +140,32 @@ impl Subcommand<'_> {
             command: modifier.command,
             label: modifier.gui_label,
         }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::argument_help;
+
+    #[test]
+    fn argument_help_includes_default_values() {
+        let argument = clap::Arg::new("example")
+            .help("Choose an example value")
+            .default_values(["one", "two"]);
+
+        assert_eq!(
+            argument_help(&argument),
+            "Choose an example value [default: one two]"
+        );
+    }
+
+    #[test]
+    fn argument_help_respects_hidden_default_values() {
+        let argument = clap::Arg::new("example")
+            .help("Choose an example value")
+            .default_value("one")
+            .hide_default_value(true);
+
+        assert_eq!(argument_help(&argument), "Choose an example value");
     }
 }

--- a/installer-gui/src/lib/ArgMenu.svelte
+++ b/installer-gui/src/lib/ArgMenu.svelte
@@ -36,12 +36,35 @@
     }
 </script>
 
+{#snippet argument_label(arg: InstallerArgument)}
+    <label for={arg.flag} class="font-medium text-sm text-gray-700">
+        {arg.label}
+    </label>
+    {#if arg.help}
+        <span class="group relative inline-flex">
+            <button
+                aria-label={`${arg.label}: ${arg.help}`}
+                class="border border-gray-400 flex h-4 items-center justify-center rounded-full text-[10px] text-gray-600 w-4"
+                type="button"
+            >
+                ?
+            </button>
+            <span
+                class="absolute bottom-full left-1/2 mb-2 hidden max-w-72 -translate-x-1/2 rounded bg-gray-900 px-2 py-1 text-xs text-white whitespace-normal w-max z-10 group-focus-within:block group-hover:block"
+                role="tooltip"
+            >
+                {arg.help}
+            </span>
+        </span>
+    {/if}
+{/snippet}
+
 {#snippet submenu(args: InstallerArgument[])}
     {#each args as arg (arg.flag)}
         {#if arg.takes_values}
-            <label class="block font-medium mb-1 text-gray-700 text-sm" for={arg.flag}>
-                {arg.label}
-            </label>
+            <div class="flex items-center gap-1 mb-1">
+                {@render argument_label(arg)}
+            </div>
             <input
                 bind:value={inputData.strings[arg.flag]}
                 class="bg-white border border-gray-300 focus:outline-hidden focus:ring-2 focus:ring-rayhunter-blue px-3 py-2 rounded-md w-full"
@@ -58,9 +81,9 @@
                     spellcheck="false"
                     type="checkbox"
                 />
-                <label for={arg.flag} class="font-medium ml-2 text-sm text-gray-700">
-                    {arg.label}
-                </label>
+                <div class="flex items-center gap-1 ml-2">
+                    {@render argument_label(arg)}
+                </div>
             </div>
         {/if}
     {/each}

--- a/installer-gui/src/lib/types.svelte.ts
+++ b/installer-gui/src/lib/types.svelte.ts
@@ -16,6 +16,7 @@ export interface InstallerSubcommand {
 export interface InstallerArgument {
     advanced: boolean;
     flag: string;
+    help: string;
     label: string;
     takes_values: boolean;
 }


### PR DESCRIPTION
This work is for #1130. I moved the CLI help and default values from the backend introspection section to the GUI. I added a help icon and a tooltip next to the argument label. I added a unit test to verify the backend behavior.

## Pull Request Checklist

- [x] The Rayhunter team has recently expressed interest in reviewing a PR for this.
  - If not, this PR may be closed due our limited resources and need to prioritize how we spend them.
- [x] Added or updated any documentation as needed to support the changes in this PR.
- [ ] Code has been linted and run through `cargo fmt`.
- [x] If any new functionality has been added, unit tests were also added.
- [x] [CONTRIBUTING.md](https://github.com/EFForg/rayhunter/blob/main/CONTRIBUTING.md) has been read.
- [x] Your pull request is fewer than ~400 lines of code.

You must check one of:
- [ ] No generative AI (including LLMs) tools were used to create this PR.
- [x] Generative AI was used to create this PR. I certify that I have read and understand the code, and *that all comments and descriptions were authored by myself* and are not the product of generative AI.
