### PR TITLE
hide tplink sdcard default value

### DIFF
--- a/installer/src/lib.rs
+++ b/installer/src/lib.rs
@@ -88,7 +88,7 @@ struct InstallTpLink {
     ///
     /// Only override this when the installer does not work on your hardware version, as otherwise
     /// your custom path may conflict with the builtin storage functionality.
-    #[arg(long, default_value = "")]
+    #[arg(long, default_value = "", hide_default_value = true)]
     sdcard_path: String,
 
     /// Overwrite config.toml even if it already exists on the device.


### PR DESCRIPTION
while reviewing https://github.com/EFForg/rayhunter/pull/1134 i noticed that `installer tplink --help` looked like:
```
--sdcard-path <SDCARD_PATH>
  For advanced users: Specify the path of the SD card to be mounted explicitly.
  
  The default (empty string) is to use whichever sdcard path the device would use natively to mount storage on. On most TP-Link this is /media/card, but on hardware versions 9+ this is /media/sdcard
  
  Only override this when the installer does not work on your hardware version, as otherwise your custom path may conflict with the builtin storage functionality.
  
  [default: ]
```
i think this `[default: ]` looks bad and is redundant with the help text. setting this attribute removes it from the help output

## Pull Request Checklist

- [ ] The Rayhunter team has recently expressed interest in reviewing a PR for this.
  - If not, this PR may be closed due our limited resources and need to prioritize how we spend them.
- [x] Added or updated any documentation as needed to support the changes in this PR.
- [x] Code has been linted and run through `cargo fmt`.
- [ ] If any new functionality has been added, unit tests were also added.
- [x] [CONTRIBUTING.md](https://github.com/EFForg/rayhunter/blob/main/CONTRIBUTING.md) has been read.
- [x] Your pull request is fewer than ~400 lines of code.

You must check one of:
- [x] No generative AI (including LLMs) tools were used to create this PR.
- [ ] Generative AI was used to create this PR. I certify that I have read and understand the code, and *that all comments and descriptions were authored by myself* and are not the product of generative AI.
