### PR TITLE
Add experimental MR1100 port and installer

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2898,11 +2898,13 @@ dependencies = [
  "nusb",
  "reqwest 0.12.20",
  "serde",
+ "serde_json",
  "sha2",
  "termios",
  "tokio",
  "tokio-retry2",
  "tokio-stream",
+ "toml 0.8.22",
 ]
 
 [[package]]

--- a/daemon/src/battery/mod.rs
+++ b/daemon/src/battery/mod.rs
@@ -119,3 +119,16 @@ pub fn run_battery_notification_worker(
         }
     });
 }
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[tokio::test]
+    async fn mr1100_does_not_use_generic_battery_sysfs() {
+        assert!(matches!(
+            get_battery_status(&Device::Mr1100).await,
+            Err(RayhunterError::FunctionNotSupportedForDeviceError)
+        ));
+    }
+}

--- a/daemon/src/config.rs
+++ b/daemon/src/config.rs
@@ -255,3 +255,27 @@ pub fn parse_args() -> Args {
         config_path: args[1].clone(),
     }
 }
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn mr1100_example_uses_bounded_headless_configuration() {
+        let config: Config = toml::from_str(include_str!("../../dist/config.mr1100.toml")).unwrap();
+        assert_eq!(config.device, Device::Mr1100);
+        assert_eq!(config.ui_level, UiLevel::Invisible);
+        assert_eq!(config.key_input_mode, KeyInputMode::Disabled);
+        assert_eq!(config.gps_mode, GpsMode::Disabled);
+        assert_eq!(config.clock_sync_mode, ClockSyncMode::Off);
+        assert!(!config.debug_mode);
+        assert!(!config.wifi_enabled);
+        assert!(!config.auto_check_updates);
+        assert!(config.enabled_notifications.is_empty());
+        assert!(config.ntfy_url.is_none());
+        assert!(config.webdav.url.is_empty());
+        assert_eq!(config.qmdl_store_path, "/media/ram/rayhunter-mr1100/qmdl");
+        assert_eq!(config.min_space_to_start_recording_mb, 175);
+        assert_eq!(config.min_space_to_continue_recording_mb, 165);
+    }
+}

--- a/daemon/src/key_input.rs
+++ b/daemon/src/key_input.rs
@@ -1,4 +1,5 @@
-use log::{error, info};
+use log::{error, info, warn};
+use rayhunter::Device;
 use std::time::{Duration, Instant};
 use tokio::fs::File;
 use tokio::io::AsyncReadExt;
@@ -24,6 +25,11 @@ pub fn run_key_input_thread(
     cancellation_token: CancellationToken,
 ) {
     if config.key_input_mode == KeyInputMode::Disabled {
+        return;
+    }
+    if config.device == Device::Mr1100 {
+        // Preserve the native power key until its evdev format is supported.
+        warn!("Key input is not supported on MR1100; leaving native input untouched");
         return;
     }
 
@@ -111,6 +117,19 @@ fn parse_event(input: [u8; INPUT_EVENT_SIZE]) -> Event {
 #[cfg(test)]
 mod tests {
     use super::*;
+
+    #[test]
+    fn mr1100_does_not_start_key_input_even_when_requested() {
+        let config = config::Config {
+            device: Device::Mr1100,
+            key_input_mode: KeyInputMode::DoubleTapPower,
+            ..Default::default()
+        };
+        let tracker = TaskTracker::new();
+        let (diag_tx, _diag_rx) = tokio::sync::mpsc::channel(1);
+        run_key_input_thread(&tracker, &config, diag_tx, CancellationToken::new());
+        assert!(tracker.is_empty());
+    }
 
     #[test]
     fn test_parse_event_keydown_m7350_v5() {

--- a/daemon/src/main.rs
+++ b/daemon/src/main.rs
@@ -251,7 +251,7 @@ async fn run_with_config(
             Device::Tplink => display::tplink::update_ui,
             Device::Tmobile => display::tmobile::update_ui,
             Device::Wingtech => display::wingtech::update_ui,
-            Device::Pinephone => display::headless::update_ui,
+            Device::Pinephone | Device::Mr1100 => display::headless::update_ui,
             Device::Uz801 => display::uz801::update_ui,
         };
         update_ui(&task_tracker, &config, shutdown_token.clone(), ui_update_rx);

--- a/dist/config.mr1100.toml
+++ b/dist/config.mr1100.toml
@@ -1,0 +1,23 @@
+# Short MR1100 tests only. See doc/mr1100.md before starting the daemon.
+# /media/ram must be the existing tmpfs, not a directory on internal NAND.
+qmdl_store_path = "/media/ram/rayhunter-mr1100/qmdl"
+port = 8080
+device = "mr1100"
+ui_level = 0
+key_input_mode = 0
+debug_mode = false
+
+# Preserve native router operation; do not enable untested integrations.
+wifi_enabled = false
+gps_mode = 0
+enabled_notifications = []
+auto_check_updates = false
+clock_sync_mode = 0
+
+# Tested tmpfs capacity: about 195 MiB. These are reserves, not size limits.
+# Also use an external runtime limit; free-space checks do not bound RAM use.
+min_space_to_start_recording_mb = 175
+min_space_to_continue_recording_mb = 165
+
+[webdav]
+url = ""

--- a/dist/scripts/rayhunter_mr1100
+++ b/dist/scripts/rayhunter_mr1100
@@ -1,0 +1,174 @@
+#!/bin/sh
+# rayhunter-mr1100-v1
+# Dedicated MR1100 Rayhunter service. Firewall rules stay installed on stop.
+umask 077
+ROOT=/data/rayhunter
+MARKER=$ROOT/.mr1100-install
+DAEMON=$ROOT/rayhunter-daemon
+CONFIG=$ROOT/config.toml
+RUN=/media/ram/rayhunter-mr1100
+LOG=$RUN/rayhunter.log
+PIDFILE=$RUN/rayhunter.pid
+LOCK=$RUN/start.lock
+CHAIN=RH_MR1100
+
+msg() { echo "rayhunter_mr1100: $*" >&2; }
+mounted() {
+    awk -v d="$1" -v m="$2" -v t="$3" \
+        '$1==d && $2==m && $3==t { found=1 } END { exit !found }' /proc/mounts
+}
+install_ok() {
+    [ -d "$ROOT" ] && [ ! -L "$ROOT" ] &&
+    [ "$(cat "$MARKER" 2>/dev/null)" = mr1100-v1 ] &&
+    [ -x "$DAEMON" ] && [ -f "$CONFIG" ]
+}
+exact_pid() {
+    [ "$1" -gt 1 ] 2>/dev/null &&
+        [ "$(readlink "/proc/$1/exe" 2>/dev/null)" = "$DAEMON" ]
+}
+read_pid() {
+    [ -e "$PIDFILE" ] || [ -L "$PIDFILE" ] || return 1
+    [ -f "$PIDFILE" ] && [ ! -L "$PIDFILE" ] || return 2
+    pid=$(cat "$PIDFILE" 2>/dev/null)
+    case "$pid" in ''|*[!0-9]*) return 2;; esac
+    [ "$pid" -gt 1 ] 2>/dev/null || return 2
+}
+lock() {
+    mkdir "$LOCK" 2>/dev/null || { msg "service operation already active"; return 1; }
+    trap 'rmdir "$LOCK" 2>/dev/null' 0 1 2 3 15
+}
+unlock() { rmdir "$LOCK" 2>/dev/null; trap - 0 1 2 3 15; }
+rule_count() {
+    "$1" -n -L "$CHAIN" 2>/dev/null |
+        awk 'NR>2 && NF { n++ } END { print n+0 }'
+}
+chain_ok() {
+    fw=$1; want=$2
+    [ "$(rule_count "$fw")" = "$want" ] || return 1
+    "$fw" -C "$CHAIN" -i lo -j ACCEPT >/dev/null 2>&1 || return 1
+    if [ "$want" = 3 ]; then
+        "$fw" -C "$CHAIN" -m physdev --physdev-in rndis0 -j ACCEPT >/dev/null 2>&1 || return 1
+    fi
+    "$fw" -C "$CHAIN" -j REJECT >/dev/null 2>&1
+}
+ensure_chain() {
+    fw=$1; want=$2
+    if "$fw" -n -L "$CHAIN" >/dev/null 2>&1; then
+        chain_ok "$fw" "$want" || { msg "$fw chain collision or no -C support"; return 1; }
+    else
+        "$fw" -N "$CHAIN" && "$fw" -A "$CHAIN" -i lo -j ACCEPT || return 1
+        if [ "$want" = 3 ]; then
+            "$fw" -A "$CHAIN" -m physdev --physdev-in rndis0 -j ACCEPT || return 1
+        fi
+        "$fw" -A "$CHAIN" -j REJECT || return 1
+        chain_ok "$fw" "$want" || return 1
+    fi
+    for port in 8080 23; do
+        "$fw" -C INPUT -p tcp --dport "$port" -j "$CHAIN" >/dev/null 2>&1 ||
+            "$fw" -I INPUT 1 -p tcp --dport "$port" -j "$CHAIN" || return 1
+    done
+}
+firewall() {
+    command -v iptables >/dev/null 2>&1 || { msg "iptables is unavailable"; return 1; }
+    ensure_chain iptables 3 || { msg "IPv4 protection failed"; return 1; }
+    if [ -e /proc/net/if_inet6 ]; then
+        command -v ip6tables >/dev/null 2>&1 || { msg "IPv6 is active but ip6tables is unavailable"; return 1; }
+        ensure_chain ip6tables 2 || { msg "IPv6 protection failed"; return 1; }
+    fi
+}
+prepare() {
+    install_ok || { msg "invalid MR1100 installation"; return 1; }
+    mounted ubi0:usrfs /data ubifs || { msg "/data is not ubi0:usrfs ubifs"; return 1; }
+    mounted tmpfs /media/ram tmpfs || { msg "/media/ram is not tmpfs"; return 1; }
+    [ -d "$RUN" ] || mkdir "$RUN" || return 1
+    [ ! -L "$RUN" ] || { msg "unsafe runtime path"; return 1; }
+    [ -d "$RUN/qmdl" ] || mkdir "$RUN/qmdl" || return 1
+    [ ! -L "$RUN/qmdl" ] || { msg "unsafe capture path"; return 1; }
+    chmod 700 "$RUN" "$RUN/qmdl" || return 1
+}
+abort_spawn() {
+    if exact_pid "$pid"; then kill -INT "$pid" 2>/dev/null; fi
+    n=0
+    while exact_pid "$pid" && [ "$n" -lt 10 ]; do sleep 1; n=$((n + 1)); done
+    if exact_pid "$pid"; then kill -KILL "$pid" 2>/dev/null; fi
+    # The child may not have reached exec yet. Only signal our own direct child.
+    if [ "$(awk '/^PPid:/ {print $2}' "/proc/$pid/status" 2>/dev/null)" = "$$" ]; then
+        kill -KILL "$pid" 2>/dev/null
+    fi
+    msg "startup failed; stopped new child $pid"
+    return 1
+}
+start_locked() {
+    firewall || return 1
+    read_pid; rc=$?
+    if [ "$rc" = 0 ]; then
+        exact_pid "$pid" && { msg "already running ($pid)"; return 0; }
+        [ -d "/proc/$pid" ] && { msg "PID file refers to another process"; return 1; }
+        rm -f "$PIDFILE" || return 1
+    elif [ "$rc" = 2 ]; then
+        msg "unsafe PID file"; return 1
+    fi
+    [ ! -L "$LOG" ] || { msg "unsafe log path"; return 1; }
+    : >>"$LOG" || return 1
+    chmod 600 "$LOG" || return 1
+    RUST_LOG=info "$DAEMON" "$CONFIG" </dev/null >>"$LOG" 2>&1 & pid=$!
+    n=0
+    while ! exact_pid "$pid" && [ "$n" -lt 5 ]; do sleep 1; n=$((n + 1)); done
+    exact_pid "$pid" || { abort_spawn; return 1; }
+    if ! { [ ! -e "$PIDFILE.$$" ] && [ ! -L "$PIDFILE.$$" ] &&
+        printf '%s\n' "$pid" >"$PIDFILE.$$" && mv "$PIDFILE.$$" "$PIDFILE"; }; then
+        abort_spawn; return 1
+    fi
+    ( trap - 0 1 2 3 15
+      while exact_pid "$pid"; do
+        sleep 30; exact_pid "$pid" || break
+        [ "$(wc -c <"$LOG")" -le 1048576 ] || : >"$LOG"
+      done ) </dev/null >/dev/null 2>&1 &
+    msg "started ($pid)"
+}
+start_service() { prepare && lock || return 1; start_locked; rc=$?; unlock; return "$rc"; }
+
+stop_locked() {
+    read_pid; rc=$?
+    [ "$rc" = 1 ] && { msg "not running"; return 0; }
+    [ "$rc" = 2 ] && { msg "unsafe PID file"; return 1; }
+    if [ ! -d "/proc/$pid" ]; then rm -f "$PIDFILE"; msg "not running"; return 0; fi
+    exact_pid "$pid" || { msg "PID file refers to another process"; return 1; }
+    kill -INT "$pid" || return 1
+    n=0
+    while [ -d "/proc/$pid" ] && [ "$n" -lt 10 ]; do
+        exact_pid "$pid" || { [ -e "/proc/$pid/exe" ] && { msg "PID changed owner"; return 1; }; }
+        sleep 1; n=$((n + 1))
+    done
+    if exact_pid "$pid"; then
+        kill -KILL "$pid" || return 1
+        sleep 1
+    fi
+    [ ! -d "/proc/$pid" ] || { msg "process did not exit"; return 1; }
+    rm -f "$PIDFILE" || return 1
+    msg "stopped"
+}
+stop_service() {
+    [ -d "$RUN" ] || { msg "not running"; return 0; }
+    [ ! -L "$RUN" ] && lock || return 1
+    stop_locked; rc=$?; unlock; return "$rc"
+}
+status_service() {
+    read_pid; rc=$?
+    [ "$rc" = 0 ] && exact_pid "$pid" && { msg "running ($pid)"; return 0; }
+    [ "$rc" = 0 ] && [ -d "/proc/$pid" ] && msg "unsafe PID owner" || msg "not running"
+    return 1
+}
+
+# S88 runs before the stock S90swiapplaunch.sh can start root Telnet.
+case "${0##*/}" in
+    S88rayhunter_mr1100_firewall) firewall; exit $?;;
+esac
+case "${1-}" in
+    start) start_service;;
+    stop) stop_service;;
+    restart) stop_service && start_service;;
+    status) status_service;;
+    *) echo "Usage: $0 {start|stop|restart|status}" >&2; exit 2;;
+esac
+exit $?

