### PR TITLE
installer: reject oversized Wingtech admin passwords

### DIFF
--- a/installer/src/wingtech.rs
+++ b/installer/src/wingtech.rs
@@ -36,6 +36,10 @@ const KEY: &[u8] = b"abcdefghijklmn12";
 /// Returns password encrypted in AES128 ECB mode with the key b"abcdefghijklmn12",
 /// with Pkcs7 padding, encoded in base64.
 fn encrypt_password(password: &[u8]) -> Result<String> {
+    if password.len() > 16 {
+        bail!("Wingtech admin password must be at most 16 bytes");
+    }
+
     let c = Aes128::new_from_slice(KEY)?;
     let mut b = GenericArray::from([0u8; 16]);
     b[..password.len()].copy_from_slice(password);
@@ -56,7 +60,7 @@ pub async fn run_command(admin_ip: &str, admin_password: &str, cmd: &str) -> Res
     let qcmap_auth_endpoint = format!("http://{admin_ip}/cgi-bin/qcmap_auth");
     let qcmap_web_cgi_endpoint = format!("http://{admin_ip}/cgi-bin/qcmap_web_cgi");
 
-    let encrypted_pw = encrypt_password(admin_password.as_bytes()).ok().unwrap();
+    let encrypted_pw = encrypt_password(admin_password.as_bytes())?;
 
     let client = Client::new();
     let LoginResponse { token } = client
@@ -158,4 +162,13 @@ fn test_encrypt_password() {
     let s = encrypt_password(p).ok();
     let expected = Some("5brvd8xl732cSoFTAy67ig==".to_string());
     assert_eq!(s, expected);
+}
+
+#[test]
+fn test_encrypt_password_rejects_passwords_longer_than_block() {
+    let error = encrypt_password(b"12345678901234567").unwrap_err();
+    assert_eq!(
+        error.to_string(),
+        "Wingtech admin password must be at most 16 bytes"
+    );
 }


### PR DESCRIPTION
This PR addresses the panic reported in #967 when a Wingtech installer admin password exceeds the 16-byte limit, improving error handling for this case.

## Changes

- **Input validation:** The existing AES-128 encryption behavior is preserved, while a length check is added before copying the password into the fixed-size block. Passwords longer than 16 bytes now return a clear error instead of causing a runtime panic.
- **Error handling:** The unwrap-based error path in run_command() has been removed, and encryption errors are now propagated normally to the caller.
 - **Test coverage:**A regression test has been added for a 17-byte password to ensure this case no longer panics.

Addresses the password-length panic in #967.

## Pull Request Checklist

- [ ] The Rayhunter team has recently expressed interest in reviewing a PR for this.
  - If not, this PR may be closed due our limited resources and need to prioritize how we spend them.
- [ ] Added or updated any documentation as needed to support the changes in this PR.
- [ ] Code has been linted and run through `cargo fmt`.
- [x] If any new functionality has been added, unit tests were also added.
- [x] [CONTRIBUTING.md](https://github.com/EFForg/rayhunter/blob/main/CONTRIBUTING.md) has been read.
- [x] Your pull request is fewer than ~400 lines of code.

You must check one of:
- [ ] No generative AI (including LLMs) tools were used to create this PR.
- [x] Generative AI was used to create this PR. I certify that I have read and understand the code, and *that all comments and descriptions were authored by myself* and are not the product of generative AI.