--- a/doc/SUMMARY.md
+++ b/doc/SUMMARY.md
@@ -23,5 +23,6 @@
   - [UZ801](./uz801.md)
   - [Wingtech CT2MHS01](./wingtech-ct2mhs01.md)
   - [PinePhone and PinePhone Pro](./pinephone.md)
+  - [Netgear Nighthawk M1 MR1100](./mr1100.md)
   - [Moxee Hotspot](./moxee.md)
 - [REST API Documentation](./api-docs.md)

--- a/doc/mr1100.md
+++ b/doc/mr1100.md
@@ -1,0 +1,242 @@
+# Netgear Nighthawk M1 MR1100
+
+MR1100 support is experimental and headless. The command-line installer keeps the
+native firmware and router services. It installs only its own files and links.
+
+## Tested hardware and firmware
+
+The evidence below is from one AT&T device observed on 2026-09-12. The installer
+rejects other firmware. These results do not establish support for each carrier
+or regional variant.
+
+| Item | Tested value |
+| --- | --- |
+| Model / hardware revision | MR1100 / 1.0 |
+| Carrier firmware package | `MR1100ABS-2A1NAS_NTG9X50C_12.06.39.00_ATT_06.14` |
+| Firmware and bootloader | `NTG9X50C_12.06.39.00` |
+| Firmware build date / PRI | 2021-05-10 / 06.14 |
+| Linux | 3.18.31, ARMv7 Cortex-A7 |
+| Modem | Qualcomm MDM9250 / Snapdragon X16; MDM9650 platform naming |
+| Diagnostic interface | Internal `/dev/diag`, character device 246:0 |
+| Access path | USB network; AT on TCP 5510; root shell on TCP 23 |
+
+The tested `/data` filesystem was a separate UBIFS with about 24 MiB of space.
+Files in it survived a restart. The installer stores the executable and
+configuration in `/data/rayhunter`. It stores logs and captures in the tmpfs at
+`/media/ram/rayhunter-mr1100`. A restart deletes these RAM files. No SD card is
+necessary.
+
+Do not flash this carrier firmware on another variant. Firmware replacement,
+bootloader changes, external USB DIAG, and NV/EFS edits are not part of this
+port. Do not enable external USB DIAG with `AT!UDPID=9025`.
+
+## Network and root safety
+
+Use USB tethering. The tested device required USB tethering before TCP 5510 was
+available. Disconnect Wi-Fi and Ethernet devices that use the same subnet.
+Binding only the local IP address does not prevent a connection through another
+interface.
+
+Use an isolated, trusted network for the first root bootstrap. Root Telnet can be
+passwordless during this step. Installation closes persistent root Telnet even
+if it was previously enabled. The installer clears its boot flag before writing
+application files, while retaining the current shell until restart. Thus a
+firewall failure during a later boot cannot expose a root Telnet service.
+It preserves the original `RDENABLE` value. On failure it restores the previous
+access settings; on success it restarts and verifies that TCP 23 is closed.
+Do not run concurrent installers or change device settings during installation.
+Finish any manual access-setting changes with a restart first. On this firmware,
+`bsinfo -sn` reports the value used at boot, not a pending AT change. The installer
+uses a real restart and a TCP 23 check to verify access cleanup.
+
+The installer does not include a key helper. Supply B. Kerler's `sierrakeygen.py`
+for installation, including when root is already available. It needs Python 3 and `pyserial`. The installer calls
+it for `MDM9x40`. Review the helper before use. Its license and commercial-use
+note are not clear, so Rayhunter does not vendor it. Do not run the Hacking
+repository's `main.py`; that program can change the IMEI.
+
+The tested helper is [this pinned file](https://github.com/RupGautam/Hacking_MR1100_Hotspot/blob/dfc6d510b0a77abeebcc9fb15904d8cfc161b6c2/sierrakeygen.py).
+Its SHA-256 is
+`09860d75bfa7725a5a7140a98d561f6d20a5864b3194be7d25d9db2531382ad1`.
+Install `pyserial` in a Python virtual environment, activate that environment,
+and make sure the installer's `python3` can import it. If using `sudo`, preserve
+that virtual environment's `PATH` explicitly; do not run an unrelated root script.
+
+## Build and install
+
+Follow the prerequisites in [Installing from source](installing-from-source.md).
+Build only; do not run a generic install script:
+
+```sh
+(cd daemon/web && npm ci && npm run build)
+rustup target add armv7-unknown-linux-musleabihf
+cargo build-daemon-firmware-devel --locked
+cargo build --locked -p installer
+```
+
+Find the host IPv4 address and interface for the MR1100 USB network. On Linux,
+run:
+
+```sh
+sudo ./target/debug/installer mr1100 \
+  --local-ip HOST_USB_IPV4 \
+  --interface USB_INTERFACE \
+  --keygen /path/to/sierrakeygen.py \
+  --volatile-captures
+```
+
+`--keygen` is required for installation so that root access can be closed safely.
+Add `--lte-only` only as described below. The default router address is
+`192.168.1.1`; use `--admin-ip` if the router uses a different address.
+
+`--interface` is supported on Linux and Android. It is not supported on macOS or
+Windows. On those systems, omit it and disconnect all other devices on the same
+subnet.
+
+The installer accepts RAM-only storage only when `--volatile-captures` is
+present. The configured free-space reserves are 175 MiB to start and 165 MiB to
+continue. These values are stop thresholds, not storage limits. The service
+checks the log every 30 seconds and truncates it after it grows above about 1
+MiB.
+
+Open `http://192.168.1.1:8080` through USB after installation. Check
+`/api/qmdl-manifest` for a growing capture. Copy needed captures before a
+restart.
+
+## LTE selection
+
+The native **LTE All** preset produced LTE records on the tested firmware. The
+preset indices were Auto 0, WCDMA All 1, and LTE All 2. Do not use these indices
+on other firmware.
+
+`--lte-only` selects the native LTE All preset. It needs the native API to give the installer
+an admin session, as it did on the tested factory-setup device. Browser login
+cookies are not imported and automatic password login is not implemented. If
+the installer cannot obtain that session, select LTE All in the native GUI and
+omit `--lte-only`. The installer stores the
+original preset and restores it on rollback or uninstall.
+
+On the tested unit, `AT!SELRAT=06`, `00`, and `11` returned `ERROR`. Do not use
+these commands as a replacement for the native preset. A SIM was not necessary
+for broadcast and paging reception. Actual LTE reception is still necessary.
+The web API can report `Preferred3G` even during LTE reception. Check AT radio
+status and actual captured records, not that label alone.
+
+## Installed service and firewall
+
+The installer transfers files with SHA-256 checks. Fixed ownership markers let
+rollback and uninstall remove only installer-owned files. It does not replace a
+native script.
+
+The installed links are:
+
+- `S88rayhunter_mr1100_firewall`, before the native `S90` Telnet service
+- `S99rayhunter_mr1100`, for the Rayhunter application
+- `K01rayhunter_mr1100` in run levels 0 and 6, for shutdown
+
+For TCP 23 and 8080, the persistent IPv4 firewall accepts loopback and USB
+`rndis0` traffic only. Its IPv6 firewall accepts loopback only. Persistent root Telnet is disabled
+before a successful install returns; the firewall is not its only protection.
+Rayhunter does not start if firewall setup fails. During transfer,
+a temporary TCP 8081 rule accepts only the selected host IPv4 address through
+`rndis0`. The installer removes this rule after transfer.
+
+A repeated install verifies the complete state and preserves all files and the
+configuration. There is no in-place upgrade. If the completion marker is missing
+or the state changed, the installer makes no changes and requires uninstall.
+
+## Uninstall
+
+Run:
+
+```sh
+sudo ./target/debug/installer mr1100 \
+  --local-ip HOST_USB_IPV4 \
+  --interface USB_INTERFACE \
+  --uninstall
+```
+
+Add `--keygen /path/to/sierrakeygen.py` if root is not available. Uninstall
+removes only owned files, links, and firewall chains. It keeps extra user files
+and the ownership marker. It restores a saved native radio preset. If root is already available and no key helper is supplied, uninstall leaves
+that access unchanged; removal of the USB firewall restores its earlier exposure.
+With a key helper, uninstall closes root access and restarts, even if root was
+already available.
+
+Without a key helper, uninstall leaves the current RAM capture directory.
+With a key helper, its final restart deletes all RAM captures.
+Copy captures first.
+
+## Capture and installer evidence
+
+Two stock v0.12.0 captures used the existing PinePhone headless path. They
+contained 1,011 CRC-valid diagnostic packets and 107 LTE RRC OTA records
+(`0xb0c0`). Independent ASN.1 decoding found 12 broadcast messages with SIB1
+through SIB5 and 95 paging messages, with no RRC decode errors. Native GUI and
+modem-service process IDs did not change. SIGINT returned status 0 and restored
+the saved DIAG state.
+
+A later ARMv7 development build used `device = "mr1100"`. Its API reported that
+profile. It captured 302 CRC-valid packets, including 30 independently decoded
+LTE paging messages, and returned status 0 after SIGINT. Its branch base was
+`15630ed9c7ac900271d8c3de2ea5c12ccaf9e2f5`. Its SHA-256 was
+`03d68bc3f9c44f253c97d8247030c907bcf89c1f3f388b896df619b9e91defc1`.
+
+The implemented installer passed these tests on the tested unit:
+
+- full install with existing root, a growing capture, and a repeated state check
+- rejection of a missing completion marker with unchanged file hashes
+- startup and a growing capture after restart
+- uninstall with an extra user file and marker, and repeated cleanup
+- recovery from partial staging and a temporary transfer firewall
+- refusal to execute a foreign init script
+- cleanup with TCP 23 closed after a deliberate root-bootstrap preflight failure
+- bootstrap uninstall with TCP 23 closed
+- full root-bootstrap install, automatic restart, and TCP 23 closed
+
+A post-bootstrap restart also resumed recording with `device = "mr1100"` and
+TCP 23 closed. The `/data` UBIFS files survived restart. These tests do not prove
+support for untested firmware or radio conditions.
+
+## Timing-record format
+
+MR1100 `0xb114` records use the format discriminator `0x7a` (122), not the
+version-1 layout seen on the Orbic. Every one of 12,008 CRC-valid MR1100 timing
+records in a later sample had a 16-byte fixed part and 8 bytes per record. The
+record count occupies the low five bits of the second byte and was 1 through 20.
+The Orbic version-1 layout instead uses 12 fixed bytes and 3 bytes per record.
+This difference is inside the valid DIAG frame, not an HDLC escape or offset error.
+
+The parser now validates the MR1100 envelope and preserves the unknown header
+bits and record bytes. It does not interpret them as version-1 timing values or
+calculate timing advance or distance from them. No reliable definition of those
+fields was available. Both timing variants remain outside the current GSMTAP
+analysis path; the original bytes remain in QMDL recordings.
+
+Offline replay of that sample parsed all 14,411 packets without timing-version
+errors. Five separate `UnsupportedGsmtapType(LteMacFramed)` skips remained.
+The Orbic reference replay parsed 9,578 packets without skips. Synthetic tests
+cover both formats, raw-byte round trips, invalid counts, truncation, and unknown
+format tags. Invalid records are still reported as errors.
+
+The updated daemon was also tested on the device. A fresh sample contained
+1,068 CRC-valid packets, including 692 `0xb114` records, with no timing-version
+errors in the analysis report. One unrelated MAC-message skip remained.
+
+Errors already stored in an earlier recording's analysis report do not disappear
+when the daemon is updated. Use a new recording or reanalyze the saved QMDL.
+
+## Known limits
+
+- Full LTE NAS coverage and normal subscriber-attachment behavior remain unverified.
+  The later replay included 18 NAS records without parser errors.
+- In an idle DIAG session, shutdown can block in `diagchar_read`. The service
+  sends SIGINT, waits 10 seconds, and then sends SIGKILL.
+- MR1100 `0xb114` timing values remain undecoded. Its envelope is supported and
+  raw fields are retained, but their meaning must not be inferred from version 1.
+- Device timestamps can be wrong. Set time before you depend on capture times.
+- Display, button, battery, GPS, Wi-Fi client, and automatic-update integration
+  are not provided. The native GUI keeps control of the screen.
+
+Keep captures, device and SIM identifiers, credentials, session tokens, and raw
+API output private. Empty alert output is not a safety guarantee.

--- a/doc/supported-devices.md
+++ b/doc/supported-devices.md
@@ -28,6 +28,14 @@ Rayhunter is confirmed to work on these devices.
 | [FY UZ801](./uz801.md) | Asia, Europe |
 | [Moxee hotspot](./moxee.md) | Americas |
 
+## 3. Experimental devices
+
+These devices require manual setup and have known limitations.
+
+| Device | Tested variant and status |
+| ------ | ------ |
+| [Netgear Nighthawk M1 MR1100](./mr1100.md) | AT&T 12.06.39.00; command-line installer and headless LTE capture verified; RAM-only captures, idle shutdown workaround, limited NAS validation, and opaque timing fields |
+
 ## Adding new devices
 Rayhunter was built and tested primarily on the Orbic RC400L mobile hotspot, but the community has been working hard at adding support for other devices. Theoretically, if a device runs a Qualcomm modem and exposes a `/dev/diag` interface, Rayhunter may work on it.
 

--- a/installer/Cargo.toml
+++ b/installer/Cargo.toml
@@ -27,8 +27,10 @@ md5crypt = "1.0.0"
 nusb = "0.1.13"
 reqwest = { version = "0.12.15", features = ["json"], default-features = false }
 serde = { version = "1.0.219", features = ["derive"] }
+serde_json = "1.0"
+toml = "0.8.8"
 sha2 = "0.10.8"
-tokio = { version = "1.44.2", features = ["io-util", "io-std", "macros", "rt"], default-features = false }
+tokio = { version = "1.44.2", features = ["io-util", "io-std", "macros", "rt", "process"], default-features = false }
 tokio-retry2 = "0.5.7"
 tokio-stream = "0.1.17"
 futures = "0.3"

--- a/installer/src/lib.rs
+++ b/installer/src/lib.rs
@@ -12,6 +12,8 @@ mod files;
 pub(crate) use files::*;
 
 mod moxee;
+mod mr1100;
+mod mr1100_transport;
 #[cfg(not(target_os = "android"))]
 mod orbic;
 mod orbic_auth;
@@ -53,6 +55,8 @@ enum Command {
     Orbic(OrbicNetworkArgs),
     /// Install rayhunter on the Moxee Hotspot via network.
     Moxee(MoxeeArgs),
+    /// Install Rayhunter on the tested Netgear MR1100 firmware through USB networking.
+    Mr1100(mr1100::Options),
     /// Install rayhunter on the TMobile TMOHS1.
     Tmobile(TmobileArgs),
     /// Install rayhunter on the Uz801.
@@ -290,6 +294,7 @@ async fn run(args: Args) -> Result<(), Error> {
         Command::OrbicUsb(args) => orbic::install(args.reset_config).await.context("\nFailed to install rayhunter on the Orbic RC400L (USB installer)")?,
         Command::Orbic(args) => orbic_network::install(args.admin_ip, args.admin_username, args.admin_password, args.reset_config, args.data_dir).await.context("\nFailed to install rayhunter on the Orbic RC400L")?,
         Command::Moxee(args) => moxee::install(args).await.context("\nFailed to install rayhunter on the Moxee Hotspot")?,
+        Command::Mr1100(args) => mr1100::install(args).await.context("Failed to install Rayhunter on the MR1100")?,
         Command::Wingtech(args) => wingtech::install(args).await.context("\nFailed to install rayhunter on the Wingtech CT2MHS01")?,
         Command::Util(subcommand) => {
             match subcommand.command {

--- a/installer/src/mr1100.rs
+++ b/installer/src/mr1100.rs
@@ -1,0 +1,903 @@
+use std::net::Ipv4Addr;
+use std::path::PathBuf;
+use std::time::Duration;
+
+use anyhow::{Context, Result, bail, ensure};
+use clap::Args;
+use reqwest::{Client, header};
+use serde_json::Value;
+use sha2::{Digest, Sha256};
+use tokio::time::{sleep, timeout};
+
+use crate::mr1100_transport::Connection;
+use crate::output::println;
+
+const ROOT: &str = "/data/rayhunter";
+const STAGE: &str = "/data/.rayhunter-mr1100-install";
+const INIT: &str = "/etc/init.d/rayhunter_mr1100";
+const MARKER: &str = "mr1100-v1";
+const CONFIG: &str = include_str!("../../dist/config.mr1100.toml");
+const SERVICE: &str = include_str!("../../dist/scripts/rayhunter_mr1100");
+const LINKS: [&str; 4] = [
+    "/etc/rc5.d/S88rayhunter_mr1100_firewall",
+    "/etc/rc5.d/S99rayhunter_mr1100",
+    "/etc/rc0.d/K01rayhunter_mr1100",
+    "/etc/rc6.d/K01rayhunter_mr1100",
+];
+
+#[derive(Args, Debug)]
+pub(crate) struct Options {
+    /// MR1100 USB gateway address. Disconnect other hotspots with the same address.
+    #[arg(long, default_value = "192.168.1.1")]
+    admin_ip: Ipv4Addr,
+    /// This computer's IPv4 address on the MR1100 USB network (not the gateway).
+    #[arg(long)]
+    local_ip: Ipv4Addr,
+    /// Linux/Android: bind every connection to this USB interface. May require root.
+    #[arg(long)]
+    interface: Option<String>,
+    /// Acknowledge that default captures are RAM-backed and lost at reboot.
+    #[arg(long)]
+    volatile_captures: bool,
+    /// Select the native LTE All preset. Requires an authenticated native web session.
+    #[arg(long)]
+    lte_only: bool,
+    /// Path to sierrakeygen.py. Required for install: persistent root Telnet is closed.
+    #[arg(long, required_unless_present = "uninstall")]
+    keygen: Option<PathBuf>,
+    /// Remove this installer's files and startup links; retain RAM captures.
+    #[arg(long, conflicts_with = "lte_only")]
+    uninstall: bool,
+}
+
+pub async fn install(options: Options) -> Result<()> {
+    ensure!(
+        options.uninstall || options.volatile_captures,
+        "Specify --volatile-captures to acknowledge RAM-only recordings; no SD card is required"
+    );
+    ensure!(
+        options.local_ip != options.admin_ip && !options.local_ip.is_unspecified(),
+        "Specify the host's USB IPv4 address"
+    );
+    let binary: &[u8] = if options.uninstall {
+        &[]
+    } else {
+        crate::get_file!("FILE_RAYHUNTER_DAEMON")
+    };
+    if !options.uninstall {
+        validate_binary(binary)?;
+        validate_config(CONFIG)?;
+    }
+    #[cfg(not(any(target_os = "linux", target_os = "android", target_os = "fuchsia")))]
+    ensure!(
+        options.interface.is_none(),
+        "--interface is supported on Linux/Android; otherwise disconnect other hotspots with the same subnet"
+    );
+    let conn = Connection {
+        admin: options.admin_ip,
+        local: options.local_ip,
+        interface: options.interface,
+    };
+    verify_device(&conn).await?;
+    let web = Web::new(&conn)?;
+    let mut access_changed = false;
+    let had_root = has_root(&conn).await;
+    if !options.uninstall || !had_root {
+        options.keygen.as_deref().context(
+            "Supply --keygen: installation must close persistent root Telnet for safe boot",
+        )?;
+    }
+    let original_telnet = if had_root {
+        let value = conn
+            .run("/usr/bin/bsinfo -sn")
+            .await?
+            .trim()
+            .parse::<u8>()?;
+        ensure!(value <= 1, "Unexpected persistent Telnet setting");
+        value
+    } else {
+        0
+    };
+    let original_rd = if options.keygen.is_some() {
+        Some(parse_rd_enable(&conn.at("AT!CUSTOM?").await?)?)
+    } else {
+        None
+    };
+    let result = async {
+        if let Some(rd) = original_rd {
+            if !had_root {
+                ensure_root(&conn, options.keygen.as_deref(), &mut access_changed).await?;
+            }
+            // Do not depend on a boot-time firewall to contain persistent root Telnet.
+            // The current shell remains usable until the final reboot.
+            access_changed = true;
+            restore_access_flags(&conn, options.keygen.as_deref().unwrap(), 0, rd).await?;
+            // bsinfo reports the current boot's value, not a pending AT change.
+            // Verify that TCP 23 is closed after the final restart instead.
+        }
+        if options.uninstall {
+            uninstall(&conn, &web).await
+        } else {
+            install_rooted(&conn, &web, binary, options.lte_only).await
+        }
+    }
+    .await;
+    if access_changed {
+        let telnet = if result.is_err() { original_telnet } else { 0 };
+        println!(
+            "Restoring debug settings and restarting (persistent Telnet={telnet}). RAM captures will be lost."
+        );
+        let cleanup = async {
+            restore_access_flags(
+                &conn,
+                options.keygen.as_deref().unwrap(),
+                telnet,
+                original_rd.unwrap(),
+            )
+            .await?;
+            let _ = conn.at("AT!RESET").await;
+            sleep(Duration::from_secs(10)).await;
+            timeout(Duration::from_secs(180), async {
+                loop {
+                    if verify_device(&conn).await.is_ok() {
+                        break;
+                    }
+                    sleep(Duration::from_secs(2)).await;
+                }
+            })
+            .await
+            .context("Router did not return after closing temporary root access")?;
+            if telnet == 0 {
+                ensure!(
+                    conn.connect(23).await.is_err(),
+                    "Root Telnet is still listening after access cleanup"
+                );
+            } else {
+                ensure!(
+                    has_root(&conn).await,
+                    "Could not verify restoration of original root access"
+                );
+            }
+            Ok::<_, anyhow::Error>(())
+        }
+        .await;
+        if let Err(error) = cleanup {
+            bail!(
+                "Temporary root cleanup failed: {error:#}. Keep the router isolated and disable TELEN/RDENABLE before use. Operation result: {result:?}"
+            );
+        }
+    }
+    result
+}
+
+async fn install_rooted(conn: &Connection, web: &Web, binary: &[u8], lte_only: bool) -> Result<()> {
+    conn.run("test \"$(id -u)\" = 0\ntest \"$(uname -m)\" = armv7l\ntest \"$(uname -r)\" = 3.18.31\ntest -c /dev/diag\ngrep -q '^ubi0:usrfs /data ubifs rw' /proc/mounts\ngrep -q '^tmpfs /media/ram tmpfs ' /proc/mounts").await?;
+    let existing = conn
+        .run(&format!(
+            "if [ -e {ROOT} ] || [ -L {ROOT} ]; then echo PRESENT; fi"
+        ))
+        .await?;
+    if existing.trim() == "PRESENT" {
+        let marker = conn.run(&format!("cat {ROOT}/.mr1100-install")).await?;
+        ensure!(
+            marker.trim() == MARKER,
+            "Existing /data/rayhunter is not owned by the MR1100 installer"
+        );
+        validate_installation(conn).await.context("Installation is incomplete or modified. Use --uninstall to recover; configuration is not overwritten")?;
+        println!("Complete MR1100 installation verified; files and configuration left unchanged.");
+        return Ok(());
+    }
+    conn.run(&format!(
+        "test ! -e {STAGE}\ntest ! -L {STAGE}\ntest ! -e {INIT}\ntest ! -L {INIT}\ntest ! -e {INIT}.tmp\ntest ! -L {INIT}.tmp"
+    ))
+    .await?;
+    for path in LINKS {
+        conn.run(&format!("test ! -e {path}\ntest ! -L {path}"))
+            .await?;
+    }
+    conn.run("if iptables -S RH_MR1100 >/dev/null 2>&1; then exit 1; fi\nif iptables -S RH_MR_INSTALL >/dev/null 2>&1; then exit 1; fi\nif ip6tables -S RH_MR1100 >/dev/null 2>&1; then exit 1; fi").await?;
+    let free = conn
+        .run("df -Pk /data | tail -n 1 | awk '{print $4}'")
+        .await?
+        .trim()
+        .parse::<u64>()?;
+    ensure!(
+        free * 1024 > binary.len() as u64 + 4 * 1024 * 1024,
+        "Not enough /data space for the binary plus a 4 MiB reserve"
+    );
+    let status = conn.run("cat /sys/kernel/debug/diag/status").await?;
+    require_idle_diag(&status)?;
+    conn.run("test -d /sys/class/net/rndis0\ntest \"$(cat /proc/sys/net/bridge/bridge-nf-call-iptables)\" = 1").await?;
+
+    // Only an explicit option changes the native radio profile. Save it for uninstall.
+    let original_band = if lte_only {
+        let index = web.current_band().await?;
+        ensure!(matches!(index, 0..=2), "Unexpected native band preset");
+        Some(index)
+    } else {
+        None
+    };
+    println!(
+        "Installing to /data/rayhunter. Captures and logs remain in RAM; TCP 8080 and root Telnet will be restricted to USB."
+    );
+    conn.run(&format!(
+        "umask 077\nmkdir {STAGE}\nprintf '{MARKER}\\n' > {STAGE}/.mr1100-install"
+    ))
+    .await?;
+    let result = install_files(conn, web, binary, original_band).await;
+    if let Err(error) = &result {
+        println!("Installation failed; removing files created by this attempt.");
+        if let Err(cleanup) = stop_owned(conn).await {
+            bail!(
+                "{:#}; rollback stopped to avoid deleting a live or unverified installation: {cleanup:#}",
+                error
+            );
+        }
+        if let Err(cleanup) = remove_files(conn).await {
+            println!(
+                "WARNING: cleanup incomplete; ownership metadata retained for --uninstall: {cleanup:#}"
+            );
+        }
+        if let Some(index) = original_band
+            && web.set_band(index).await.is_err()
+        {
+            println!("WARNING: restore the original native band preset manually (index {index}).");
+        }
+    }
+    result?;
+    println!(
+        "Installed and started. Open http://{}:8080 through USB. RAM recordings stop when the configured reserve is reached and disappear at reboot.",
+        conn.admin
+    );
+    println!(
+        "The early firewall hook precedes native Telnet startup. Persistent root Telnet is disabled before the final reboot, so firewall failure cannot expose it. No native startup script was replaced."
+    );
+    Ok(())
+}
+
+async fn install_files(
+    conn: &Connection,
+    web: &Web,
+    binary: &[u8],
+    original_band: Option<u64>,
+) -> Result<()> {
+    // The temporary receiver is reachable only through the selected USB host.
+    conn.run(&format!("echo owned > {STAGE}/.transfer-firewall"))
+        .await?;
+    conn.run("iptables -N RH_MR_INSTALL").await?;
+    let transfer = async {
+        conn.run(&format!("iptables -A RH_MR_INSTALL -s {} -m physdev --physdev-in rndis0 -j ACCEPT\niptables -A RH_MR_INSTALL -j REJECT\niptables -I INPUT 1 -p tcp --dport 8081 -j RH_MR_INSTALL", conn.local)).await?;
+        conn.write(&format!("{STAGE}/rayhunter-daemon"), binary).await?;
+        conn.write(&format!("{STAGE}/config.toml"), CONFIG.as_bytes()).await?;
+        conn.write(&format!("{STAGE}/service"), SERVICE.as_bytes()).await?;
+        if let Some(index) = original_band {
+            conn.run(&format!("echo {index} > {STAGE}/original-band")).await?;
+        }
+        Ok::<_, anyhow::Error>(())
+    }.await;
+    let cleanup = conn.run("iptables -D INPUT -p tcp --dport 8081 -j RH_MR_INSTALL 2>/dev/null || true\niptables -F RH_MR_INSTALL\niptables -X RH_MR_INSTALL").await;
+    transfer?;
+    cleanup?;
+    conn.run(&format!(
+        "rm {STAGE}/.transfer-firewall\nprintf '{:x}\\n' > {STAGE}/.binary-sha256",
+        Sha256::digest(binary)
+    ))
+    .await?;
+    conn.run(&format!("chmod 700 {STAGE}/rayhunter-daemon {STAGE}/service\nsh -n {STAGE}/service\nmv {STAGE} {ROOT}\necho owned > {ROOT}/.init-transfer\ncp {ROOT}/service {INIT}.tmp\nchmod 755 {INIT}.tmp")).await?;
+    validate_service(conn, &format!("{INIT}.tmp")).await?;
+    conn.run(&format!("mv {INIT}.tmp {INIT}\nrm {ROOT}/.init-transfer"))
+        .await?;
+    conn.run("ln -s /media/ram/rayhunter-mr1100/rayhunter.log /data/rayhunter/rayhunter.log")
+        .await?;
+    if original_band.is_some() {
+        web.set_band(2).await?;
+        sleep(Duration::from_secs(15)).await;
+    }
+    conn.run(&format!(
+        "echo owned > {ROOT}/.service-firewall\n{INIT} start"
+    ))
+    .await?;
+    let captured = timeout(Duration::from_secs(60), async {
+        loop {
+            sleep(Duration::from_secs(5)).await;
+            if let Ok(response) = web
+                .client
+                .get(format!("{}/api/qmdl-manifest", web.daemon_url()))
+                .send()
+                .await
+                && let Ok(value) = response.json::<Value>().await
+                && value["current_entry"]["qmdl_size_bytes"]
+                    .as_u64()
+                    .unwrap_or(0)
+                    > 0
+            {
+                break;
+            }
+        }
+    })
+    .await
+    .is_ok();
+    ensure!(
+        captured,
+        "No diagnostic records arrived within 60 seconds. Check actual LTE reception; use the native LTE All preset or --lte-only"
+    );
+    conn.run(&format!("{INIT} status")).await?;
+    for path in LINKS {
+        conn.run(&format!("ln -s ../init.d/rayhunter_mr1100 {path}"))
+            .await?;
+    }
+    conn.run(&format!("sync\nprintf '{MARKER}\\n' > {ROOT}/.mr1100-complete.tmp\nsync\nmv {ROOT}/.mr1100-complete.tmp {ROOT}/.mr1100-complete\nsync")).await?;
+    println!(
+        "Recording is growing. Startup links installed; inspect captured RRC/NAS before making detection claims."
+    );
+    Ok(())
+}
+
+async fn verify_device(conn: &Connection) -> Result<()> {
+    validate_identity(&conn.at("ATI").await?)
+}
+
+fn validate_identity(info: &str) -> Result<()> {
+    ensure!(
+        info.lines().any(|line| line.trim() == "Model: MR1100"),
+        "Target is not an MR1100; no changes made"
+    );
+    ensure!(
+        info.lines()
+            .any(|line| line.trim().starts_with("Revision: NTG9X50C_12.06.39.00 ")),
+        "Only tested MR1100 firmware NTG9X50C_12.06.39.00 is supported; no changes made"
+    );
+    Ok(())
+}
+
+async fn unlock(conn: &Connection, keygen: &std::path::Path) -> Result<()> {
+    let challenge = conn.at("AT!OPENLOCK?").await?;
+    let challenge = challenge
+        .lines()
+        .map(str::trim)
+        .find(|line| is_hex_key(line))
+        .context("No valid OPENLOCK challenge")?;
+    let output = timeout(
+        Duration::from_secs(20),
+        tokio::process::Command::new("python3")
+            .arg(keygen)
+            .args(["-d", "MDM9x40", "-l", challenge])
+            .kill_on_drop(true)
+            .output(),
+    )
+    .await
+    .context("OPENLOCK helper timed out")??;
+    ensure!(
+        output.status.success(),
+        "OPENLOCK helper failed; check Python and pyserial installation"
+    );
+    let response = parse_keygen_output(&String::from_utf8(output.stdout)?)?;
+    conn.at_ok(&format!("AT!OPENLOCK=\"{response}\"")).await
+}
+
+async fn ensure_root(
+    conn: &Connection,
+    keygen: Option<&std::path::Path>,
+    changed: &mut bool,
+) -> Result<()> {
+    let keygen = keygen.context("Supply --keygen for temporary root access")?;
+    unlock(conn, keygen).await?;
+    println!(
+        "Enabling temporary root access. Keep the router isolated during bootstrap; it will restart."
+    );
+    *changed = true;
+    conn.at_ok("AT!TELEN=1").await?;
+    conn.at_ok("AT!CUSTOM=\"RDENABLE\",1").await?;
+    let _ = conn.at("AT!RESET").await;
+    sleep(Duration::from_secs(10)).await;
+    timeout(Duration::from_secs(180), async {
+        loop {
+            if verify_device(conn).await.is_ok() && has_root(conn).await {
+                break;
+            }
+            sleep(Duration::from_secs(2)).await;
+        }
+    })
+    .await
+    .context("Root did not become available after restart; check USB and local IP")?;
+    Ok(())
+}
+
+fn parse_rd_enable(output: &str) -> Result<u8> {
+    ensure!(
+        output.lines().any(|l| l.trim() == "OK") && output.contains("!CUSTOM:"),
+        "Cannot read original debug settings"
+    );
+    for line in output.lines() {
+        let words: Vec<_> = line.split_whitespace().collect();
+        if words.first() == Some(&"RDENABLE") {
+            let value = words.get(1).context("Missing RDENABLE value")?;
+            let value = u8::from_str_radix(value.trim_start_matches("0x"), 16)?;
+            ensure!(value <= 1, "Unexpected RDENABLE value");
+            return Ok(value);
+        }
+    }
+    Ok(0)
+}
+
+async fn restore_access_flags(
+    conn: &Connection,
+    keygen: &std::path::Path,
+    telnet: u8,
+    rd: u8,
+) -> Result<()> {
+    unlock(conn, keygen).await?;
+    conn.at_ok(&format!("AT!CUSTOM=\"RDENABLE\",{rd}")).await?;
+    conn.at_ok(&format!("AT!TELEN={telnet}")).await?;
+    Ok(())
+}
+
+async fn has_root(conn: &Connection) -> bool {
+    timeout(Duration::from_secs(8), conn.run("id -u"))
+        .await
+        .is_ok_and(|result| result.is_ok_and(|out| out.trim() == "0"))
+}
+
+fn is_hex_key(value: &str) -> bool {
+    value.len() == 16 && value.bytes().all(|c| c.is_ascii_hexdigit())
+}
+fn parse_keygen_output(output: &str) -> Result<String> {
+    let key = output
+        .lines()
+        .find_map(|line| {
+            line.trim()
+                .strip_prefix("AT!OPENLOCK=\"")
+                .and_then(|s| s.strip_suffix('"'))
+        })
+        .context("OPENLOCK helper returned no response")?;
+    ensure!(is_hex_key(key), "Invalid OPENLOCK helper response");
+    Ok(key.to_owned())
+}
+
+fn validate_binary(binary: &[u8]) -> Result<()> {
+    ensure!(
+        binary.len() > 52
+            && &binary[..4] == b"\x7fELF"
+            && binary[4] == 1
+            && binary[5] == 1
+            && binary[18..20] == [40, 0],
+        "Installer payload is not a 32-bit ARM ELF"
+    );
+    ensure!(
+        binary.windows(6).any(|bytes| bytes == b"mr1100"),
+        "Daemon does not contain the MR1100 profile; rebuild it from this branch"
+    );
+    Ok(())
+}
+fn validate_config(text: &str) -> Result<()> {
+    let value: toml::Value = toml::from_str(text)?;
+    ensure!(
+        value.get("device").and_then(toml::Value::as_str) == Some("mr1100")
+            && value.get("port").and_then(toml::Value::as_integer) == Some(8080),
+        "Unsafe MR1100 configuration"
+    );
+    ensure!(
+        value.get("qmdl_store_path").and_then(toml::Value::as_str)
+            == Some("/media/ram/rayhunter-mr1100/qmdl"),
+        "Installer requires RAM-backed captures"
+    );
+    ensure!(
+        value.get("wifi_enabled").and_then(toml::Value::as_bool) == Some(false)
+            && value
+                .get("auto_check_updates")
+                .and_then(toml::Value::as_bool)
+                == Some(false),
+        "Unsupported integration enabled"
+    );
+    Ok(())
+}
+fn require_idle_diag(status: &str) -> Result<()> {
+    for field in [
+        "Logging Mode: 0",
+        "MD session mode: 0",
+        "MD session mask: 0",
+    ] {
+        ensure!(
+            status.lines().any(|line| line.trim() == field),
+            "DIAG is not in the tested idle state; do not stop native clients blindly"
+        );
+    }
+    Ok(())
+}
+
+struct Web {
+    client: Client,
+    base: String,
+}
+impl Web {
+    fn new(conn: &Connection) -> Result<Self> {
+        let builder = Client::builder()
+            .no_proxy()
+            .local_address(std::net::IpAddr::V4(conn.local))
+            .timeout(Duration::from_secs(12))
+            .redirect(reqwest::redirect::Policy::none());
+        #[cfg(any(target_os = "linux", target_os = "android", target_os = "fuchsia"))]
+        let builder = if let Some(interface) = &conn.interface {
+            builder.interface(interface)
+        } else {
+            builder
+        };
+        Ok(Self {
+            client: builder.build()?,
+            base: format!("http://{}", conn.admin),
+        })
+    }
+    fn daemon_url(&self) -> String {
+        format!("{}:8080", self.base)
+    }
+    async fn model(&self) -> Result<(Value, String)> {
+        let origin = reqwest::Url::parse(&self.base)?;
+        let mut url = origin.clone();
+        let mut jar = std::collections::BTreeMap::new();
+        let mut cookies = String::new();
+        let mut ready = false;
+        // The native server establishes its session through /sess_cd_tmp redirects.
+        // Keep cookies on this origin only; do not follow arbitrary remote redirects.
+        for _ in 0..8 {
+            let response = self
+                .client
+                .get(url.clone())
+                .header(header::COOKIE, &cookies)
+                .send()
+                .await?;
+            for value in response.headers().get_all(header::SET_COOKIE) {
+                if let Some((name, value)) = value
+                    .to_str()?
+                    .split(';')
+                    .next()
+                    .and_then(|p| p.split_once('='))
+                {
+                    jar.insert(name.trim().to_owned(), value.to_owned());
+                }
+            }
+            cookies = jar
+                .iter()
+                .map(|(k, v)| format!("{k}={v}"))
+                .collect::<Vec<_>>()
+                .join("; ");
+            if !response.status().is_redirection() {
+                response.error_for_status()?;
+                ready = true;
+                break;
+            }
+            url = url.join(
+                response
+                    .headers()
+                    .get(header::LOCATION)
+                    .context("Missing session redirect")?
+                    .to_str()?,
+            )?;
+            ensure!(
+                url.origin() == origin.origin(),
+                "Refusing cross-origin native session redirect"
+            );
+        }
+        ensure!(ready, "Native session redirect limit reached");
+        let model = self
+            .client
+            .get(format!("{}/api/model.json?internalapi=1", self.base))
+            .header(header::COOKIE, &cookies)
+            .send()
+            .await?
+            .error_for_status()?
+            .json::<Value>()
+            .await?;
+        ensure!(
+            model["general"]["model"].as_str() == Some("MR1100"),
+            "Unexpected native web target"
+        );
+        Ok((model, cookies))
+    }
+    async fn current_band(&self) -> Result<u64> {
+        let (model, _) = self.model().await?;
+        model["wwan"]["bandRegion"]
+            .as_array()
+            .context("Native band presets unavailable")?
+            .iter()
+            .find(|entry| entry["current"].as_bool() == Some(true))
+            .and_then(|entry| entry["index"].as_u64())
+            .context("Native band preset unavailable")
+    }
+    async fn set_band(&self, index: u64) -> Result<()> {
+        let (model, cookies) = self.model().await?;
+        let expected = match index {
+            0 => "Auto",
+            1 => "WCDMA All",
+            2 => "LTE All",
+            _ => bail!("Unsupported band preset"),
+        };
+        ensure!(model["wwan"]["bandRegion"].as_array().context("No presets")?.iter().any(|v| v["index"].as_u64() == Some(index) && v["name"].as_str() == Some(expected)), "Native preset does not match tested firmware");
+        let token = model["session"]["secToken"].as_str().context("Native admin session unavailable. Select LTE All in the web interface and omit --lte-only")?;
+        let result = self
+            .client
+            .post(format!("{}/Forms/config", self.base))
+            .header(header::COOKIE, cookies)
+            .form(&[
+                ("token", token),
+                ("wwan.bandRegion.setIndex", &index.to_string()),
+                ("ok_redirect", "/success.json"),
+                ("err_redirect", "/error.json"),
+            ])
+            .send()
+            .await?;
+        ensure!(
+            result.status().is_success() || result.status().is_redirection(),
+            "Native preset request failed"
+        );
+        sleep(Duration::from_secs(2)).await;
+        ensure!(
+            self.current_band().await? == index,
+            "Native preset was not changed; verify admin access"
+        );
+        Ok(())
+    }
+}
+
+async fn validate_service(conn: &Connection, path: &str) -> Result<()> {
+    conn.run(&format!("test -f {path}\ntest ! -L {path}"))
+        .await?;
+    let output = conn.run(&format!("sha256sum {path}")).await?;
+    let expected = format!("{:x}", Sha256::digest(SERVICE.as_bytes()));
+    ensure!(
+        output.split_whitespace().next() == Some(expected.as_str()),
+        "Service script differs from this installer; refusing to execute or delete it"
+    );
+    Ok(())
+}
+
+async fn validate_installation(conn: &Connection) -> Result<()> {
+    conn.run(&format!(
+        "test ! -L {ROOT}\ntest ! -L {ROOT}/.mr1100-complete"
+    ))
+    .await?;
+    ensure!(
+        conn.run(&format!("cat {ROOT}/.mr1100-complete"))
+            .await?
+            .trim()
+            == MARKER,
+        "Missing completion marker"
+    );
+    validate_service(conn, INIT).await?;
+    validate_service(conn, &format!("{ROOT}/service")).await?;
+    validate_config(&conn.run(&format!("cat {ROOT}/config.toml")).await?)?;
+    let digest = conn.run(&format!("cat {ROOT}/.binary-sha256")).await?;
+    let actual = conn
+        .run(&format!("sha256sum {ROOT}/rayhunter-daemon"))
+        .await?;
+    ensure!(
+        actual.split_whitespace().next() == Some(digest.trim()),
+        "Installed daemon checksum changed"
+    );
+    for link in LINKS {
+        ensure!(
+            conn.run(&format!("readlink {link}")).await?.trim() == "../init.d/rayhunter_mr1100",
+            "Startup link is missing or changed"
+        );
+    }
+    conn.run(&format!("{ROOT}/service status")).await?;
+    for port in [23, 8080] {
+        conn.run(&format!(
+            "iptables -C INPUT -p tcp --dport {port} -j RH_MR1100"
+        ))
+        .await?;
+        conn.run(&format!("if [ -e /proc/net/if_inet6 ]; then ip6tables -C INPUT -p tcp --dport {port} -j RH_MR1100; fi")).await?;
+    }
+    Ok(())
+}
+
+async fn stop_owned(conn: &Connection) -> Result<()> {
+    let present = conn
+        .run(&format!(
+            "if [ -e {ROOT}/service ] || [ -L {ROOT}/service ]; then echo PRESENT; fi"
+        ))
+        .await?;
+    if present.trim() == "PRESENT" {
+        validate_service(conn, &format!("{ROOT}/service")).await?;
+        conn.run(&format!("{ROOT}/service stop")).await?;
+    }
+    // A missing PID file must not let rollback unlink a still-running executable.
+    conn.run("for f in /proc/[0-9]*/exe; do\ncase \"$(readlink \"$f\" 2>/dev/null)\" in\n/data/rayhunter/rayhunter-daemon*) exit 1;;\nesac\ndone").await?;
+    Ok(())
+}
+
+async fn uninstall(conn: &Connection, web: &Web) -> Result<()> {
+    let mut found = false;
+    for base in [ROOT, STAGE] {
+        let present = conn
+            .run(&format!(
+                "if [ -e {base} ] || [ -L {base} ]; then echo PRESENT; fi"
+            ))
+            .await?;
+        if present.trim() == "PRESENT" {
+            conn.run(&format!(
+                "test ! -L {base}\ntest ! -L {base}/.mr1100-install"
+            ))
+            .await?;
+            ensure!(
+                conn.run(&format!("cat {base}/.mr1100-install"))
+                    .await?
+                    .trim()
+                    == MARKER,
+                "Not an MR1100 installer-owned directory"
+            );
+            found = true;
+        }
+    }
+    ensure!(
+        found,
+        "No owned MR1100 installation or staging directory found"
+    );
+    stop_owned(conn).await?;
+    for base in [ROOT, STAGE] {
+        let band = conn
+            .run(&format!(
+                "if [ -f {base}/original-band ]; then cat {base}/original-band; fi"
+            ))
+            .await?;
+        if !band.trim().is_empty() {
+            web.set_band(band.trim().parse()?).await?;
+        }
+    }
+    remove_files(conn).await?;
+    println!(
+        "Application and startup links removed. Capture files were not deleted, but an access-cleanup restart will erase RAM. Without --keygen, existing root access keeps its prior exposure."
+    );
+    Ok(())
+}
+
+async fn remove_files(conn: &Connection) -> Result<()> {
+    let mut errors = Vec::new();
+    // Do independent cleanup even after a failure, but retain directory ownership
+    // and the verified service copy until all external references are removed.
+    for path in LINKS {
+        let result = conn.run(&format!("if [ -e {path} ] || [ -L {path} ]; then\ntest \"$(readlink {path})\" = ../init.d/rayhunter_mr1100\nrm {path}\nfi")).await;
+        if let Err(error) = result {
+            errors.push(error.to_string());
+        }
+    }
+    let present = conn
+        .run(&format!(
+            "if [ -e {INIT} ] || [ -L {INIT} ]; then echo PRESENT; fi"
+        ))
+        .await?;
+    if present.trim() == "PRESENT" {
+        match validate_service(conn, INIT).await {
+            Ok(()) => {
+                if let Err(e) = conn.run(&format!("rm {INIT}")).await {
+                    errors.push(e.to_string());
+                }
+            }
+            Err(e) => errors.push(e.to_string()),
+        }
+    }
+    let partial_init = conn
+        .run(&format!(
+            "if [ -f {ROOT}/.init-transfer ]; then echo OWNED; fi"
+        ))
+        .await?;
+    if partial_init.trim() == "OWNED"
+        && let Err(error) = conn.run(&format!("rm -f {INIT}.tmp")).await
+    {
+        errors.push(error.to_string());
+    }
+    // All callers have an owned directory; fresh installs also preflight chain absence.
+    for (tool, chain, ports) in [
+        ("iptables", "RH_MR_INSTALL", &[8081][..]),
+        ("iptables", "RH_MR1100", &[23, 8080][..]),
+        ("ip6tables", "RH_MR1100", &[23, 8080][..]),
+    ] {
+        let journal = if chain == "RH_MR_INSTALL" {
+            ".transfer-firewall"
+        } else {
+            ".service-firewall"
+        };
+        let owned = conn
+            .run(&format!(
+                "if [ -f {ROOT}/{journal} ] || [ -f {STAGE}/{journal} ]; then echo OWNED; fi"
+            ))
+            .await?;
+        if owned.trim() != "OWNED" {
+            continue;
+        }
+        for port in ports {
+            let result = conn.run(&format!("if command -v {tool} >/dev/null; then\nwhile {tool} -C INPUT -p tcp --dport {port} -j {chain} 2>/dev/null; do\n{tool} -D INPUT -p tcp --dport {port} -j {chain}\ndone\nfi")).await;
+            if let Err(e) = result {
+                errors.push(e.to_string());
+            }
+        }
+        let result = conn.run(&format!("if command -v {tool} >/dev/null && {tool} -S {chain} >/dev/null 2>&1; then\n{tool} -F {chain}\n{tool} -X {chain}\nfi")).await;
+        if let Err(e) = result {
+            errors.push(e.to_string());
+        }
+    }
+    ensure!(
+        errors.is_empty(),
+        "Cleanup incomplete; ownership metadata retained: {}",
+        errors.join("; ")
+    );
+    for base in [ROOT, STAGE] {
+        let result = conn.run(&format!("if [ \"$(cat {base}/.mr1100-install 2>/dev/null)\" = {MARKER} ]; then\nrm -f {base}/rayhunter-daemon {base}/rayhunter-daemon.tmp\nrm -f {base}/config.toml {base}/config.toml.tmp\nrm -f {base}/service {base}/service.tmp {base}/original-band\nrm -f {base}/rayhunter.log {base}/.binary-sha256\nrm -f {base}/.transfer-firewall {base}/.service-firewall {base}/.init-transfer\nrm -f {base}/.mr1100-complete {base}/.mr1100-complete.tmp\nfi")).await;
+        if let Err(e) = result {
+            errors.push(e.to_string());
+            continue;
+        }
+        let result = conn.run(&format!("if [ -f {base}/.mr1100-install ]; then\nif [ \"$(find {base} -mindepth 1 -maxdepth 1 ! -name .mr1100-install | wc -l)\" -eq 0 ]; then\nrm {base}/.mr1100-install\nif ! rmdir {base}; then echo {MARKER} > {base}/.mr1100-install; exit 1; fi\nelse\necho USER_FILES_RETAINED\nfi\nfi")).await;
+        match result {
+            Ok(output) if output.contains("USER_FILES_RETAINED") => {
+                println!("Retained {base} and ownership marker because it contains user files.")
+            }
+            Ok(_) => {}
+            Err(e) => errors.push(e.to_string()),
+        }
+    }
+    ensure!(
+        errors.is_empty(),
+        "Cleanup incomplete; retry --uninstall: {}",
+        errors.join("; ")
+    );
+    Ok(())
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    #[cfg(unix)]
+    #[test]
+    fn startup_failure_checks() {
+        let result = std::process::Command::new("sh")
+            .arg(concat!(
+                env!("CARGO_MANIFEST_DIR"),
+                "/tests/rayhunter_mr1100_test.sh"
+            ))
+            .output()
+            .unwrap();
+        assert!(
+            result.status.success(),
+            "{}",
+            String::from_utf8_lossy(&result.stderr)
+        );
+    }
+
+    #[test]
+    fn firmware_and_device_gate() {
+        assert!(validate_identity("Model: MR1100\nRevision: NTG9X50C_12.06.39.00 r4374\n").is_ok());
+        assert!(validate_identity("Model: RC400L\nRevision: NTG9X50C_12.06.39.00 r4374").is_err());
+        assert!(validate_identity("Model: MR1100\nRevision: NTG9X50C_12.06.11.00 r1").is_err());
+    }
+    #[test]
+    fn helper_output_is_not_shell_code() {
+        assert_eq!(
+            parse_keygen_output("AT!OPENLOCK=\"1033773720F6EE66\"\n").unwrap(),
+            "1033773720F6EE66"
+        );
+        assert!(parse_keygen_output("AT!OPENLOCK=\"x\"; reboot").is_err());
+        assert!(parse_keygen_output("AT!OPENCND=\"1033773720F6EE66\"").is_err());
+    }
+    #[test]
+    fn original_debug_state_is_checked_before_bootstrap() {
+        assert_eq!(parse_rd_enable("!CUSTOM:\nRDENABLE 0x01\nOK\n").unwrap(), 1);
+        assert_eq!(
+            parse_rd_enable("!CUSTOM:\nNATENABLED 0x01\nOK\n").unwrap(),
+            0
+        );
+        assert!(parse_rd_enable("ERROR\n").is_err());
+        assert!(parse_rd_enable("!CUSTOM:\nRDENABLE 0xff\nOK\n").is_err());
+    }
+
+    #[test]
+    fn safe_config_and_idle_session() {
+        assert!(validate_config("").is_err());
+        validate_config(CONFIG).unwrap();
+        assert!(validate_config(&CONFIG.replace("port = 8080", "port = 80")).is_err());
+        require_idle_diag("Logging Mode: 0\nMD session mode: 0\nMD session mask: 0\n").unwrap();
+        assert!(
+            require_idle_diag("Logging Mode: 1\nMD session mode: 1\nMD session mask: 31").is_err()
+        );
+        assert!(validate_binary(b"not a firmware binary").is_err());
+    }
+}

--- a/installer/src/mr1100_transport.rs
+++ b/installer/src/mr1100_transport.rs
@@ -1,0 +1,245 @@
+use std::net::{Ipv4Addr, SocketAddr};
+use std::time::Duration;
+
+use anyhow::{Context, Result, bail, ensure};
+use sha2::{Digest, Sha256};
+use tokio::io::{AsyncReadExt, AsyncWriteExt};
+use tokio::net::{TcpSocket, TcpStream};
+use tokio::time::{sleep, timeout};
+
+#[derive(Clone)]
+pub(super) struct Connection {
+    pub admin: Ipv4Addr,
+    pub local: Ipv4Addr,
+    pub interface: Option<String>,
+}
+
+impl Connection {
+    pub async fn connect(&self, port: u16) -> Result<TcpStream> {
+        #[cfg(not(any(target_os = "linux", target_os = "android", target_os = "fuchsia")))]
+        ensure!(
+            self.interface.is_none(),
+            "Explicit interface binding is not supported on this platform"
+        );
+        let socket = TcpSocket::new_v4()?;
+        #[cfg(any(target_os = "linux", target_os = "android", target_os = "fuchsia"))]
+        if let Some(interface) = &self.interface {
+            socket
+                .bind_device(Some(interface.as_bytes()))
+                .context("Cannot bind USB interface; check its name and permissions")?;
+        }
+        socket.bind(SocketAddr::from((self.local, 0)))?;
+        Ok(timeout(
+            Duration::from_secs(5),
+            socket.connect((self.admin, port).into()),
+        )
+        .await
+        .context("MR1100 connection timed out")??)
+    }
+
+    pub async fn at(&self, command: &str) -> Result<String> {
+        ensure!(!command.contains(['\r', '\n']), "Invalid AT command");
+        let mut stream = timeout(Duration::from_secs(15), async {
+            loop {
+                if let Ok(stream) = self.connect(5510).await {
+                    break stream;
+                }
+                sleep(Duration::from_millis(300)).await;
+            }
+        })
+        .await
+        .context("MR1100 AT service unavailable on the selected USB interface")?;
+        timeout(Duration::from_secs(8), async {
+            stream
+                .write_all(format!("{command}\r\n").as_bytes())
+                .await?;
+            let mut output = Vec::new();
+            loop {
+                let byte = stream.read_u8().await?;
+                output.push(byte);
+                ensure!(output.len() < 16384, "AT response too large");
+                let text = String::from_utf8_lossy(&output);
+                // A previous TCP client can leave a delayed modem reply behind.
+                // The tested AT bridge echoes commands; accept only our own reply.
+                if let Some(response) = at_reply(&text, command) {
+                    return Ok(response.to_owned());
+                }
+            }
+        })
+        .await
+        .context("MR1100 AT command timed out")?
+    }
+
+    pub async fn at_ok(&self, command: &str) -> Result<()> {
+        let output = self.at(command).await?;
+        ensure!(
+            output.lines().any(|line| line.trim() == "OK"),
+            "MR1100 rejected AT command"
+        );
+        Ok(())
+    }
+
+    pub async fn run(&self, command: &str) -> Result<String> {
+        ensure!(
+            command.lines().all(|line| line.len() <= 200),
+            "MR1100 shell line exceeds 200 bytes"
+        );
+        let mut stream = self.connect(23).await?;
+        timeout(Duration::from_secs(75), async {
+            let mut greeting = Vec::new();
+            while !greeting.ends_with(b"# ") {
+                greeting.push(telnet_byte(&mut stream).await?);
+                ensure!(greeting.len() < 16384, "Root shell prompt not found");
+            }
+            stream.write_all(b"stty -echo\nPS1='' PS2=''\nprintf '\\nRH_READY\\n'\n").await?;
+            let mut ready = Vec::new();
+            while !ready.ends_with(b"RH_READY\r\n") && !ready.ends_with(b"RH_READY\n") {
+                ready.push(telnet_byte(&mut stream).await?);
+                ensure!(ready.len() < 16384, "Shell setup failed");
+            }
+            // Separate short lines avoid the stock shell's input-line truncation.
+            let request = format!("echo RH_'BEGIN'\n(\nset -e\n{command}\n)\nr=$?\nprintf '\\nRH_EXIT:%s\\n' \"$r\"\necho RH_'END'\r\n");
+            stream.write_all(request.as_bytes()).await?;
+            let mut bytes = Vec::new();
+            loop {
+                bytes.push(telnet_byte(&mut stream).await?);
+                ensure!(bytes.len() <= 2 * 1024 * 1024, "Shell response too large");
+                if bytes.ends_with(b"\nRH_END\r\n") || bytes.ends_with(b"\nRH_END\n") {
+                    return parse_shell_output(&String::from_utf8_lossy(&bytes));
+                }
+            }
+        })
+        .await
+        .context("MR1100 shell command timed out")?
+    }
+
+    pub async fn write(&self, path: &str, bytes: &[u8]) -> Result<()> {
+        ensure!(
+            path.bytes()
+                .all(|c| c.is_ascii_alphanumeric() || b"/._-".contains(&c)),
+            "Unsafe remote path"
+        );
+        let receiver = self.clone();
+        let command =
+            format!("umask 077\ntimeout -t 60 -s KILL nc -l -p 8081 </dev/null > {path}.tmp");
+        let task = tokio::spawn(async move { receiver.run(&command).await });
+        let send: Result<()> = async {
+            let mut connected = None;
+            for _ in 0..10 {
+                sleep(Duration::from_millis(250)).await;
+                if let Ok(stream) = self.connect(8081).await {
+                    connected = Some(stream);
+                    break;
+                }
+            }
+            let mut stream = connected.context("File receiver did not start")?;
+            timeout(Duration::from_secs(45), async {
+                stream.write_all(bytes).await?;
+                stream.shutdown().await
+            })
+            .await
+            .context("File transfer timed out")??;
+            Ok(())
+        }
+        .await;
+        let received = task.await.context("File receiver task failed")?;
+        send?;
+        received?;
+        let expected = format!("{:x}", Sha256::digest(bytes));
+        let output = self.run(&format!("sha256sum {path}.tmp")).await?;
+        ensure!(
+            output.split_whitespace().next() == Some(expected.as_str()),
+            "Transferred file checksum mismatch"
+        );
+        self.run(&format!("mv {path}.tmp {path}")).await?;
+        Ok(())
+    }
+}
+
+fn at_reply<'a>(text: &'a str, command: &str) -> Option<&'a str> {
+    let start = text.rfind(&format!("{command}\r"))?;
+    let response = &text[start + command.len()..];
+    (response.contains("\r\nOK\r\n") || response.contains("\r\nERROR\r\n"))
+        .then_some(&text[start..])
+}
+
+async fn telnet_byte(stream: &mut TcpStream) -> Result<u8> {
+    loop {
+        let byte = stream.read_u8().await?;
+        if byte != 255 {
+            return Ok(byte);
+        }
+        match stream.read_u8().await? {
+            255 => return Ok(255),
+            op @ (251..=254) => {
+                let option = stream.read_u8().await?;
+                if op == 251 {
+                    stream.write_all(&[255, 254, option]).await?;
+                }
+                if op == 253 {
+                    stream.write_all(&[255, 252, option]).await?;
+                }
+            }
+            250 => {
+                let mut previous = 0;
+                loop {
+                    let next = stream.read_u8().await?;
+                    if previous == 255 && next == 240 {
+                        break;
+                    }
+                    previous = next;
+                }
+            }
+            _ => {}
+        }
+    }
+}
+
+fn parse_shell_output(text: &str) -> Result<String> {
+    let lines: Vec<_> = text
+        .lines()
+        .map(|line| line.trim_end_matches('\r'))
+        .collect();
+    let start = lines
+        .iter()
+        .position(|line| *line == "RH_BEGIN")
+        .context("Missing shell start marker")?;
+    let end = lines
+        .iter()
+        .rposition(|line| *line == "RH_END")
+        .context("Missing shell end marker")?;
+    let status = lines[..end]
+        .iter()
+        .rposition(|line| line.starts_with("RH_EXIT:"))
+        .context("Missing shell exit status")?;
+    ensure!(start < status, "Invalid shell markers");
+    if lines[status] != "RH_EXIT:0" {
+        bail!("MR1100 shell command failed ({})", lines[status]);
+    }
+    Ok(lines[start + 1..status].join("\n").trim().to_owned())
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn delayed_at_reply_cannot_complete_a_new_command() {
+        assert!(at_reply("AT!CUSTOM?\r\r\nOK\r\nATI\r\r\nModel: MR1100\r\n", "ATI").is_none());
+        assert_eq!(
+            at_reply("old\r\nOK\r\nATI\r\r\nModel: MR1100\r\nOK\r\n", "ATI"),
+            Some("ATI\r\r\nModel: MR1100\r\nOK\r\n")
+        );
+    }
+
+    #[test]
+    fn shell_requires_real_markers_and_success() {
+        assert_eq!(
+            parse_shell_output("echo RH_'BEGIN'\r\nRH_BEGIN\r\nvalue\r\nRH_EXIT:0\r\nRH_END\r\n")
+                .unwrap(),
+            "value"
+        );
+        assert!(parse_shell_output("RH_BEGIN\nRH_EXIT:1\nRH_END\n").is_err());
+        assert!(parse_shell_output("echo RH_BEGIN; echo RH_EXIT:0; echo RH_END").is_err());
+    }
+}

--- a/installer/tests/rayhunter_mr1100_test.sh
+++ b/installer/tests/rayhunter_mr1100_test.sh
@@ -1,0 +1,62 @@
+#!/bin/sh
+# Focused, host-safe regression checks. The service itself is not started.
+set -eu
+SCRIPT=${1:-"$(dirname "$0")/../../dist/scripts/rayhunter_mr1100"}
+fail() { echo "FAIL: $*" >&2; exit 1; }
+has() { grep -F -- "$1" "$SCRIPT" >/dev/null || fail "missing: $1"; }
+not_has() { ! grep -F -- "$1" "$SCRIPT" >/dev/null || fail "forbidden: $1"; }
+
+sh -n "$SCRIPT" || fail "shell syntax"
+usage=$("$SCRIPT" invalid 2>&1) && fail "invalid action succeeded"
+[ "$?" -eq 2 ] || fail "invalid action status"
+[ "$usage" = "Usage: $SCRIPT {start|stop|restart|status}" ] || fail "usage contract"
+
+has 'ROOT=/data/rayhunter'
+has 'RUN=/media/ram/rayhunter-mr1100'
+has 'CHAIN=RH_MR1100'
+has 'mounted ubi0:usrfs /data ubifs'
+has 'mounted tmpfs /media/ram tmpfs'
+has '[ "$(cat "$MARKER" 2>/dev/null)" = mr1100-v1 ]'
+has '"$fw" -C "$CHAIN" -i lo -j ACCEPT'
+has '"$fw" -C "$CHAIN" -m physdev --physdev-in rndis0 -j ACCEPT'
+has '"$fw" -C "$CHAIN" -j REJECT'
+has 'for port in 8080 23; do'
+has '"$fw" -C INPUT -p tcp --dport "$port" -j "$CHAIN"'
+has 'if [ -e /proc/net/if_inet6 ]; then'
+not_has 'if [ -s /proc/net/if_inet6 ]; then'
+has '"$fw" -I INPUT 1 -p tcp --dport "$port" -j "$CHAIN"'
+has 'LOG=$RUN/rayhunter.log'
+has 'exact_pid "$pid" || { msg "PID file refers to another process"; return 1; }'
+has 'kill -INT "$pid"'
+has 'kill -KILL "$pid"'
+has '[ "$n" -lt 10 ]'
+has 'mkdir "$LOCK"'
+has 'sleep 30; exact_pid "$pid" || break'
+not_has 'iptables -F'
+not_has 'ip6tables -F'
+not_has '/etc/init.d/'
+not_has 'start-stop-daemon'
+
+has 'S88rayhunter_mr1100_firewall) firewall; exit $?;;'
+has 'abort_spawn; return 1'
+
+# Exercise a PID-file write failure with an ordinary host sleep process.
+# No device paths, firewall commands, or network sockets are used.
+tmp=$(mktemp -d)
+trap 'rm -rf "$tmp"' EXIT HUP INT TERM
+awk 'index($0, "case \"${0##*/}\" in") == 1 { exit } { print }' "$SCRIPT" > "$tmp/functions"
+(
+    . "$tmp/functions"
+    LOG=$tmp/log
+    PIDFILE=$tmp/missing/pid
+    DAEMON=$(command -v sleep)
+    CONFIG=30
+    firewall() { return 0; }
+    read_pid() { return 1; }
+    exact_pid() { kill -0 "$1" 2>/dev/null; }
+    if start_locked; then fail "PID-file failure reported success"; fi
+    wait "$pid" 2>/dev/null || true
+    if kill -0 "$pid" 2>/dev/null; then fail "new daemon survived PID-file failure"; fi
+)
+
+echo "PASS: rayhunter_mr1100 (including PID failure cleanup)"

--- a/lib/src/diag/diaglog/ll1.rs
+++ b/lib/src/diag/diaglog/ll1.rs
@@ -1,10 +1,20 @@
 use deku::prelude::*;
 
 #[derive(Debug, Clone, PartialEq, DekuRead, DekuWrite)]
+#[deku(id_type = "u8", ctx = "body_len: u16")]
+pub enum ServingCellTiming {
+    #[deku(id = "1")]
+    V1 { data: ServingCellTimingV1 },
+    #[deku(id = "0x7a")]
+    V122 {
+        #[deku(assert = "body_len == 16 + 8 * u16::from(data.num_records)")]
+        data: ServingCellTimingV122,
+    },
+}
+
+#[derive(Debug, Clone, PartialEq, DekuRead, DekuWrite)]
 #[deku(bit_order = "lsb")]
-pub struct ServingCellTiming {
-    #[deku(assert_eq = "1")]
-    pub version: u8,
+pub struct ServingCellTimingV1 {
     #[deku(bits = 5, assert = "(1..=20).contains(num_records)")]
     pub num_records: u8,
     #[deku(bits = 4, assert = "*starting_sub_fn <= 9")]
@@ -29,6 +39,20 @@ pub struct ServingCellTiming {
     pub timing_adjustment: Vec<TimingAdjustment>,
 }
 
+/// The MR1100 envelope is verified; the timing fields inside these bytes are not.
+/// Do not interpret these blocks using the version-1 timing units or bit layout.
+#[derive(Debug, Clone, PartialEq, DekuRead, DekuWrite)]
+#[deku(bit_order = "lsb")]
+pub struct ServingCellTimingV122 {
+    #[deku(bits = 5, assert = "(1..=20).contains(num_records)")]
+    pub num_records: u8,
+    #[deku(bits = 3)]
+    pub unknown_flags: u8,
+    pub header_tail: [u8; 14],
+    #[deku(count = "num_records")]
+    pub record_bytes: Vec<[u8; 8]>,
+}
+
 #[derive(Debug, Clone, PartialEq, DekuRead, DekuWrite)]
 #[deku(bit_order = "lsb", ctx = "_: deku::ctx::Order")]
 pub struct TimingAdjustment {
@@ -41,4 +65,136 @@ pub struct TimingAdjustment {
     pub ul_frame_timing_adjustment: i8, // in Ts units
     #[deku(assert = "(-128..=127).contains(timing_advance)")]
     pub timing_advance: i8, // in 16 Ts units
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::diag::diaglog::LogBody;
+    use crate::diag::{CRC_CCITT, Message};
+    use crate::hdlc::hdlc_encapsulate;
+
+    // Synthetic fixtures: preserve the observed framing, not captured radio data.
+    fn fixture(version: u8, count: u8) -> Vec<u8> {
+        let (header, stride) = if version == 1 { (12, 3) } else { (16, 8) };
+        let mut body = vec![0; header + stride * usize::from(count)];
+        body[0] = version;
+        body[1] = count;
+        if version == 0x7a {
+            body[1] |= 0b101 << 5;
+            for (i, byte) in body[2..].iter_mut().enumerate() {
+                *byte = (i as u8).wrapping_add(0x70);
+            }
+        }
+        body
+    }
+
+    fn wire(body: &[u8]) -> Vec<u8> {
+        let length = (body.len() as u16 + 12).to_le_bytes();
+        let mut message = vec![0x10, 0];
+        message.extend(length);
+        message.extend(length);
+        message.extend(0xb114u16.to_le_bytes());
+        message.extend([0; 8]);
+        message.extend(body);
+        message
+    }
+
+    fn decode(body: &[u8]) -> Result<Message, crate::diag::DiagParsingError> {
+        Message::from_hdlc(&hdlc_encapsulate(&wire(body), &CRC_CCITT))
+    }
+
+    #[test]
+    fn version_one_still_decodes_and_round_trips() {
+        for count in [1, 20] {
+            let body = fixture(1, count);
+            let message = decode(&body).unwrap();
+            assert_eq!(message.to_bytes().unwrap(), wire(&body));
+            let Message::Log {
+                body:
+                    LogBody::LteLl1ServingCellTiming {
+                        data: ServingCellTiming::V1 { data },
+                    },
+                ..
+            } = message
+            else {
+                panic!("wrong timing format")
+            };
+            assert_eq!(data.num_records, count);
+            assert_eq!(data.starting_ul_timing_advance, 0);
+            assert_eq!(data.timing_adjustment.len(), usize::from(count));
+        }
+    }
+
+    #[test]
+    fn mr1100_preserves_every_unknown_byte() {
+        for count in 1..=20 {
+            let body = fixture(0x7a, count);
+            let message = decode(&body).unwrap();
+            assert_eq!(message.to_bytes().unwrap(), wire(&body));
+            let Message::Log {
+                body:
+                    LogBody::LteLl1ServingCellTiming {
+                        data: ServingCellTiming::V122 { data },
+                    },
+                ..
+            } = message
+            else {
+                panic!("wrong timing format")
+            };
+            assert_eq!(data.num_records, count);
+            assert_eq!(data.unknown_flags, 0b101);
+            assert_eq!(&data.header_tail, &body[2..16]);
+            assert_eq!(data.record_bytes.concat(), body[16..]);
+        }
+    }
+
+    #[test]
+    fn invalid_counts_lengths_and_versions_still_fail() {
+        for version in [1, 0x7a] {
+            for count in [0, 21, 31] {
+                assert!(decode(&fixture(version, count)).is_err());
+            }
+            let body = fixture(version, 2);
+            for cut in 0..body.len() {
+                assert!(
+                    decode(&body[..cut]).is_err(),
+                    "accepted truncated format {version}, length {cut}"
+                );
+            }
+            if version == 0x7a {
+                let mut extra = body;
+                extra.push(0);
+                assert!(decode(&extra).is_err());
+            }
+        }
+        assert!(decode(&fixture(2, 1)).is_err());
+        assert!(decode(&fixture(0xff, 1)).is_err());
+    }
+
+    #[test]
+    fn version_one_field_validation_is_unchanged() {
+        let mut body = fixture(1, 1);
+        // Four-bit subframe crosses bytes 1 and 2. A subframe of 15 is invalid.
+        body[1] |= 0b111 << 5;
+        body[2] |= 1;
+        assert!(decode(&body).is_err());
+    }
+
+    #[test]
+    fn valid_mr1100_records_do_not_become_analysis_errors() {
+        use crate::analysis::analyzer::{AnalyzerConfig, Harness};
+        let mut harness = Harness::new_with_config(&AnalyzerConfig::default(), &Default::default());
+        let row = harness.analyze_qmdl_message(decode(&fixture(0x7a, 1)));
+        assert!(row.skipped_message_reason.is_none());
+        assert!(!row.contains_warnings());
+        let malformed = harness.analyze_qmdl_message(decode(&fixture(0x7a, 0)));
+        assert!(malformed.skipped_message_reason.is_some());
+    }
+
+    #[test]
+    fn mr1100_does_not_invent_a_gsmtap_timing_message() {
+        let message = decode(&fixture(0x7a, 1)).unwrap();
+        assert!(crate::gsmtap::parser::parse(message).unwrap().is_none());
+    }
 }

--- a/lib/src/diag/diaglog/mod.rs
+++ b/lib/src/diag/diaglog/mod.rs
@@ -93,7 +93,10 @@ pub enum LogBody {
     #[deku(id = "0xb064")]
     LteMacUl { packet: mac::Packet },
     #[deku(id = "0xb114")]
-    LteLl1ServingCellTiming { data: ll1::ServingCellTiming },
+    LteLl1ServingCellTiming {
+        #[deku(ctx = "hdr_len")]
+        data: ll1::ServingCellTiming,
+    },
 }
 
 #[derive(Debug, Clone, PartialEq, DekuRead, DekuWrite)]

--- a/lib/src/lib.rs
+++ b/lib/src/lib.rs
@@ -45,6 +45,7 @@ pub enum Device {
     Tmobile,
     Wingtech,
     Pinephone,
+    Mr1100,
     Uz801,
     Moxee,
 }
@@ -58,4 +59,16 @@ pub struct DeviceMetadata {
     /// The subscriber's home PLMNs as `"MCC-MNC"`, read from EF_HPLMNwAcT
     /// (`6F62`) on the SIM. Empty when unknown.
     pub home_plmn: BTreeSet<String>,
+}
+
+#[cfg(test)]
+mod tests {
+    use super::Device;
+
+    #[test]
+    fn mr1100_device_name_round_trips() {
+        let device: Device = serde_json::from_str("\"mr1100\"").unwrap();
+        assert_eq!(device, Device::Mr1100);
+        assert_eq!(serde_json::to_string(&device).unwrap(), "\"mr1100\"");
+    }
 }


### PR DESCRIPTION
## Summary

Add experimental, headless support and a command-line installer for the Netgear Nighthawk M1 MR1100. This is an application port on stock firmware, not a firmware replacement.

Related discussion: https://github.com/EFForg/rayhunter/discussions/858

The branch contains one commit so further review changes can be kept together.

## Tested device

- MR1100 hardware revision 1.0, AT&T firmware package `MR1100ABS-2A1NAS_NTG9X50C_12.06.39.00_ATT_06.14`.
- Firmware and bootloader `NTG9X50C_12.06.39.00`, Linux 3.18.31, ARMv7.
- Qualcomm MDM9250 / Snapdragon X16 modem, exposed through internal `/dev/diag`.
- No SIM was installed during these tests. Other firmware and regional variants are not claimed as tested.

## Changes

- Add `device = "mr1100"` using the existing DIAG path and headless display.
- Refuse the generic key-input worker on MR1100; leave native display and battery handling alone.
- Add `installer mr1100`, with firmware checks, explicit Linux USB-interface binding, temporary root access through a user-supplied `sierrakeygen.py`, SHA-256-checked transfers, installation-state checks, rollback, and uninstall.
- Store the executable and configuration in `/data/rayhunter`. Keep captures and logs in RAM, with explicit acknowledgement and free-space reserves.
- Add dedicated startup and firewall hooks without replacing Netgear scripts. Successful installation disables persistent root Telnet and verifies TCP 23 is closed after restart. The early firewall hook precedes native Telnet startup, and the Rayhunter service refuses to start if its firewall setup fails.
- Document the exact firmware, configuration, native LTE preset, access requirements, validation evidence, and remaining limits.

## Device validation

The initial unchanged v0.12.0 daemon worked through the existing PinePhone headless profile. The named MR1100 development build was then tested separately.

- In the same running capture, the native WCDMA All preset produced zero bytes; selecting LTE All produced diagnostic records. Records continued after restoring Auto during the test.
- Two stock-binary captures contained 1,011 CRC-valid diagnostic packets, including 107 LTE RRC records. Independent ASN.1 decoding confirmed SIB1 through SIB5 and 95 paging messages, with no RRC decode errors.
- The named MR1100 build captured 302 CRC-valid packets, including 30 independently decoded LTE paging messages.
- Active-LTE runs stopped with SIGINT, returned status 0, and restored the saved DIAG state.
- `/data` persistence, installation, startup and recording after restart, repeated invocation, incomplete-install detection, partial-transfer cleanup, preservation of user files, foreign-init rejection, and uninstall were tested on the device.
- Temporary-root cleanup was tested after a forced installation failure and a successful installation. The final installed service resumed recording after restart with root Telnet closed.

Raw captures, identifiers, credentials, and API session data are not included in this PR.

## Timing-format follow-up

The MR1100 layout differs from the Orbic version-1 layout (12 fixed bytes plus 3 bytes per record). All 12,008 MR1100 timing records in a 14,411-packet sample matched the new envelope. The additional fields have no verified semantic definition yet and remain opaque. This is structural support, not a complete timing-value decoder.

Updated offline replay removed all timing-version errors; only five unrelated `UnsupportedGsmtapType(LteMacFramed)` skips remained. The Orbic reference and three earlier MR1100 captures also passed. A live updated-daemon sample contained 1,068 CRC-valid packets, including 692 timing records, with no timing-version errors in its analysis report.

Synthetic tests cover both variants, byte-preserving round trips, invalid counts, truncated bodies, unknown formats, and preservation of version-1 field validation. No raw capture data is added. Historical analysis reports are not silently rewritten.

## Automated checks

Passed locally:

- `cargo test --locked -p rayhunter -p rayhunter-daemon -p installer`
- `cargo clippy --locked -p rayhunter -p rayhunter-daemon -p installer --all-targets -- -D warnings`
- `cargo fmt --all --check`
- ARMv7 daemon and Linux x86_64 installer builds
- mdBook build and tests

The tests include configuration and device-name checks, unsupported input/battery handling, AT response framing, firmware checks, and PID-file failure cleanup.

## Known limits

- The shared no-data DIAG shutdown hang is not fixed here. The service uses SIGINT, a bounded wait, and an exact-process SIGKILL fallback.
- The MR1100's `0xb114` format (`0x7a`) now has strict envelope handling: 16 fixed bytes plus 8 bytes per record. The unknown timing fields are retained as raw bytes, not interpreted using version-1 units. Timing advance/distance from these fields remains unsupported.
- Full LTE NAS coverage, subscriber attachment, and complete analyzer behavior remain unverified. A later replay included 18 NAS records without parser errors. Empty alert output is not a safety guarantee.
- Captures are RAM-backed, stop at the configured free-space reserve, and disappear at restart. There is no SD-card installation mode or in-place upgrade in this patch.
- Native web password login is not automated. The optional LTE-preset request requires an admin session supplied by the native API; otherwise the operator must select LTE All through the native UI.
- `sierrakeygen.py` is an external dependency, not vendored code. Its source and checksum are documented. Initial root bootstrap requires an isolated, trusted network.
- No display, battery, button, GPS, or Wi-Fi client integration is added.

## AI assistance

Implementation, tests, documentation, and this PR description were AI-assisted. Validation included real MR1100 hardware tests directed by the repository owner. This disclosure does not imply an independent human review of every generated line.
